### PR TITLE
fix: GitHub Pages Permissions - Resolver Error 403 Deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,9 @@
 name: Documentación Profesional
 
 permissions:
-  contents: read
+  contents: write
+  pages: write
+  id-token: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
## Problema Critical:
remote: Permission denied to github-actions[bot]
Error 403 al intentar deployment GitHub Pages

## Solucion Aplicada:
- contents: write (crear branch gh-pages)
- pages: write (deployment GitHub Pages)  
- id-token: write (autenticacion)

## Resultado: peaceiris/actions-gh-pages funcionara correctamente