### PR TITLE
fix(timbrado): fallback On Net Total cuando item_wise_tax_detail es NULL

### DIFF
--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -1662,6 +1662,21 @@ class TimbradoAPI:
 
 		for tax in sales_invoice.taxes:
 			if not tax.item_wise_tax_detail:
+				# Fallback para On Net Total sin item_wise_tax_detail (p.ej. SI creada via API
+				# o cuando ERPNext v16 no persistió el desglose por item).
+				# Solo aplica a tasas sobre base neta: amount = net_amount × rate / 100.
+				if getattr(tax, "charge_type", None) == "On Net Total" and flt(tax.rate):
+					amount = flt(item.net_amount) * flt(tax.rate) / 100
+					if amount and tax.account_head not in taxes_dict:
+						taxes_dict[tax.account_head] = {
+							"account_head": tax.account_head,
+							"rate": flt(tax.rate),
+							"amount": amount,
+						}
+						frappe.logger().info(
+							f"E4-RO - Item {item.item_code}: Tax {tax.account_head} "
+							f"calculado por fallback On Net Total (rate={tax.rate}, amount={amount})"
+						)
 				continue
 
 			# Parse item_wise_tax_detail
@@ -1670,7 +1685,8 @@ class TimbradoAPI:
 			except (json.JSONDecodeError, TypeError):
 				continue
 
-			# Buscar este item con fallback de llaves (Cambio 3)
+			# Buscar este item con fallback de llaves:
+			# ERPNext v16 usa item.name (row UUID); versiones anteriores usan item.item_code.
 			rate_from_json = 0.0
 			amount = 0.0
 			key_used = None


### PR DESCRIPTION
## Problema

Al intentar timbrar `ACC-SINV-2026-00001` (y cualquier SI con IVA estándar):

```
ObjetoImp: 02 - Sí objeto de impuesto / Sales Invoice: Sin impuestos configurados
```

## Root cause

`_read_taxes_from_sales_invoice_item` en `timbrado_api.py:1664` hacía `continue` cuando `item_wise_tax_detail = NULL`, devolviendo `taxes_payload = []`.

ERPNext v16 no siempre persiste `item_wise_tax_detail` en la DB — ocurre cuando la SI se crea vía API, script, o cuando el hook `before_validate` reemplaza las filas de impuestos vía `doc.extend("taxes", tax_rows)` y el ciclo de `calculate_taxes_and_totals()` no completa la persistencia del campo.

Con `objeto_imp = "02"` (Sí objeto de impuesto — determinado por `fm_producto_servicio_sat = 70151501` en el catálogo SAT) y `taxes_payload = []`, la validación E4.6 lanzaba el error.

## Fix

Cuando `item_wise_tax_detail = NULL` y `charge_type = "On Net Total"`:

```python
amount = flt(item.net_amount) * flt(tax.rate) / 100
```

Esto cubre todos los casos de IVA estándar (`On Net Total`) donde el campo no fue persistido. El path para IEPS Cuota (`charge_type = "Actual"`) no se toca — esos siguen usando el hook `sales_invoice_ieps.py` (actualmente E4 DISABLED).

## Archivos modificados

- `facturacion_mexico/facturacion_fiscal/timbrado_api.py` — función `_read_taxes_from_sales_invoice_item` (+17 líneas)

## Test plan

- [ ] Timbrar `ACC-SINV-2026-00001` (item `_Test FG Item 2`, IVA 16%, `item_wise_tax_detail = NULL`) → debe pasar sin error
- [ ] Timbrar una SI con `item_wise_tax_detail` poblado → no debe regresar (path normal intacto)
- [ ] Timbrar una SI con IEPS Cuota (`charge_type = Actual`) → no debe afectarse (path IEPS sin tocar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)