### PR TITLE
fix(linters): corregir ruff, prettier y mkdocs

### DIFF
--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -77,7 +77,7 @@
 			frappe.msgprint({
 				title: __("Sustitución CFDI (01)"),
 				message: __(
-					'Para sustitución, use el botón <b>"Sustituir CFDI (01)"</b> en el Sales Invoice.'
+					'Para sustitución, use el botón <b>"Sustituir CFDI (01)"</b> en el Sales Invoice.',
 				),
 				indicator: "orange",
 				primary_action: {
@@ -106,12 +106,12 @@
 								`2️⃣ Use el botón "🔄 Sustituir CFDI (01)"<br>` +
 								`3️⃣ Se creará un SI de reemplazo para correcciones<br>` +
 								`4️⃣ El sistema manejará la relación TipoRelación 04 automáticamente<br><br>` +
-								`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`
+								`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`,
 						),
 						indicator: "blue",
 					});
 				},
-				__("Ayuda")
+				__("Ayuda"),
 			);
 		}
 	}
@@ -249,7 +249,7 @@
 							});
 						}
 					},
-					__("Comprobantes")
+					__("Comprobantes"),
 				);
 
 				// 2) Enviar CFDI por email - Agrupado en "Comprobantes"
@@ -270,7 +270,7 @@
 							} else if (res && res.reason === "no-recipient") {
 								frappe.msgprint({
 									message: __(
-										"No se envió: no hay destinatario (FFM ni Settings)."
+										"No se envió: no hay destinatario (FFM ni Settings).",
 									),
 									indicator: "orange",
 								});
@@ -286,7 +286,7 @@
 							frappe.msgprint({ message: __(String(e)), indicator: "red" });
 						}
 					},
-					__("Comprobantes")
+					__("Comprobantes"),
 				);
 			}
 
@@ -304,12 +304,12 @@
 									`2️⃣ Use el botón "🔄 Sustituir CFDI (01)"<br>` +
 									`3️⃣ Se creará un SI de reemplazo para correcciones<br>` +
 									`4️⃣ El sistema manejará la relación TipoRelación 04 automáticamente<br><br>` +
-									`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`
+									`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`,
 							),
 							indicator: "blue",
 						});
 					},
-					__("Ayuda")
+					__("Ayuda"),
 				);
 			}
 
@@ -392,14 +392,14 @@
 								frm.set_df_property(
 									"fm_tipo_comprobante",
 									"options",
-									tipo_comprobante_options.join("\n")
+									tipo_comprobante_options.join("\n"),
 								);
 							}
 							if (tipo_relacion_options && tipo_relacion_options.length) {
 								frm.set_df_property(
 									"fm_tipo_relacion_sat",
 									"options",
-									tipo_relacion_options.join("\n")
+									tipo_relacion_options.join("\n"),
 								);
 							}
 						}
@@ -438,9 +438,15 @@
 						if ($menu && $menu.length) {
 							$menu.find("a, .dropdown-item, .menu-item").each(function () {
 								const t = (this.innerText || "").trim().toUpperCase();
-								if (t === "CANCEL" || t === "CANCELAR"
-									|| t === "AMEND" || t === "CORREGIR"
-									|| t === "ENMENDAR" || t === "AMENDMENT") this.remove();
+								if (
+									t === "CANCEL" ||
+									t === "CANCELAR" ||
+									t === "AMEND" ||
+									t === "CORREGIR" ||
+									t === "ENMENDAR" ||
+									t === "AMENDMENT"
+								)
+									this.remove();
 							});
 						}
 					} catch (e) {
@@ -637,7 +643,7 @@
 		}
 
 		console.log(
-			`🔍 auto_assign_cfdi_from_customer: Cargando Use CFDI para customer: ${customer}`
+			`🔍 auto_assign_cfdi_from_customer: Cargando Use CFDI para customer: ${customer}`,
 		);
 
 		frappe.db
@@ -656,12 +662,12 @@
 							indicator: "green",
 						},
 						7,
-						ALERT_DURATION_DEFAULT
+						ALERT_DURATION_DEFAULT,
 					);
 				} else {
 					// Customer no tiene uso CFDI configurado - dejar vacío
 					console.log(
-						"⚠️ Customer no tiene fm_uso_cfdi_default configurado - campo vacío"
+						"⚠️ Customer no tiene fm_uso_cfdi_default configurado - campo vacío",
 					);
 					frm.set_value("fm_cfdi_use", "");
 				}
@@ -686,7 +692,7 @@
 				message: __("Actualizando datos fiscales del cliente..."),
 				indicator: "blue",
 			},
-			ALERT_DURATION_DEFAULT
+			ALERT_DURATION_DEFAULT,
 		);
 
 		// PASO 1: Obtener datos básicos del customer para uso CFDI y campos fiscales legacy
@@ -733,7 +739,7 @@
 							message: __("Datos fiscales y de facturación actualizados"),
 							indicator: "green",
 						},
-						ALERT_DURATION_DEFAULT
+						ALERT_DURATION_DEFAULT,
 					);
 				}
 			},
@@ -743,7 +749,7 @@
 						message: __("Error al cargar datos fiscales del Cliente"),
 						indicator: "red",
 					},
-					ALERT_DURATION_DEFAULT
+					ALERT_DURATION_DEFAULT,
 				);
 			},
 		});
@@ -863,7 +869,7 @@
 								message: __("Factura timbrada exitosamente"),
 								indicator: "green",
 							},
-							ALERT_DURATION_DEFAULT
+							ALERT_DURATION_DEFAULT,
 						);
 						frm.reload_doc();
 					} else if (r.message && r.message.user_error) {
@@ -924,7 +930,7 @@
 				if (hasLinkedSI && status === "TIMBRADO") {
 					// Filtrar opciones que empiecen con "01\t"
 					filtered_options = motives_config.select_options.filter(
-						(option) => !option.startsWith(SUB_01 + "\t")
+						(option) => !option.startsWith(SUB_01 + "\t"),
 					);
 				}
 
@@ -937,7 +943,7 @@
 							reqd: 1,
 							options: filtered_options,
 							description: __(
-								"Seleccione el motivo de cancelación según catálogo SAT"
+								"Seleccione el motivo de cancelación según catálogo SAT",
 							),
 						},
 						{
@@ -947,7 +953,7 @@
 							depends_on: "eval:doc.motive=='01'",
 							mandatory_depends_on: "eval:doc.motive=='01'",
 							description: __(
-								"Requerido solo para motivo 01 - Comprobantes con errores con relación"
+								"Requerido solo para motivo 01 - Comprobantes con errores con relación",
 							),
 						},
 					],
@@ -962,7 +968,7 @@
 						await cancelar_cfdi(frm, values);
 					},
 					__("Cancelación Fiscal SAT"),
-					__("Enviar")
+					__("Enviar"),
 				);
 			},
 		});
@@ -1009,19 +1015,19 @@
 					message: __("✅ Factura cancelada exitosamente"),
 					indicator: "green",
 				},
-				ALERT_DURATION_DEFAULT
+				ALERT_DURATION_DEFAULT,
 			);
 
 			const lines = [
 				`<b>FFM:</b> ${frappe.utils.escape_html(msg.ffm || frm.doc.name)}`,
 				`<b>Sales Invoice:</b> ${frappe.utils.escape_html(
-					msg.sales_invoice || frm.doc.sales_invoice
+					msg.sales_invoice || frm.doc.sales_invoice,
 				)}`,
 				`<b>Estado FFM:</b> ${frappe.utils.escape_html(msg.status_ffm || "")}`,
 				`<b>Estado SI:</b> ${frappe.utils.escape_html(msg.status_si || "")}`,
 				`<b>UUID:</b> ${frappe.utils.escape_html(msg.uuid || "")}`,
 				`<b>Fecha cancelación:</b> ${frappe.utils.escape_html(
-					msg.cancellation_date || ""
+					msg.cancellation_date || "",
 				)}`,
 			]
 				.filter(Boolean)
@@ -1047,7 +1053,7 @@
 					const d3 = frappe.msgprint({
 						title: __("Conexión Exitosa"),
 						message: __(
-							"La conexión con FacturAPI se estableció correctamente. El sistema está listo para timbrar facturas."
+							"La conexión con FacturAPI se estableció correctamente. El sistema está listo para timbrar facturas.",
 						),
 						indicator: "green",
 						primary_action: {
@@ -1089,7 +1095,7 @@
 		});
 
 		console.log(
-			"✅ Filtros Sales Invoice configurados - Solo facturas disponibles para timbrado"
+			"✅ Filtros Sales Invoice configurados - Solo facturas disponibles para timbrado",
 		);
 
 		// Respaldo: validar RFC si usuario trae SI por link directo
@@ -1107,8 +1113,8 @@
 							if (!r.message || !r.message.ok) {
 								frappe.msgprint(
 									__(
-										"El RFC del cliente de la Sales Invoice seleccionada NO está validado con SAT. No puedes continuar."
-									)
+										"El RFC del cliente de la Sales Invoice seleccionada NO está validado con SAT. No puedes continuar.",
+									),
 								);
 								frm.set_value("sales_invoice", null);
 							}
@@ -1158,16 +1164,16 @@
 										fiscal_r.message &&
 										states &&
 										states.cancelable_states.includes(
-											fiscal_r.message.fm_fiscal_status
+											fiscal_r.message.fm_fiscal_status,
 										)
 									) {
 										frappe.msgprint({
 											title: __("Sales Invoice No Disponible"),
 											message: __(
-												"La Sales Invoice {0} ya ha sido timbrada en el documento {1}. Por favor seleccione otra factura."
+												"La Sales Invoice {0} ya ha sido timbrada en el documento {1}. Por favor seleccione otra factura.",
 											).format(
 												frm.doc.sales_invoice,
-												sales_invoice_data.fm_factura_fiscal_mx
+												sales_invoice_data.fm_factura_fiscal_mx,
 											),
 											indicator: "red",
 										});
@@ -1185,7 +1191,7 @@
 						frappe.msgprint({
 							title: __("Sales Invoice No Válida"),
 							message: __(
-								"La Sales Invoice debe estar enviada (submitted) para crear factura fiscal."
+								"La Sales Invoice debe estar enviada (submitted) para crear factura fiscal.",
 							),
 							indicator: "orange",
 						});
@@ -1196,7 +1202,7 @@
 						frappe.msgprint({
 							title: __("RFC Faltante"),
 							message: __(
-								"La Sales Invoice debe tener RFC del cliente para facturación fiscal."
+								"La Sales Invoice debe tener RFC del cliente para facturación fiscal.",
 							),
 							indicator: "orange",
 						});
@@ -1333,7 +1339,7 @@
 				if (!$(this).find("input").is(":checked")) {
 					$(this).css("background-color", "transparent");
 				}
-			}
+			},
 		);
 
 		// Aplicar resaltado inicial
@@ -1406,7 +1412,7 @@
 					message: `<strong>${__(title)}</strong><br>${__(message)}`,
 					indicator: indicator,
 				},
-				ALERT_DURATION_DEFAULT
+				ALERT_DURATION_DEFAULT,
 			); // Duración extendida para mensaje crítico PPD/PUE
 		}
 	}
@@ -1434,7 +1440,7 @@
 					message: __("Forma de pago asignada automáticamente: 99 - Por definir"),
 					indicator: "orange",
 				},
-				ALERT_DURATION_DEFAULT
+				ALERT_DURATION_DEFAULT,
 			);
 		} else if (payment_method === "PUE") {
 			// Para PUE: Mostrar campo y filtrar opciones (sin "99 - Por definir")
@@ -1456,7 +1462,7 @@
 						message: __("Debe seleccionar una forma de pago específica para PUE"),
 						indicator: "yellow",
 					},
-					ALERT_DURATION_DEFAULT
+					ALERT_DURATION_DEFAULT,
 				);
 			}
 		}
@@ -1481,7 +1487,7 @@
 					message: __(message),
 					indicator: color,
 				},
-				ALERT_DURATION_DEFAULT
+				ALERT_DURATION_DEFAULT,
 			);
 		}
 	}
@@ -1700,7 +1706,7 @@
 					indicator: "blue",
 				},
 				3,
-				ALERT_DURATION_DEFAULT
+				ALERT_DURATION_DEFAULT,
 			);
 			frm.doc.__multisucursal_indicator_shown = true;
 		}
@@ -1773,7 +1779,7 @@
 				(f) =>
 					!frm.doc[f.field] ||
 					frm.doc[f.field].includes("⚠️ FALTA") ||
-					frm.doc[f.field].includes("❌ ERROR")
+					frm.doc[f.field].includes("❌ ERROR"),
 			);
 
 			// Determinar color y mensaje según validación SAT (RFC validado tiene prioridad)
@@ -1940,7 +1946,7 @@ function validate_billing_data_visual(frm) {
 
 		if (field_config.required && !field_config.check_value) {
 			console.log(
-				`🔴 [DEBUG] Campo ${field_config.fieldname} FALTANTE - aplicando estilo rojo`
+				`🔴 [DEBUG] Campo ${field_config.fieldname} FALTANTE - aplicando estilo rojo`,
 			);
 			// Campo faltante - resaltar en rojo
 			const control_input = field_wrapper.$wrapper.find(".control-input");
@@ -1993,7 +1999,7 @@ function validate_billing_data_visual(frm) {
 				message: `⚠️ Datos de facturación incompletos: ${missing_list}. Configure estos datos en el Cliente.`,
 				indicator: "orange",
 			},
-			ALERT_DURATION_DEFAULT
+			ALERT_DURATION_DEFAULT,
 		);
 	}
 
@@ -2124,7 +2130,7 @@ function validate_billing_data_visual(frm) {
 
 		// Remover clases de color previas
 		target_element.removeClass(
-			"billing-section-red billing-section-yellow billing-section-green"
+			"billing-section-red billing-section-yellow billing-section-green",
 		);
 
 		// Definir colores según estado
@@ -2267,7 +2273,7 @@ function validate_billing_data_visual(frm) {
 						show_customer_fiscal_warning(
 							frm,
 							sales_invoice_customer,
-							sales_invoice_customer_name
+							sales_invoice_customer_name,
 						);
 					} else {
 						// Mismo cliente - ocultar aviso
@@ -2361,7 +2367,7 @@ function validate_billing_data_visual(frm) {
 		}
 
 		console.log(
-			`🔍 FASE 4: Verificando consistencia Payment Entry para documento existente ${frm.doc.name}`
+			`🔍 FASE 4: Verificando consistencia Payment Entry para documento existente ${frm.doc.name}`,
 		);
 
 		// Solo verificar para PUE (PPD siempre usa "99 - Por definir")
@@ -2388,7 +2394,7 @@ function validate_billing_data_visual(frm) {
 							const payment_method = payment_entry.mode_of_payment;
 
 							console.log(
-								`🔍 FASE 4: Payment Entry encontrado - ${payment_entry.name}, Método: ${payment_method}`
+								`🔍 FASE 4: Payment Entry encontrado - ${payment_entry.name}, Método: ${payment_method}`,
 							);
 
 							if (current_forma_pago) {
@@ -2396,12 +2402,12 @@ function validate_billing_data_visual(frm) {
 								if (current_forma_pago === payment_method) {
 									// ✅ Consistente - no mostrar aviso
 									console.log(
-										`✅ FASE 4: Forma de pago consistente: ${current_forma_pago}`
+										`✅ FASE 4: Forma de pago consistente: ${current_forma_pago}`,
 									);
 								} else {
 									// ⚠️ Inconsistente - mostrar mensaje persistente
 									console.log(
-										`⚠️ FASE 4: Inconsistencia detectada - Factura: ${current_forma_pago}, Payment: ${payment_method}`
+										`⚠️ FASE 4: Inconsistencia detectada - Factura: ${current_forma_pago}, Payment: ${payment_method}`,
 									);
 
 									const d4 = frappe.msgprint({
@@ -2415,7 +2421,7 @@ function validate_billing_data_visual(frm) {
 												"<span style='color: #0066cc;'>" +
 													payment_method +
 													"</span>",
-											]
+											],
 										),
 										indicator: "orange",
 										primary_action: {
@@ -2427,7 +2433,7 @@ function validate_billing_data_visual(frm) {
 							} else {
 								// Sin forma de pago pero hay Payment Entry - auto-cargar
 								console.log(
-									`✅ FASE 4: Auto-cargando ${payment_method} desde ${payment_entry.name}`
+									`✅ FASE 4: Auto-cargando ${payment_method} desde ${payment_entry.name}`,
 								);
 
 								frm.set_value("fm_forma_pago_timbrado", payment_method);
@@ -2439,7 +2445,7 @@ function validate_billing_data_visual(frm) {
 										indicator: "green",
 									},
 									5,
-									ALERT_DURATION_DEFAULT
+									ALERT_DURATION_DEFAULT,
 								);
 							}
 						} else {
@@ -2456,7 +2462,7 @@ function validate_billing_data_visual(frm) {
 											"<span style='color: #0066cc;'>" +
 												current_forma_pago +
 												"</span>",
-										]
+										],
 									),
 									indicator: "blue",
 									primary_action: {
@@ -2469,7 +2475,7 @@ function validate_billing_data_visual(frm) {
 								const d6 = frappe.msgprint({
 									title: __("ℹ️ Sin Pago Registrado"),
 									message: __(
-										"No hay Payment Entry registrado para esta factura.<br><br>Seleccione la forma de pago manualmente antes de timbrar."
+										"No hay Payment Entry registrado para esta factura.<br><br>Seleccione la forma de pago manualmente antes de timbrar.",
 									),
 									indicator: "blue",
 									primary_action: {
@@ -2487,7 +2493,7 @@ function validate_billing_data_visual(frm) {
 								indicator: "red",
 							},
 							3,
-							ALERT_DURATION_DEFAULT
+							ALERT_DURATION_DEFAULT,
 						);
 					}
 				},
@@ -2533,7 +2539,7 @@ function validate_billing_data_visual(frm) {
 			}
 
 			console.log(
-				`🔍 FASE 4: Buscando Payment Entry para Sales Invoice ${frm.doc.sales_invoice}`
+				`🔍 FASE 4: Buscando Payment Entry para Sales Invoice ${frm.doc.sales_invoice}`,
 			);
 
 			// Usar método Python con SQL correcto (no sintaxis child table problemática)
@@ -2552,33 +2558,33 @@ function validate_billing_data_visual(frm) {
 							frappe.show_alert(
 								{
 									message: __(
-										"Forma de pago cargada automáticamente desde Payment Entry {0}"
+										"Forma de pago cargada automáticamente desde Payment Entry {0}",
 									).format(payment_entry.name),
 									indicator: "green",
 								},
 								4,
-								ALERT_DURATION_DEFAULT
+								ALERT_DURATION_DEFAULT,
 							);
 
 							console.log(
-								`✅ FASE 4: Auto-cargado PUE - ${payment_entry.mode_of_payment} desde ${payment_entry.name}`
+								`✅ FASE 4: Auto-cargado PUE - ${payment_entry.mode_of_payment} desde ${payment_entry.name}`,
 							);
 						}
 					} else {
 						// PUE sin Payment Entry - dejar vacío para selección manual
 						console.log(
-							"ℹ️ FASE 4: PUE sin Payment Entry - usuario debe seleccionar manualmente"
+							"ℹ️ FASE 4: PUE sin Payment Entry - usuario debe seleccionar manualmente",
 						);
 
 						frappe.show_alert(
 							{
 								message: __(
-									"No se encontró Payment Entry. Seleccione forma de pago manualmente."
+									"No se encontró Payment Entry. Seleccione forma de pago manualmente.",
 								),
 								indicator: "yellow",
 							},
 							3,
-							ALERT_DURATION_DEFAULT
+							ALERT_DURATION_DEFAULT,
 						);
 					}
 				},
@@ -2635,11 +2641,11 @@ function validate_billing_data_visual(frm) {
 								message: __("FFM cancelada y SI liberada."),
 								indicator: "green",
 							},
-							ALERT_DURATION_DEFAULT
+							ALERT_DURATION_DEFAULT,
 						);
 						frm.reload_doc();
 					},
-					__("Acciones")
+					__("Acciones"),
 				);
 			}
 		},

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -77,7 +77,7 @@
 			frappe.msgprint({
 				title: __("Sustitución CFDI (01)"),
 				message: __(
-					'Para sustitución, use el botón <b>"Sustituir CFDI (01)"</b> en el Sales Invoice.',
+					'Para sustitución, use el botón <b>"Sustituir CFDI (01)"</b> en el Sales Invoice.'
 				),
 				indicator: "orange",
 				primary_action: {
@@ -106,12 +106,12 @@
 								`2️⃣ Use el botón "🔄 Sustituir CFDI (01)"<br>` +
 								`3️⃣ Se creará un SI de reemplazo para correcciones<br>` +
 								`4️⃣ El sistema manejará la relación TipoRelación 04 automáticamente<br><br>` +
-								`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`,
+								`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`
 						),
 						indicator: "blue",
 					});
 				},
-				__("Ayuda"),
+				__("Ayuda")
 			);
 		}
 	}
@@ -249,7 +249,7 @@
 							});
 						}
 					},
-					__("Comprobantes"),
+					__("Comprobantes")
 				);
 
 				// 2) Enviar CFDI por email - Agrupado en "Comprobantes"
@@ -270,7 +270,7 @@
 							} else if (res && res.reason === "no-recipient") {
 								frappe.msgprint({
 									message: __(
-										"No se envió: no hay destinatario (FFM ni Settings).",
+										"No se envió: no hay destinatario (FFM ni Settings)."
 									),
 									indicator: "orange",
 								});
@@ -286,7 +286,7 @@
 							frappe.msgprint({ message: __(String(e)), indicator: "red" });
 						}
 					},
-					__("Comprobantes"),
+					__("Comprobantes")
 				);
 			}
 
@@ -304,12 +304,12 @@
 									`2️⃣ Use el botón "🔄 Sustituir CFDI (01)"<br>` +
 									`3️⃣ Se creará un SI de reemplazo para correcciones<br>` +
 									`4️⃣ El sistema manejará la relación TipoRelación 04 automáticamente<br><br>` +
-									`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`,
+									`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`
 							),
 							indicator: "blue",
 						});
 					},
-					__("Ayuda"),
+					__("Ayuda")
 				);
 			}
 
@@ -392,14 +392,14 @@
 								frm.set_df_property(
 									"fm_tipo_comprobante",
 									"options",
-									tipo_comprobante_options.join("\n"),
+									tipo_comprobante_options.join("\n")
 								);
 							}
 							if (tipo_relacion_options && tipo_relacion_options.length) {
 								frm.set_df_property(
 									"fm_tipo_relacion_sat",
 									"options",
-									tipo_relacion_options.join("\n"),
+									tipo_relacion_options.join("\n")
 								);
 							}
 						}
@@ -643,7 +643,7 @@
 		}
 
 		console.log(
-			`🔍 auto_assign_cfdi_from_customer: Cargando Use CFDI para customer: ${customer}`,
+			`🔍 auto_assign_cfdi_from_customer: Cargando Use CFDI para customer: ${customer}`
 		);
 
 		frappe.db
@@ -662,12 +662,12 @@
 							indicator: "green",
 						},
 						7,
-						ALERT_DURATION_DEFAULT,
+						ALERT_DURATION_DEFAULT
 					);
 				} else {
 					// Customer no tiene uso CFDI configurado - dejar vacío
 					console.log(
-						"⚠️ Customer no tiene fm_uso_cfdi_default configurado - campo vacío",
+						"⚠️ Customer no tiene fm_uso_cfdi_default configurado - campo vacío"
 					);
 					frm.set_value("fm_cfdi_use", "");
 				}
@@ -692,7 +692,7 @@
 				message: __("Actualizando datos fiscales del cliente..."),
 				indicator: "blue",
 			},
-			ALERT_DURATION_DEFAULT,
+			ALERT_DURATION_DEFAULT
 		);
 
 		// PASO 1: Obtener datos básicos del customer para uso CFDI y campos fiscales legacy
@@ -739,7 +739,7 @@
 							message: __("Datos fiscales y de facturación actualizados"),
 							indicator: "green",
 						},
-						ALERT_DURATION_DEFAULT,
+						ALERT_DURATION_DEFAULT
 					);
 				}
 			},
@@ -749,7 +749,7 @@
 						message: __("Error al cargar datos fiscales del Cliente"),
 						indicator: "red",
 					},
-					ALERT_DURATION_DEFAULT,
+					ALERT_DURATION_DEFAULT
 				);
 			},
 		});
@@ -869,7 +869,7 @@
 								message: __("Factura timbrada exitosamente"),
 								indicator: "green",
 							},
-							ALERT_DURATION_DEFAULT,
+							ALERT_DURATION_DEFAULT
 						);
 						frm.reload_doc();
 					} else if (r.message && r.message.user_error) {
@@ -930,7 +930,7 @@
 				if (hasLinkedSI && status === "TIMBRADO") {
 					// Filtrar opciones que empiecen con "01\t"
 					filtered_options = motives_config.select_options.filter(
-						(option) => !option.startsWith(SUB_01 + "\t"),
+						(option) => !option.startsWith(SUB_01 + "\t")
 					);
 				}
 
@@ -943,7 +943,7 @@
 							reqd: 1,
 							options: filtered_options,
 							description: __(
-								"Seleccione el motivo de cancelación según catálogo SAT",
+								"Seleccione el motivo de cancelación según catálogo SAT"
 							),
 						},
 						{
@@ -953,7 +953,7 @@
 							depends_on: "eval:doc.motive=='01'",
 							mandatory_depends_on: "eval:doc.motive=='01'",
 							description: __(
-								"Requerido solo para motivo 01 - Comprobantes con errores con relación",
+								"Requerido solo para motivo 01 - Comprobantes con errores con relación"
 							),
 						},
 					],
@@ -968,7 +968,7 @@
 						await cancelar_cfdi(frm, values);
 					},
 					__("Cancelación Fiscal SAT"),
-					__("Enviar"),
+					__("Enviar")
 				);
 			},
 		});
@@ -1015,19 +1015,19 @@
 					message: __("✅ Factura cancelada exitosamente"),
 					indicator: "green",
 				},
-				ALERT_DURATION_DEFAULT,
+				ALERT_DURATION_DEFAULT
 			);
 
 			const lines = [
 				`<b>FFM:</b> ${frappe.utils.escape_html(msg.ffm || frm.doc.name)}`,
 				`<b>Sales Invoice:</b> ${frappe.utils.escape_html(
-					msg.sales_invoice || frm.doc.sales_invoice,
+					msg.sales_invoice || frm.doc.sales_invoice
 				)}`,
 				`<b>Estado FFM:</b> ${frappe.utils.escape_html(msg.status_ffm || "")}`,
 				`<b>Estado SI:</b> ${frappe.utils.escape_html(msg.status_si || "")}`,
 				`<b>UUID:</b> ${frappe.utils.escape_html(msg.uuid || "")}`,
 				`<b>Fecha cancelación:</b> ${frappe.utils.escape_html(
-					msg.cancellation_date || "",
+					msg.cancellation_date || ""
 				)}`,
 			]
 				.filter(Boolean)
@@ -1053,7 +1053,7 @@
 					const d3 = frappe.msgprint({
 						title: __("Conexión Exitosa"),
 						message: __(
-							"La conexión con FacturAPI se estableció correctamente. El sistema está listo para timbrar facturas.",
+							"La conexión con FacturAPI se estableció correctamente. El sistema está listo para timbrar facturas."
 						),
 						indicator: "green",
 						primary_action: {
@@ -1095,7 +1095,7 @@
 		});
 
 		console.log(
-			"✅ Filtros Sales Invoice configurados - Solo facturas disponibles para timbrado",
+			"✅ Filtros Sales Invoice configurados - Solo facturas disponibles para timbrado"
 		);
 
 		// Respaldo: validar RFC si usuario trae SI por link directo
@@ -1113,8 +1113,8 @@
 							if (!r.message || !r.message.ok) {
 								frappe.msgprint(
 									__(
-										"El RFC del cliente de la Sales Invoice seleccionada NO está validado con SAT. No puedes continuar.",
-									),
+										"El RFC del cliente de la Sales Invoice seleccionada NO está validado con SAT. No puedes continuar."
+									)
 								);
 								frm.set_value("sales_invoice", null);
 							}
@@ -1164,16 +1164,16 @@
 										fiscal_r.message &&
 										states &&
 										states.cancelable_states.includes(
-											fiscal_r.message.fm_fiscal_status,
+											fiscal_r.message.fm_fiscal_status
 										)
 									) {
 										frappe.msgprint({
 											title: __("Sales Invoice No Disponible"),
 											message: __(
-												"La Sales Invoice {0} ya ha sido timbrada en el documento {1}. Por favor seleccione otra factura.",
+												"La Sales Invoice {0} ya ha sido timbrada en el documento {1}. Por favor seleccione otra factura."
 											).format(
 												frm.doc.sales_invoice,
-												sales_invoice_data.fm_factura_fiscal_mx,
+												sales_invoice_data.fm_factura_fiscal_mx
 											),
 											indicator: "red",
 										});
@@ -1191,7 +1191,7 @@
 						frappe.msgprint({
 							title: __("Sales Invoice No Válida"),
 							message: __(
-								"La Sales Invoice debe estar enviada (submitted) para crear factura fiscal.",
+								"La Sales Invoice debe estar enviada (submitted) para crear factura fiscal."
 							),
 							indicator: "orange",
 						});
@@ -1202,7 +1202,7 @@
 						frappe.msgprint({
 							title: __("RFC Faltante"),
 							message: __(
-								"La Sales Invoice debe tener RFC del cliente para facturación fiscal.",
+								"La Sales Invoice debe tener RFC del cliente para facturación fiscal."
 							),
 							indicator: "orange",
 						});
@@ -1339,7 +1339,7 @@
 				if (!$(this).find("input").is(":checked")) {
 					$(this).css("background-color", "transparent");
 				}
-			},
+			}
 		);
 
 		// Aplicar resaltado inicial
@@ -1412,7 +1412,7 @@
 					message: `<strong>${__(title)}</strong><br>${__(message)}`,
 					indicator: indicator,
 				},
-				ALERT_DURATION_DEFAULT,
+				ALERT_DURATION_DEFAULT
 			); // Duración extendida para mensaje crítico PPD/PUE
 		}
 	}
@@ -1440,7 +1440,7 @@
 					message: __("Forma de pago asignada automáticamente: 99 - Por definir"),
 					indicator: "orange",
 				},
-				ALERT_DURATION_DEFAULT,
+				ALERT_DURATION_DEFAULT
 			);
 		} else if (payment_method === "PUE") {
 			// Para PUE: Mostrar campo y filtrar opciones (sin "99 - Por definir")
@@ -1462,7 +1462,7 @@
 						message: __("Debe seleccionar una forma de pago específica para PUE"),
 						indicator: "yellow",
 					},
-					ALERT_DURATION_DEFAULT,
+					ALERT_DURATION_DEFAULT
 				);
 			}
 		}
@@ -1487,7 +1487,7 @@
 					message: __(message),
 					indicator: color,
 				},
-				ALERT_DURATION_DEFAULT,
+				ALERT_DURATION_DEFAULT
 			);
 		}
 	}
@@ -1706,7 +1706,7 @@
 					indicator: "blue",
 				},
 				3,
-				ALERT_DURATION_DEFAULT,
+				ALERT_DURATION_DEFAULT
 			);
 			frm.doc.__multisucursal_indicator_shown = true;
 		}
@@ -1779,7 +1779,7 @@
 				(f) =>
 					!frm.doc[f.field] ||
 					frm.doc[f.field].includes("⚠️ FALTA") ||
-					frm.doc[f.field].includes("❌ ERROR"),
+					frm.doc[f.field].includes("❌ ERROR")
 			);
 
 			// Determinar color y mensaje según validación SAT (RFC validado tiene prioridad)
@@ -1946,7 +1946,7 @@ function validate_billing_data_visual(frm) {
 
 		if (field_config.required && !field_config.check_value) {
 			console.log(
-				`🔴 [DEBUG] Campo ${field_config.fieldname} FALTANTE - aplicando estilo rojo`,
+				`🔴 [DEBUG] Campo ${field_config.fieldname} FALTANTE - aplicando estilo rojo`
 			);
 			// Campo faltante - resaltar en rojo
 			const control_input = field_wrapper.$wrapper.find(".control-input");
@@ -1999,7 +1999,7 @@ function validate_billing_data_visual(frm) {
 				message: `⚠️ Datos de facturación incompletos: ${missing_list}. Configure estos datos en el Cliente.`,
 				indicator: "orange",
 			},
-			ALERT_DURATION_DEFAULT,
+			ALERT_DURATION_DEFAULT
 		);
 	}
 
@@ -2130,7 +2130,7 @@ function validate_billing_data_visual(frm) {
 
 		// Remover clases de color previas
 		target_element.removeClass(
-			"billing-section-red billing-section-yellow billing-section-green",
+			"billing-section-red billing-section-yellow billing-section-green"
 		);
 
 		// Definir colores según estado
@@ -2273,7 +2273,7 @@ function validate_billing_data_visual(frm) {
 						show_customer_fiscal_warning(
 							frm,
 							sales_invoice_customer,
-							sales_invoice_customer_name,
+							sales_invoice_customer_name
 						);
 					} else {
 						// Mismo cliente - ocultar aviso
@@ -2367,7 +2367,7 @@ function validate_billing_data_visual(frm) {
 		}
 
 		console.log(
-			`🔍 FASE 4: Verificando consistencia Payment Entry para documento existente ${frm.doc.name}`,
+			`🔍 FASE 4: Verificando consistencia Payment Entry para documento existente ${frm.doc.name}`
 		);
 
 		// Solo verificar para PUE (PPD siempre usa "99 - Por definir")
@@ -2394,7 +2394,7 @@ function validate_billing_data_visual(frm) {
 							const payment_method = payment_entry.mode_of_payment;
 
 							console.log(
-								`🔍 FASE 4: Payment Entry encontrado - ${payment_entry.name}, Método: ${payment_method}`,
+								`🔍 FASE 4: Payment Entry encontrado - ${payment_entry.name}, Método: ${payment_method}`
 							);
 
 							if (current_forma_pago) {
@@ -2402,12 +2402,12 @@ function validate_billing_data_visual(frm) {
 								if (current_forma_pago === payment_method) {
 									// ✅ Consistente - no mostrar aviso
 									console.log(
-										`✅ FASE 4: Forma de pago consistente: ${current_forma_pago}`,
+										`✅ FASE 4: Forma de pago consistente: ${current_forma_pago}`
 									);
 								} else {
 									// ⚠️ Inconsistente - mostrar mensaje persistente
 									console.log(
-										`⚠️ FASE 4: Inconsistencia detectada - Factura: ${current_forma_pago}, Payment: ${payment_method}`,
+										`⚠️ FASE 4: Inconsistencia detectada - Factura: ${current_forma_pago}, Payment: ${payment_method}`
 									);
 
 									const d4 = frappe.msgprint({
@@ -2421,7 +2421,7 @@ function validate_billing_data_visual(frm) {
 												"<span style='color: #0066cc;'>" +
 													payment_method +
 													"</span>",
-											],
+											]
 										),
 										indicator: "orange",
 										primary_action: {
@@ -2433,7 +2433,7 @@ function validate_billing_data_visual(frm) {
 							} else {
 								// Sin forma de pago pero hay Payment Entry - auto-cargar
 								console.log(
-									`✅ FASE 4: Auto-cargando ${payment_method} desde ${payment_entry.name}`,
+									`✅ FASE 4: Auto-cargando ${payment_method} desde ${payment_entry.name}`
 								);
 
 								frm.set_value("fm_forma_pago_timbrado", payment_method);
@@ -2445,7 +2445,7 @@ function validate_billing_data_visual(frm) {
 										indicator: "green",
 									},
 									5,
-									ALERT_DURATION_DEFAULT,
+									ALERT_DURATION_DEFAULT
 								);
 							}
 						} else {
@@ -2462,7 +2462,7 @@ function validate_billing_data_visual(frm) {
 											"<span style='color: #0066cc;'>" +
 												current_forma_pago +
 												"</span>",
-										],
+										]
 									),
 									indicator: "blue",
 									primary_action: {
@@ -2475,7 +2475,7 @@ function validate_billing_data_visual(frm) {
 								const d6 = frappe.msgprint({
 									title: __("ℹ️ Sin Pago Registrado"),
 									message: __(
-										"No hay Payment Entry registrado para esta factura.<br><br>Seleccione la forma de pago manualmente antes de timbrar.",
+										"No hay Payment Entry registrado para esta factura.<br><br>Seleccione la forma de pago manualmente antes de timbrar."
 									),
 									indicator: "blue",
 									primary_action: {
@@ -2493,7 +2493,7 @@ function validate_billing_data_visual(frm) {
 								indicator: "red",
 							},
 							3,
-							ALERT_DURATION_DEFAULT,
+							ALERT_DURATION_DEFAULT
 						);
 					}
 				},
@@ -2539,7 +2539,7 @@ function validate_billing_data_visual(frm) {
 			}
 
 			console.log(
-				`🔍 FASE 4: Buscando Payment Entry para Sales Invoice ${frm.doc.sales_invoice}`,
+				`🔍 FASE 4: Buscando Payment Entry para Sales Invoice ${frm.doc.sales_invoice}`
 			);
 
 			// Usar método Python con SQL correcto (no sintaxis child table problemática)
@@ -2558,33 +2558,33 @@ function validate_billing_data_visual(frm) {
 							frappe.show_alert(
 								{
 									message: __(
-										"Forma de pago cargada automáticamente desde Payment Entry {0}",
+										"Forma de pago cargada automáticamente desde Payment Entry {0}"
 									).format(payment_entry.name),
 									indicator: "green",
 								},
 								4,
-								ALERT_DURATION_DEFAULT,
+								ALERT_DURATION_DEFAULT
 							);
 
 							console.log(
-								`✅ FASE 4: Auto-cargado PUE - ${payment_entry.mode_of_payment} desde ${payment_entry.name}`,
+								`✅ FASE 4: Auto-cargado PUE - ${payment_entry.mode_of_payment} desde ${payment_entry.name}`
 							);
 						}
 					} else {
 						// PUE sin Payment Entry - dejar vacío para selección manual
 						console.log(
-							"ℹ️ FASE 4: PUE sin Payment Entry - usuario debe seleccionar manualmente",
+							"ℹ️ FASE 4: PUE sin Payment Entry - usuario debe seleccionar manualmente"
 						);
 
 						frappe.show_alert(
 							{
 								message: __(
-									"No se encontró Payment Entry. Seleccione forma de pago manualmente.",
+									"No se encontró Payment Entry. Seleccione forma de pago manualmente."
 								),
 								indicator: "yellow",
 							},
 							3,
-							ALERT_DURATION_DEFAULT,
+							ALERT_DURATION_DEFAULT
 						);
 					}
 				},
@@ -2641,11 +2641,11 @@ function validate_billing_data_visual(frm) {
 								message: __("FFM cancelada y SI liberada."),
 								indicator: "green",
 							},
-							ALERT_DURATION_DEFAULT,
+							ALERT_DURATION_DEFAULT
 						);
 						frm.reload_doc();
 					},
-					__("Acciones"),
+					__("Acciones")
 				);
 			}
 		},

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -1676,7 +1676,7 @@ class TimbradoAPI:
 			if not tax.item_wise_tax_detail:
 				# Fallback para On Net Total sin item_wise_tax_detail (p.ej. SI creada via API
 				# o cuando ERPNext v16 no persistió el desglose por item).
-				# Solo aplica a tasas sobre base neta: amount = net_amount × rate / 100.
+				# Solo aplica a tasas sobre base neta: amount = net_amount x rate / 100.
 				if getattr(tax, "charge_type", None) == "On Net Total" and flt(tax.rate):
 					amount = flt(item.net_amount) * flt(tax.rate) / 100
 					if amount and tax.account_head not in taxes_dict:

--- a/facturacion_mexico/public/js/sales_invoice.js
+++ b/facturacion_mexico/public/js/sales_invoice.js
@@ -63,9 +63,9 @@ frappe.ui.form.on("Sales Invoice", {
 							} else {
 								frm.dashboard.set_headline_alert(
 									__(
-										"No puedes timbrar: el RFC del cliente no está validado con SAT.",
+										"No puedes timbrar: el RFC del cliente no está validado con SAT."
 									),
-									"orange",
+									"orange"
 								);
 							}
 						});
@@ -153,7 +153,7 @@ function redirect_to_fiscal_document(frm) {
 						frappe.msgprint({
 							title: __("Ya Timbrada"),
 							message: __(
-								"Esta Sales Invoice ya está timbrada. No se puede volver a timbrar.",
+								"Esta Sales Invoice ya está timbrada. No se puede volver a timbrar."
 							),
 							indicator: "orange",
 						});
@@ -208,7 +208,7 @@ function _resolve_uuid_for_return(frm, callback) {
 					_show_uuid_dialog(frm, callback);
 				}
 			});
-		},
+		}
 	);
 }
 
@@ -220,7 +220,7 @@ function _show_uuid_dialog(frm, callback) {
 			fieldtype: "Data",
 			reqd: 1,
 			description: __(
-				"UUID del CFDI que esta nota de crédito cancela o modifica (36 caracteres)",
+				"UUID del CFDI que esta nota de crédito cancela o modifica (36 caracteres)"
 			),
 		},
 		function (values) {
@@ -229,7 +229,7 @@ function _show_uuid_dialog(frm, callback) {
 				frappe.msgprint({
 					title: __("UUID inválido"),
 					message: __(
-						"El UUID debe tener 36 caracteres (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)",
+						"El UUID debe tener 36 caracteres (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)"
 					),
 					indicator: "red",
 				});
@@ -238,7 +238,7 @@ function _show_uuid_dialog(frm, callback) {
 			callback(uuid);
 		},
 		__("UUID relacionado requerido"),
-		__("Continuar"),
+		__("Continuar")
 	);
 }
 
@@ -268,7 +268,7 @@ function _do_create_ffm(frm, extra_fields) {
 			si_iva: iva_total,
 			si_otros_impuestos: otros_impuestos,
 		},
-		extra_fields,
+		extra_fields
 	);
 
 	frappe.call({
@@ -290,7 +290,7 @@ function _do_create_ffm(frm, extra_fields) {
 								message: __("Documento fiscal creado exitosamente"),
 								indicator: "green",
 							},
-							3,
+							3
 						);
 
 						setTimeout(() => {
@@ -360,7 +360,7 @@ frappe.ui.form.on("Sales Invoice", {
 							message: __("Centro de Costos asignado automáticamente."),
 							indicator: "green",
 						},
-						6,
+						6
 					);
 
 					// Disparar evento cost_center para que recalcule Branch/Price List
@@ -370,11 +370,11 @@ frappe.ui.form.on("Sales Invoice", {
 					frappe.show_alert(
 						{
 							message: __(
-								"Este cliente no tiene Centro de Costos configurado. Selecciónalo para continuar.",
+								"Este cliente no tiene Centro de Costos configurado. Selecciónalo para continuar."
 							),
 							indicator: "orange",
 						},
-						6,
+						6
 					);
 				}
 			}
@@ -383,11 +383,11 @@ frappe.ui.form.on("Sales Invoice", {
 			frappe.show_alert(
 				{
 					message: __(
-						"Error al cargar configuración del cliente. Configura manualmente.",
+						"Error al cargar configuración del cliente. Configura manualmente."
 					),
 					indicator: "red",
 				},
-				6,
+				6
 			);
 		}
 	},
@@ -421,7 +421,7 @@ frappe.ui.form.on("Sales Invoice", {
 				const cust = await frappe.db.get_value(
 					"Customer",
 					frm.doc.customer,
-					"default_price_list",
+					"default_price_list"
 				);
 				if (cust && cust.message && cust.message.default_price_list) {
 					picked = cust.message.default_price_list;
@@ -434,7 +434,7 @@ frappe.ui.form.on("Sales Invoice", {
 				const ccpl = await frappe.db.get_value(
 					"Cost Center",
 					cc,
-					"fm_default_selling_price_list",
+					"fm_default_selling_price_list"
 				);
 				if (ccpl && ccpl.message && ccpl.message.fm_default_selling_price_list) {
 					picked = ccpl.message.fm_default_selling_price_list;
@@ -446,7 +446,7 @@ frappe.ui.form.on("Sales Invoice", {
 			if (!picked) {
 				const ss = await frappe.db.get_single_value(
 					"Selling Settings",
-					"selling_price_list",
+					"selling_price_list"
 				);
 				if (ss) {
 					picked = ss;
@@ -462,7 +462,7 @@ frappe.ui.form.on("Sales Invoice", {
 						message: __("Lista de precios asignada automáticamente."),
 						indicator: "green",
 					},
-					6,
+					6
 				);
 			}
 		} catch (e) {
@@ -504,7 +504,7 @@ frappe.ui.form.on("Sales Invoice", {
 			const cc_company = await frappe.db.get_value(
 				"Cost Center",
 				frm.doc.cost_center,
-				"company",
+				"company"
 			);
 			if (
 				cc_company &&
@@ -516,11 +516,11 @@ frappe.ui.form.on("Sales Invoice", {
 				frappe.show_alert(
 					{
 						message: __(
-							"Centro de Costos limpiado: no pertenece a la nueva Company seleccionada.",
+							"Centro de Costos limpiado: no pertenece a la nueva Company seleccionada."
 						),
 						indicator: "orange",
 					},
-					6,
+					6
 				);
 			}
 		} catch (e) {
@@ -555,7 +555,7 @@ frappe.ui.form.on("Sales Invoice", {
 				await frm.set_value("cost_center", cc);
 				frappe.show_alert(
 					{ message: "Centro de Costos asignado automáticamente.", indicator: "green" },
-					6,
+					6
 				);
 			} else {
 				frappe.show_alert(
@@ -563,7 +563,7 @@ frappe.ui.form.on("Sales Invoice", {
 						message: "El cliente no tiene Centro de Costos por defecto.",
 						indicator: "orange",
 					},
-					6,
+					6
 				);
 			}
 
@@ -595,14 +595,14 @@ frappe.ui.form.on("Sales Invoice", {
 				const { message: ccRow } = await frappe.db.get_value(
 					"Cost Center",
 					frm.doc.cost_center,
-					["fm_default_selling_price_list"],
+					["fm_default_selling_price_list"]
 				);
 				if (ccRow && ccRow.fm_default_selling_price_list) {
 					await frm.set_value("selling_price_list", ccRow.fm_default_selling_price_list);
 				} else {
 					const companyPL = await frappe.db.get_single_value(
 						"Selling Settings",
-						"selling_price_list",
+						"selling_price_list"
 					);
 					if (companyPL) await frm.set_value("selling_price_list", companyPL);
 				}

--- a/facturacion_mexico/public/js/sales_invoice.js
+++ b/facturacion_mexico/public/js/sales_invoice.js
@@ -63,9 +63,9 @@ frappe.ui.form.on("Sales Invoice", {
 							} else {
 								frm.dashboard.set_headline_alert(
 									__(
-										"No puedes timbrar: el RFC del cliente no está validado con SAT."
+										"No puedes timbrar: el RFC del cliente no está validado con SAT.",
 									),
-									"orange"
+									"orange",
 								);
 							}
 						});
@@ -153,7 +153,7 @@ function redirect_to_fiscal_document(frm) {
 						frappe.msgprint({
 							title: __("Ya Timbrada"),
 							message: __(
-								"Esta Sales Invoice ya está timbrada. No se puede volver a timbrar."
+								"Esta Sales Invoice ya está timbrada. No se puede volver a timbrar.",
 							),
 							indicator: "orange",
 						});
@@ -200,20 +200,15 @@ function _resolve_uuid_for_return(frm, callback) {
 				return;
 			}
 
-			frappe.db.get_value(
-				"Factura Fiscal Mexico",
-				ffm_name,
-				"fm_uuid",
-				function (ffm_data) {
-					const uuid = ffm_data && ffm_data.fm_uuid;
-					if (uuid) {
-						callback(uuid);
-					} else {
-						_show_uuid_dialog(frm, callback);
-					}
+			frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "fm_uuid", function (ffm_data) {
+				const uuid = ffm_data && ffm_data.fm_uuid;
+				if (uuid) {
+					callback(uuid);
+				} else {
+					_show_uuid_dialog(frm, callback);
 				}
-			);
-		}
+			});
+		},
 	);
 }
 
@@ -225,7 +220,7 @@ function _show_uuid_dialog(frm, callback) {
 			fieldtype: "Data",
 			reqd: 1,
 			description: __(
-				"UUID del CFDI que esta nota de crédito cancela o modifica (36 caracteres)"
+				"UUID del CFDI que esta nota de crédito cancela o modifica (36 caracteres)",
 			),
 		},
 		function (values) {
@@ -234,7 +229,7 @@ function _show_uuid_dialog(frm, callback) {
 				frappe.msgprint({
 					title: __("UUID inválido"),
 					message: __(
-						"El UUID debe tener 36 caracteres (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)"
+						"El UUID debe tener 36 caracteres (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)",
 					),
 					indicator: "red",
 				});
@@ -243,7 +238,7 @@ function _show_uuid_dialog(frm, callback) {
 			callback(uuid);
 		},
 		__("UUID relacionado requerido"),
-		__("Continuar")
+		__("Continuar"),
 	);
 }
 
@@ -273,7 +268,7 @@ function _do_create_ffm(frm, extra_fields) {
 			si_iva: iva_total,
 			si_otros_impuestos: otros_impuestos,
 		},
-		extra_fields
+		extra_fields,
 	);
 
 	frappe.call({
@@ -295,7 +290,7 @@ function _do_create_ffm(frm, extra_fields) {
 								message: __("Documento fiscal creado exitosamente"),
 								indicator: "green",
 							},
-							3
+							3,
 						);
 
 						setTimeout(() => {
@@ -365,7 +360,7 @@ frappe.ui.form.on("Sales Invoice", {
 							message: __("Centro de Costos asignado automáticamente."),
 							indicator: "green",
 						},
-						6
+						6,
 					);
 
 					// Disparar evento cost_center para que recalcule Branch/Price List
@@ -375,11 +370,11 @@ frappe.ui.form.on("Sales Invoice", {
 					frappe.show_alert(
 						{
 							message: __(
-								"Este cliente no tiene Centro de Costos configurado. Selecciónalo para continuar."
+								"Este cliente no tiene Centro de Costos configurado. Selecciónalo para continuar.",
 							),
 							indicator: "orange",
 						},
-						6
+						6,
 					);
 				}
 			}
@@ -388,11 +383,11 @@ frappe.ui.form.on("Sales Invoice", {
 			frappe.show_alert(
 				{
 					message: __(
-						"Error al cargar configuración del cliente. Configura manualmente."
+						"Error al cargar configuración del cliente. Configura manualmente.",
 					),
 					indicator: "red",
 				},
-				6
+				6,
 			);
 		}
 	},
@@ -426,7 +421,7 @@ frappe.ui.form.on("Sales Invoice", {
 				const cust = await frappe.db.get_value(
 					"Customer",
 					frm.doc.customer,
-					"default_price_list"
+					"default_price_list",
 				);
 				if (cust && cust.message && cust.message.default_price_list) {
 					picked = cust.message.default_price_list;
@@ -439,7 +434,7 @@ frappe.ui.form.on("Sales Invoice", {
 				const ccpl = await frappe.db.get_value(
 					"Cost Center",
 					cc,
-					"fm_default_selling_price_list"
+					"fm_default_selling_price_list",
 				);
 				if (ccpl && ccpl.message && ccpl.message.fm_default_selling_price_list) {
 					picked = ccpl.message.fm_default_selling_price_list;
@@ -451,7 +446,7 @@ frappe.ui.form.on("Sales Invoice", {
 			if (!picked) {
 				const ss = await frappe.db.get_single_value(
 					"Selling Settings",
-					"selling_price_list"
+					"selling_price_list",
 				);
 				if (ss) {
 					picked = ss;
@@ -467,7 +462,7 @@ frappe.ui.form.on("Sales Invoice", {
 						message: __("Lista de precios asignada automáticamente."),
 						indicator: "green",
 					},
-					6
+					6,
 				);
 			}
 		} catch (e) {
@@ -509,7 +504,7 @@ frappe.ui.form.on("Sales Invoice", {
 			const cc_company = await frappe.db.get_value(
 				"Cost Center",
 				frm.doc.cost_center,
-				"company"
+				"company",
 			);
 			if (
 				cc_company &&
@@ -521,11 +516,11 @@ frappe.ui.form.on("Sales Invoice", {
 				frappe.show_alert(
 					{
 						message: __(
-							"Centro de Costos limpiado: no pertenece a la nueva Company seleccionada."
+							"Centro de Costos limpiado: no pertenece a la nueva Company seleccionada.",
 						),
 						indicator: "orange",
 					},
-					6
+					6,
 				);
 			}
 		} catch (e) {
@@ -560,7 +555,7 @@ frappe.ui.form.on("Sales Invoice", {
 				await frm.set_value("cost_center", cc);
 				frappe.show_alert(
 					{ message: "Centro de Costos asignado automáticamente.", indicator: "green" },
-					6
+					6,
 				);
 			} else {
 				frappe.show_alert(
@@ -568,7 +563,7 @@ frappe.ui.form.on("Sales Invoice", {
 						message: "El cliente no tiene Centro de Costos por defecto.",
 						indicator: "orange",
 					},
-					6
+					6,
 				);
 			}
 
@@ -600,14 +595,14 @@ frappe.ui.form.on("Sales Invoice", {
 				const { message: ccRow } = await frappe.db.get_value(
 					"Cost Center",
 					frm.doc.cost_center,
-					["fm_default_selling_price_list"]
+					["fm_default_selling_price_list"],
 				);
 				if (ccRow && ccRow.fm_default_selling_price_list) {
 					await frm.set_value("selling_price_list", ccRow.fm_default_selling_price_list);
 				} else {
 					const companyPL = await frappe.db.get_single_value(
 						"Selling Settings",
-						"selling_price_list"
+						"selling_price_list",
 					);
 					if (companyPL) await frm.set_value("selling_price_list", companyPL);
 				}

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,7 +5,7 @@ mkdocs-git-revision-date-localized-plugin==1.2.2
 mkdocs-awesome-pages-plugin==2.9.2
 mike==2.0.0
 mkdocs-macros-plugin==1.0.5
-mkdocs-mermaid2-plugin==1.1.1
+mkdocs-mermaid2-plugin==1.2.3
 mkdocs-section-index==0.3.8
 pymdown-extensions==10.7
 mkdocs-linkcheck==1.0.5

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -7,7 +7,7 @@ mike==2.0.0
 mkdocs-macros-plugin==1.0.5
 mkdocs-mermaid2-plugin==1.2.3
 mkdocs-section-index==0.3.8
-pymdown-extensions==10.7
+pymdown-extensions==10.21.2
 mkdocs-linkcheck==1.0.5
 interrogate==1.5.0
 pydocstyle==6.3.0


### PR DESCRIPTION
## Qué hace este PR

Corrige 3 checks de calidad que fallaban en CI.

## Cambios

- **ruff**: reemplaza símbolo `×` (U+00D7 MULTIPLICATION SIGN) por `x` latino en comentario `timbrado_api.py:1679`
- **prettier**: reformatea `sales_invoice.js` y `factura_fiscal_mexico.js`
- **mkdocs**: actualiza `mkdocs-mermaid2-plugin 1.1.1 → 1.2.3` — bug conocido donde pasaba `filename=None` al formatter de pygments causando `AttributeError` en `api/addendas.md`

## Verificación

- [ ] CI verde (tests + linters + mkdocs)

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>