### PR TITLE
fix: remove zombie patch create_custom_fields

### DIFF
--- a/patches.txt
+++ b/patches.txt
@@ -1,2 +1,1 @@
-facturacion_mexico.custom.fields.sales_invoice.create_custom_fields
 facturacion_mexico.patches.eliminate_duplicate_fiscal_logging


### PR DESCRIPTION
## Summary
- Elimina `facturacion_mexico.custom.fields.sales_invoice.create_custom_fields` de `patches.txt`
- Esta función viola **REGLA #4**: custom fields únicamente vía fixtures en hooks.py
- La función fue desactivada en agosto 2025 (MIGRACION_ARQUITECTURAL_FISCAL_2025.md) pero nunca se removió del patch list
- En instalación limpia de v16 puede generar `DuplicateEntryError` porque los fixtures cargan primero los mismos campos

## Por qué es bloqueante para migración v16
`bench migrate` en instalación limpia ejecuta fixtures → patches en ese orden. El patch intenta crear campos que los fixtures ya registraron, causando error silencioso o fallo ruidoso según la versión de Frappe.

## Test plan
- [ ] Verificar que `patches.txt` tiene solo `eliminate_duplicate_fiscal_logging`
- [ ] Confirmar que `bench migrate` en staging v16 no lanza `DuplicateEntryError` por custom fields de Sales Invoice

🤖 Generated with [Claude Code](https://claude.ai/claude-code)