### PR TITLE
fix(ui): ocultar Amend en FFM + refresh automático Cancel en SI

### DIFF
--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -416,6 +416,7 @@
 						frm.perm ||= [];
 						frm.perm[0] ||= {};
 						frm.perm[0].cancel = 0;
+						frm.perm[0].amend = 0;
 						frm.toolbar && frm.toolbar.refresh && frm.toolbar.refresh();
 
 						// Cinturón y tirantes
@@ -425,13 +426,21 @@
 						frm.page.remove_menu_item && frm.page.remove_menu_item("Cancel");
 						frm.page.remove_menu_item && frm.page.remove_menu_item(__("Cancel"));
 						frm.page.remove_menu_item && frm.page.remove_menu_item("Cancelar");
+						// - item de menú "Amend" y variantes
+						frm.page.remove_menu_item && frm.page.remove_menu_item("Amend");
+						frm.page.remove_menu_item && frm.page.remove_menu_item(__("Amend"));
+						frm.page.remove_menu_item && frm.page.remove_menu_item(__("Corregir"));
+						frm.page.remove_menu_item && frm.page.remove_menu_item(__("Enmendar"));
+						frm.page.remove_menu_item && frm.page.remove_menu_item(__("Amendment"));
 
 						// - limpiar si algún app lo reinyecta en el menú
 						const $menu = frm.page.menu || frm.page.actions_menu;
 						if ($menu && $menu.length) {
 							$menu.find("a, .dropdown-item, .menu-item").each(function () {
 								const t = (this.innerText || "").trim().toUpperCase();
-								if (t === "CANCEL" || t === "CANCELAR") this.remove();
+								if (t === "CANCEL" || t === "CANCELAR"
+									|| t === "AMEND" || t === "CORREGIR"
+									|| t === "ENMENDAR" || t === "AMENDMENT") this.remove();
 							});
 						}
 					} catch (e) {
@@ -480,16 +489,6 @@
 			// PROTECCIÓN: Bloquear campos fiscales post-submit
 			freeze_fiscal_fields_after_submit(frm);
 			freeze_payment_fields_after_submit(frm);
-
-			// BLOQUEO DEFINITIVO: Quitar "Amend" del menú de acciones
-			setTimeout(() => {
-				if (frm.page && frm.page.remove_menu_item) {
-					frm.page.remove_menu_item(__("Amend")); // idioma base
-					frm.page.remove_menu_item(__("Corregir")); // español México
-					frm.page.remove_menu_item(__("Enmendar")); // otra traducción
-					frm.page.remove_menu_item(__("Amendment")); // variante inglés
-				}
-			}, 100);
 
 			// Aplicar nueva lógica de botones con estados centralizados
 			applyFFMUi(frm);

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -1233,6 +1233,18 @@ class TimbradoAPI:
 
 				frappe.db.commit()  # nosemgrep: frappe-manual-commit - Required to ensure cancellation transaction is committed
 
+				# Notificar al formulario SI si está abierto en otro tab
+				frappe.publish_realtime(
+					event="fiscal_status_changed",
+					message={
+						"sales_invoice": sales_invoice_name,
+						"fm_fiscal_status": fiscal_status,
+						"ffm": factura_fiscal.name,
+					},
+					doctype="Sales Invoice",
+					docname=sales_invoice_name,
+				)
+
 				# Descargar acuse de cancelación automáticamente
 				try:
 					self._download_cancellation_receipt_files(factura_fiscal, factura_fiscal.facturapi_id)

--- a/facturacion_mexico/public/js/sales_invoice_block_cancel.js
+++ b/facturacion_mexico/public/js/sales_invoice_block_cancel.js
@@ -27,6 +27,16 @@ frappe.ui.form.on("Sales Invoice", {
 			.catch(() => {
 				// ante error, mejor no ocultar para no bloquear indebidamente; el server-hook sigue protegiendo
 			});
+
+		// Suscribir una sola vez por instancia de formulario al evento de cancelación PAC
+		if (!frm._fm_cancel_realtime_bound) {
+			frm._fm_cancel_realtime_bound = true;
+			frappe.realtime.on("fiscal_status_changed", function (data) {
+				if (frm.doc && data.sales_invoice === frm.doc.name) {
+					frm.reload_doc();
+				}
+			});
+		}
 	},
 });
 


### PR DESCRIPTION
## Descripción

Dos fixes de UX en el flujo de cancelación de CFDI, identificados durante
verificación post-cancelación de FFMX-2026-00002 y FFMX-2026-00003.

## Cambios

### Fix 1 — Botón Amend oculto en FFM post-cancelación (`factura_fiscal_mexico.js`)

**Problema:** El botón "Amend" aparecía visible en la FFM después de cancelarla
en Frappe (docstatus=2). El bloque `setTimeout(100)` previo perdía la carrera
contra el re-render del toolbar de Frappe v16.

**Causa raíz:** Faltaba `frm.perm[0].amend = 0`. Sin ese flag, `frm.toolbar.refresh()`
(llamado internamente por Frappe) re-agregaba el botón porque los permisos seguían
habilitados en memoria.

**Fix:** Se consolidó el manejo de Amend dentro de `alwaysHideNativeCancel()`,
que ya usaba el mecanismo correcto (`perm` + triple ejecución: inmediata,
`setTimeout(0)`, `frappe.after_ajax`). Se eliminó el bloque `setTimeout(100)`
separado que era el responsable del fallo.

### Fix 2 — Botón Cancel en SI aparece automáticamente post-cancelación PAC
(`timbrado_api.py` + `sales_invoice_block_cancel.js`)

**Problema:** Al cancelar una FFM desde su formulario, el botón Cancel en la
Sales Invoice vinculada no aparecía hasta que el usuario recargaba manualmente
la página (F5 o navegación).

**Causa raíz:** `cancelar_factura()` actualizaba `fm_fiscal_status` en la SI
via `frappe.set_value()` pero no emitía ningún evento realtime. Si la SI estaba
abierta en otro tab, no recibía notificación del cambio.

**Fix:** Se agrega `frappe.publish_realtime()` con `doctype`/`docname` después
del `frappe.db.commit()` en `cancelar_factura()`. En el cliente, se suscribe
al evento `fiscal_status_changed` con un flag `_fm_cancel_realtime_bound` para
evitar listeners duplicados en refreshes sucesivos. El formulario SI llama
`frm.reload_doc()` al recibir el evento.

## Testing

Verificado manualmente sobre `facturacion-v16.dev`:
- FFMX-2026-00002 — timbrado ✅ + cancelación PAC ✅ + cancelación Frappe ✅
- FFMX-2026-00003 — timbrado ✅ + cancelación PAC ✅

Checklist ADR 0009 post-timbrado: 10/10 ✅
Checklist ADR 0009 post-cancelación: 5/7 (los 2 restantes son pasos manuales de
cancelación Frappe, no errores del sistema) ✅

## Notas

- No hay cambios de schema ni fixtures — no requiere `bench migrate`
- No hay cambios de hooks.py — no requiere restart de workers
- `bench build --app facturacion_mexico` sí requerido (cambios en archivos JS públicos)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)