### PR TITLE
fix(egreso): corregir flujo CFDI tipo E - nota de crédito

### DIFF
--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -474,16 +474,13 @@
 				}
 			})();
 
-			// Espejo de reglas: SI retorno => E (solo lectura), si no => I (solo lectura)
-			const is_return = frm.doc.sales_invoice_is_return || frm.doc.is_return;
-			if (is_return) {
-				frm.set_value("fm_tipo_comprobante", "E - Egreso");
-				frm.set_df_property("fm_tipo_comprobante", "read_only", 1);
+			// fm_tipo_comprobante ya fue establecido por Python (_set_tipo_from_context)
+			// Solo aplicar read_only — no sobreescribir el valor del servidor
+			frm.set_df_property("fm_tipo_comprobante", "read_only", 1);
+			const is_egreso = (frm.doc.fm_tipo_comprobante || "").startsWith("E");
+			if (is_egreso) {
 				frm.set_df_property("fm_tipo_relacion_sat", "read_only", 1);
 				frm.set_df_property("fm_uuid_relacionado", "read_only", 1);
-			} else {
-				frm.set_value("fm_tipo_comprobante", "I - Ingreso");
-				frm.set_df_property("fm_tipo_comprobante", "read_only", 1);
 			}
 
 			// PROTECCIÓN: Bloquear campos fiscales post-submit

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -278,6 +278,7 @@ class FacturaFiscalMexico(Document):
 			# autollenar relación
 			self.fm_tipo_relacion_sat = self.fm_tipo_relacion_sat or "01 - " + TIPO_RELACION["01"]
 			self.fm_uuid_relacionado = self.fm_uuid_relacionado or self._find_uuid_cfdi_origen()
+			self.fm_payment_method_sat = "PUE"  # SAT no permite PPD en notas de crédito
 		else:
 			self.fm_tipo_comprobante = "I - Ingreso"
 			self.fm_tipo_relacion_sat = None

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -620,7 +620,7 @@ class TimbradoAPI:
 
 			# Construir concepto
 			item_payload = {
-				"quantity": item.qty,
+				"quantity": abs(item.qty),  # SIs de devolución tienen qty negativa por diseño ERPNext
 				"product": {
 					"description": item.description or item.item_name,
 					"product_key": item_doc.fm_producto_servicio_sat or "01010101",

--- a/facturacion_mexico/public/js/sales_invoice.js
+++ b/facturacion_mexico/public/js/sales_invoice.js
@@ -167,14 +167,92 @@ function redirect_to_fiscal_document(frm) {
 		return;
 	}
 
-	// No existe, crear uno nuevo
-	// Calcular IVA y otros impuestos desde la tabla taxes
+	// SI devolución → resolver UUID antes de crear FFM tipo E
+	if (frm.doc.is_return) {
+		_resolve_uuid_for_return(frm, function (uuid) {
+			if (uuid) {
+				_do_create_ffm(frm, {
+					fm_uuid_relacionado: uuid,
+					fm_tipo_relacion_sat: "01 - Nota de crédito de los documentos relacionados",
+				});
+			}
+		});
+		return;
+	}
+
+	_do_create_ffm(frm, {});
+}
+
+function _resolve_uuid_for_return(frm, callback) {
+	if (!frm.doc.return_against) {
+		_show_uuid_dialog(frm, callback);
+		return;
+	}
+
+	frappe.db.get_value(
+		"Sales Invoice",
+		frm.doc.return_against,
+		"fm_factura_fiscal_mx",
+		function (si_data) {
+			const ffm_name = si_data && si_data.fm_factura_fiscal_mx;
+			if (!ffm_name) {
+				_show_uuid_dialog(frm, callback);
+				return;
+			}
+
+			frappe.db.get_value(
+				"Factura Fiscal Mexico",
+				ffm_name,
+				"fm_uuid",
+				function (ffm_data) {
+					const uuid = ffm_data && ffm_data.fm_uuid;
+					if (uuid) {
+						callback(uuid);
+					} else {
+						_show_uuid_dialog(frm, callback);
+					}
+				}
+			);
+		}
+	);
+}
+
+function _show_uuid_dialog(frm, callback) {
+	frappe.prompt(
+		{
+			label: __("UUID del CFDI original"),
+			fieldname: "uuid",
+			fieldtype: "Data",
+			reqd: 1,
+			description: __(
+				"UUID del CFDI que esta nota de crédito cancela o modifica (36 caracteres)"
+			),
+		},
+		function (values) {
+			const uuid = (values.uuid || "").trim();
+			if (uuid.length !== 36) {
+				frappe.msgprint({
+					title: __("UUID inválido"),
+					message: __(
+						"El UUID debe tener 36 caracteres (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)"
+					),
+					indicator: "red",
+				});
+				return;
+			}
+			callback(uuid);
+		},
+		__("UUID relacionado requerido"),
+		__("Continuar")
+	);
+}
+
+function _do_create_ffm(frm, extra_fields) {
 	let iva_total = 0;
 	let otros_impuestos = 0;
 
 	if (frm.doc.taxes && frm.doc.taxes.length > 0) {
 		frm.doc.taxes.forEach(function (tax) {
-			// Identificar IVA por el account_head
 			if (tax.account_head && tax.account_head.toUpperCase().includes("IVA")) {
 				iva_total += tax.tax_amount || 0;
 			} else {
@@ -183,26 +261,26 @@ function redirect_to_fiscal_document(frm) {
 		});
 	}
 
+	const doc = Object.assign(
+		{
+			doctype: "Factura Fiscal Mexico",
+			sales_invoice: frm.doc.name,
+			company: frm.doc.company,
+			customer: frm.doc.customer,
+			fm_fiscal_status: FISCAL_STATES ? FISCAL_STATES.states.BORRADOR : "BORRADOR",
+			si_total_antes_iva: frm.doc.net_total || 0,
+			si_total_neto: frm.doc.grand_total || 0,
+			si_iva: iva_total,
+			si_otros_impuestos: otros_impuestos,
+		},
+		extra_fields
+	);
+
 	frappe.call({
 		method: "frappe.client.insert",
-		args: {
-			doc: {
-				doctype: "Factura Fiscal Mexico",
-				sales_invoice: frm.doc.name,
-				company: frm.doc.company,
-				customer: frm.doc.customer, // AÑADIR: Customer requerido
-				fm_fiscal_status: FISCAL_STATES ? FISCAL_STATES.states.BORRADOR : "BORRADOR", // Estado desde configuración
-				// fm_payment_method_sat será asignado por validate_payment_method() usando settings
-				// Agregar montos del Sales Invoice para validación posterior
-				si_total_antes_iva: frm.doc.net_total || 0,
-				si_total_neto: frm.doc.grand_total || 0,
-				si_iva: iva_total,
-				si_otros_impuestos: otros_impuestos,
-			},
-		},
+		args: { doc: doc },
 		callback: function (r) {
 			if (r.message) {
-				// Actualizar referencia en Sales Invoice
 				frappe.call({
 					method: "frappe.client.set_value",
 					args: {
@@ -212,7 +290,6 @@ function redirect_to_fiscal_document(frm) {
 						value: r.message.name,
 					},
 					callback: function () {
-						// Mostrar mensaje de éxito
 						frappe.show_alert(
 							{
 								message: __("Documento fiscal creado exitosamente"),
@@ -221,7 +298,6 @@ function redirect_to_fiscal_document(frm) {
 							3
 						);
 
-						// Forzar navegación completa con reload para corregir título
 						setTimeout(() => {
 							window.location.href = `/app/factura-fiscal-mexico/${r.message.name}`;
 						}, 1000);


### PR DESCRIPTION
## Descripción

Cuatro bugs corregidos en el flujo de CFDI tipo Egreso (nota de crédito), identificados y verificados durante prueba completa end-to-end. El flujo completo — creación de FFM tipo E, timbrado y verificación de documentos — fue probado exitosamente (FFMX-2026-00007, folio 274, UUID AA01CE5B-...).

## Cambios

### 1. `sales_invoice.js` — Auto-búsqueda UUID origen antes del insert de FFM

**Problema:** Al presionar "Timbrar Factura" en una SI de devolución, el insert fallaba con HTTP 417 porque Python exige `fm_uuid_relacionado` para tipo E, pero el JS no lo pasaba.

**Fix:** Antes de crear la FFM, el JS detecta `is_return=1`, busca el UUID via `return_against → SI origen → FFM → fm_uuid`. Si lo encuentra, lo pasa directamente en el insert. Si no, muestra un diálogo pidiendo el UUID al usuario. Se extrae `_do_create_ffm()` para reutilizar el insert en ambos casos.

### 2. `factura_fiscal_mexico.py` — Forzar PUE para retornos en `_set_tipo_from_context()`

**Problema:** Con `metodo_pago_default = "PPD"` en settings, `validate_payment_method()` asignaba PPD y luego lanzaba `ValidationError` porque el SAT no permite PPD en notas de crédito.

**Fix:** `_set_tipo_from_context()` — que ya conoce el contexto de retorno — fuerza `fm_payment_method_sat = "PUE"` antes de que `validate_payment_method()` corra.

### 3. `factura_fiscal_mexico.js` — Eliminar `frm.set_value` que sobreescribía el tipo

**Problema:** En el `refresh` de la FFM, el JS leía `frm.doc.sales_invoice_is_return` (campo que no existe en FFM) → siempre `undefined` → siempre ejecutaba el `else` → `frm.set_value("fm_tipo_comprobante", "I - Ingreso")`, sobreescribiendo el "E - Egreso" que Python estableció correctamente.

**Fix:** El JS ya no sobreescribe `fm_tipo_comprobante`. Solo aplica `read_only` sobre el valor que Python ya estableció en servidor. Lee `frm.doc.fm_tipo_comprobante` para decidir si también bloquear los campos de relación/UUID.

### 4. `timbrado_api.py` — `abs(item.qty)` para SIs de devolución

**Problema:** ERPNext crea SIs de devolución con `qty` negativa por diseño (-1.0). FacturAPI rechazaba con `"items[0].quantity must be a positive number"`.

**Fix:** `abs(item.qty)` al construir el payload. Una línea.

## Testing

Flujo completo verificado en `facturacion-v16.dev`:

| Documento | Estado | Verificación |
|-----------|--------|--------------|
| ACC-SINV-2026-00004 (SI original) | TIMBRADO | FFM tipo I, UUID 0886AF8D-... |
| ACC-SINV-2026-00009 (SI devolución) | TIMBRADO | is_return=1, qty=-1.0 |
| FFMX-2026-00007 (FFM tipo E) | TIMBRADO | tipo=E, PUE, UUID relacionado correcto, folio 274 |
| Response Log | HTTP 200 success=1 | Segundo intento tras fix qty |
| PDF + XML adjuntos | ✅ | XML 5,225 bytes, PDF 157,907 bytes |

## Notas

- `bench build --app facturacion_mexico` requerido (cambios en JS)
- No hay cambios de schema ni fixtures
- No hay cambios en `hooks.py`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)