### PR TITLE
feat(cancelacion): flujo completo cancelaciones CFDI + Revisar Estatus

### DIFF
--- a/docs/adr/0013-arquitectura-sistema-cancelaciones-cfdi.md
+++ b/docs/adr/0013-arquitectura-sistema-cancelaciones-cfdi.md
@@ -1,0 +1,216 @@
+# ADR 0013 — Arquitectura del Sistema de Cancelaciones CFDI
+
+**Fecha:** 2026-05-04
+**Estado:** Implementado
+**Autor:** Luis Montanaro Sánchez
+
+---
+
+## Contexto
+
+El SAT define 4 motivos de cancelación para CFDI 4.0. La migración a v16 requirió
+verificar y corregir el flujo completo de cancelaciones, incluyendo escenarios que
+nunca habían sido probados en producción (motivo 01 con sustitución) y estados
+intermedios que no tenían mecanismo de resolución (PENDIENTE_CANCELACION).
+
+Verificaciones realizadas en `facturacion-v16.dev` contra sandbox de FacturAPI.
+
+---
+
+## Los 4 motivos SAT y su implementación
+
+### Motivo 02 — Comprobantes emitidos con errores sin relación
+
+**Cuándo usar:** Error en el CFDI que no tiene un documento sustituto.
+
+**Flujo:**
+```
+FFM (TIMBRADO) → Cancelar en FacturAPI → botón "Cancelar en FacturAPI" → diálogo motivos
+→ usuario selecciona 02 → cancelar_factura(motivo="02") → PAC → CANCELADO
+```
+
+**Requiere UUID sustituto:** No.
+**Estado final FFM:** CANCELADO. **Estado final SI:** CANCELADO (fm_fiscal_status).
+**Verificado:** sesión 2026-05-01.
+
+---
+
+### Motivo 03 — No se llevó a cabo la operación
+
+**Cuándo usar:** La operación comercial no ocurrió.
+
+**Flujo:** idéntico a motivo 02 salvo el código enviado al PAC.
+
+**Requiere UUID sustituto:** No.
+**Verificado:** FFMX-2026-00010, 2026-05-04.
+
+---
+
+### Motivo 04 — Operación nominativa relacionada en factura global
+
+**Cuándo usar:** La operación fue incluida en una Factura Global.
+
+**Flujo:** idéntico a motivos 02/03.
+
+**Requiere UUID sustituto:** No.
+**Verificado:** FFMX-2026-00011, 2026-05-04.
+
+---
+
+### Motivo 01 — Comprobantes emitidos con errores con relación (sustitución)
+
+**Cuándo usar:** El CFDI tiene errores y será reemplazado por uno nuevo.
+
+**Flujo completo:**
+```
+SI original (TIMBRADO)
+  → botón "🔄 Sustituir CFDI (01)" en "Acciones Fiscales" (si_post_fiscal_actions.js)
+  → create_substitution_si(si_name)  [timbrado_api.py]
+      → frappe.copy_doc(SI original)
+      → limpia campos fiscales (fm_factura_fiscal_mx, fm_fiscal_status)
+      → guarda ffm_substitution_source_uuid = UUID del CFDI original
+      → inserta SI sustituto como borrador
+  → usuario corrige datos en SI borrador
+  → usuario timbra SI sustituto
+      → al timbrar detecta ffm_substitution_source_uuid
+      → inyecta TipoRelación "04" en el CFDI nuevo (relación con UUID original)
+      → _cascade_cancel_previous_after_substitute() en background:
+          1. Cancelar CFDI original en PAC con motivo "01" (referenciando UUID del nuevo)
+          2. Hardening preventivo: limpiar links SI↔FFM antes de cancel()
+          3. Restaurar link sales_invoice en FFM original post-cancel (fix v16)
+          4. Cancelar SI original (docstatus=2)
+          5. Cancelar FFM original (docstatus=2)
+```
+
+**Requiere UUID sustituto:** Sí — el UUID del nuevo CFDI.
+**Guard backend:** `_guard_motive_01_only_from_substitution()` bloquea si no viene `substitution_uuid`.
+**Guard UI:** motivo 01 filtrado del selector de cancelación directa desde FFM.
+**Verificado:** FFMX-2026-00012 y FFMX-2026-00014, 2026-05-04.
+
+**Nota UX:** El diálogo de confirmación menciona "TipoRelación 04" (no motivo 01) porque
+describe lo que sucede en el CFDI **nuevo**, no el motivo de cancelación del original.
+Son conceptos SAT distintos que operan en paralelo en el mismo flujo.
+
+---
+
+## Estado PENDIENTE_CANCELACION y su resolución
+
+### Cuándo ocurre
+
+El SAT requiere que ciertos receptores (grandes empresas) acepten explícitamente
+la cancelación antes de que surta efecto. FacturAPI devuelve `cancellation_status: "pending"`.
+
+También ocurre como fallback conservador si la respuesta del PAC es inesperada.
+
+### Tres rutas hacia PENDIENTE_CANCELACION
+
+| Origen | Llama PAC |
+|---|---|
+| PAC responde `cancellation_status: "pending"` | Sí |
+| PAC responde con status inesperado (fallback) | Sí |
+| Hook SI native cancel (`sales_invoice_cancel.py`) | No — solo setea estado |
+
+### Resolución — botón "Revisar Estatus Cancelación"
+
+Implementado en PR #90 (2026-05-04). Visible solo cuando `fm_fiscal_status = PENDIENTE_CANCELACION`.
+
+**Backend:** `revisar_estatus_cancelacion(ffm_name)` en `timbrado_api.py`:
+- `GET /v2/invoices/{facturapi_id}` a FacturAPI
+- Lee `cancellation_status` de la respuesta
+- Transiciona según respuesta:
+
+| Respuesta PAC | Estado resultante |
+|---|---|
+| `status: "canceled"` o `cancellation_status: "accepted"` | CANCELADO |
+| `cancellation_status: "rejected"` | TIMBRADO (receptor rechazó) |
+| `cancellation_status: "pending"` | PENDIENTE_CANCELACION (sin cambio) |
+
+- Registra en `FacturAPI Response Log` con `operation_type: "Consulta Estado"` para trazabilidad
+
+**Recovery Worker:** `process_timeout_recovery()` en `tasks.py` llama `query_pac_status()`
+(implementada en `api_client.py`) cada 5 minutos via scheduler. Resuelve cancelaciones
+pendientes automáticamente si la función de recuperación lo permite.
+
+---
+
+## Bloqueo de Amend en SI con historial fiscal
+
+**Problema:** Frappe permite "Amend" en cualquier documento cancelado (docstatus=2).
+Una SI cancelada como parte de una sustitución CFDI no debe poder ser enmendada —
+crearía un documento que bypasea el proceso fiscal.
+
+**Implementación** (`si_post_fiscal_actions.js`):
+```javascript
+if (frm.doc.docstatus === 2 && frm.doc.fm_fiscal_status === "CANCELADO") {
+    frm.perm[0].amend = 0;
+    frm.page.clear_primary_action(); // retira botón ya renderizado por Frappe
+}
+```
+
+**Alcance:** solo SIs con `fm_fiscal_status = "CANCELADO"`. SIs canceladas nativamente
+sin CFDI (`fm_fiscal_status` vacío) no se ven afectadas.
+
+La FFM ya tenía doble protección preexistente (Python en `overrides.py` + JS).
+
+---
+
+## Gaps encontrados y resueltos
+
+### Bug: `sales_invoice` vacío en FFM original post-sustitución
+
+**Causa:** El "hardening preventivo" en `_cascade_cancel_previous_after_substitute`
+limpiaba `orig_ffm.sales_invoice = ""` antes de llamar `orig_si.cancel()` para evitar
+`LinkExistsError`. El link nunca se restauraba.
+
+**Fix:** Después de `orig_si.cancel()`, se restaura:
+```python
+orig_ffm.db_set("sales_invoice", orig_si_name)
+```
+
+### Bug: `query_pac_status` devolvía None en todos los campos
+
+**Causa:** `client.get_invoice()` devuelve un wrapper `{success, status_code, raw_response}`.
+`query_pac_status` leía `response.get("status")` del wrapper en lugar de
+`response["raw_response"].get("status")`. Todos los campos de la factura devolvían `None`.
+
+**Fix:** Extraer `invoice = wrapper.get("raw_response") or {}` antes de leer campos.
+
+### Bug: comment stale bloqueaba Recovery Worker
+
+**Causa:** `tasks.py` tenía un `except ImportError` que atrapaba el import de
+`query_pac_status` y retornaba failure con mensaje "no está implementado aún".
+La función SÍ existía en `api_client.py`.
+
+**Fix:** Eliminado el bloque `except ImportError`.
+
+### Bug: Cost Center con `fm_mapped_branch` apuntando a Branch eliminado
+
+**Causa:** El Cost Center `"Main - _TC"` tenía `fm_mapped_branch = "Test Branch Addenda"`.
+El hook `before_validate` del SI re-asignaba este valor inválido en cada SI nuevo,
+incluyendo los SIs creados por `create_substitution_si`. La limpieza masiva de SIs
+no resolvió el problema porque el hook lo re-aplicaba en cada nuevo documento.
+
+**Fix:** `frappe.db.set_value("Cost Center", "Main - _TC", "fm_mapped_branch", None)`
+
+---
+
+## Trazabilidad de operaciones
+
+Todas las operaciones de cancelación y consulta de estado quedan registradas en
+`FacturAPI Response Log`:
+
+| operation_type (label) | Cuándo |
+|---|---|
+| Timbrado | Al crear el CFDI |
+| Solicitud Cancelación | Al cancelar con cualquier motivo |
+| Consulta Estado | Al usar botón "Revisar Estatus Cancelación" |
+
+---
+
+## Referencias
+
+- PR #90 — implementación completa del sistema de cancelaciones v16
+- `facturacion_mexico/facturacion_fiscal/timbrado_api.py` — lógica principal
+- `facturacion_mexico/public/js/si_post_fiscal_actions.js` — UI sustitución y bloqueo Amend
+- `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js` — botón Revisar Estatus
+- `facturacion_mexico/config/sat_cancellation_motives.py` — enum oficial motivos SAT

--- a/facturacion_mexico/facturacion_fiscal/api_client.py
+++ b/facturacion_mexico/facturacion_fiscal/api_client.py
@@ -429,31 +429,32 @@ def query_pac_status(factura_fiscal_name: str) -> dict[str, Any]:
 			}
 
 		# Consultar factura en FacturAPI
-		response = client.get_invoice(facturapi_id)
+		# _make_request devuelve {"success": True, "status_code": 200, "raw_response": {...}}
+		wrapper = client.get_invoice(facturapi_id)
 
-		# Procesar respuesta
-		if response:
-			return {
-				"success": True,
-				"data": {
-					"status": response.get("status"),
-					"uuid": response.get("uuid"),
-					"cancellation_status": response.get("cancellation_status"),
-					"cancellation_date": response.get("canceled_at"),
-					"verification_url": response.get("verification_url"),
-					"sat_signature": response.get("sat_signature"),
-					"cfdi_version": response.get("cfdi_version"),
-					"created_at": response.get("created_at"),
-					"certified_at": response.get("certified_at"),
-					"pac_certificate": response.get("pac_certificate_number"),
-					"error_message": response.get("error", {}).get("message")
-					if response.get("error")
-					else None,
-				},
-				"raw_response": response,
-			}
-		else:
-			return {"success": False, "error": "No se recibió respuesta del PAC"}
+		if not wrapper or not wrapper.get("success"):
+			return {"success": False, "error": wrapper.get("error", "No se recibió respuesta del PAC")}
+
+		# Los datos reales de la factura están en raw_response
+		invoice = wrapper.get("raw_response") or {}
+
+		return {
+			"success": True,
+			"data": {
+				"status": invoice.get("status"),
+				"uuid": invoice.get("uuid"),
+				"cancellation_status": invoice.get("cancellation_status"),
+				"cancellation_date": invoice.get("canceled_at"),
+				"verification_url": invoice.get("verification_url"),
+				"sat_signature": invoice.get("sat_signature"),
+				"cfdi_version": invoice.get("cfdi_version"),
+				"created_at": invoice.get("created_at"),
+				"certified_at": invoice.get("certified_at"),
+				"pac_certificate": invoice.get("pac_certificate_number"),
+				"error_message": invoice.get("error", {}).get("message") if invoice.get("error") else None,
+			},
+			"raw_response": invoice,
+		}
 
 	except frappe.DoesNotExistError:
 		return {"success": False, "error": f"Factura Fiscal {factura_fiscal_name} no encontrada"}

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -315,23 +315,27 @@
 
 			// --- BOTÓN REVISAR ESTATUS (solo cuando PENDIENTE_CANCELACION) ---
 			if (frm.doc.docstatus === 1 && status === states.states.PENDIENTE_CANCELACION) {
-				frm.add_custom_button(
-					__("Revisar Estatus Cancelación"),
-					async () => {
-						frappe.show_alert({ message: __("Consultando estado en FacturAPI..."), indicator: "blue" });
-						const r = await frappe.call({
-							method: "facturacion_mexico.facturacion_fiscal.timbrado_api.revisar_estatus_cancelacion",
-							args: { ffm_name: frm.doc.name },
-							freeze: true,
-							freeze_message: __("Consultando PAC..."),
+				frm.add_custom_button(__("Revisar Estatus Cancelación"), async () => {
+					frappe.show_alert({
+						message: __("Consultando estado en FacturAPI..."),
+						indicator: "blue",
+					});
+					const r = await frappe.call({
+						method: "facturacion_mexico.facturacion_fiscal.timbrado_api.revisar_estatus_cancelacion",
+						args: { ffm_name: frm.doc.name },
+						freeze: true,
+						freeze_message: __("Consultando PAC..."),
+					});
+					const res = r && r.message;
+					if (res) {
+						frappe.msgprint({
+							title: __("Resultado"),
+							message: __(res.message),
+							indicator: res.indicator,
 						});
-						const res = r && r.message;
-						if (res) {
-							frappe.msgprint({ title: __("Resultado"), message: __(res.message), indicator: res.indicator });
-							frm.reload_doc();
-						}
+						frm.reload_doc();
 					}
-				).addClass("btn-primary");
+				}).addClass("btn-primary");
 			}
 
 			// Reponer botón de navegación SIEMPRE que exista Sales Invoice

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -313,6 +313,27 @@
 				);
 			}
 
+			// --- BOTÓN REVISAR ESTATUS (solo cuando PENDIENTE_CANCELACION) ---
+			if (frm.doc.docstatus === 1 && status === states.states.PENDIENTE_CANCELACION) {
+				frm.add_custom_button(
+					__("Revisar Estatus Cancelación"),
+					async () => {
+						frappe.show_alert({ message: __("Consultando estado en FacturAPI..."), indicator: "blue" });
+						const r = await frappe.call({
+							method: "facturacion_mexico.facturacion_fiscal.timbrado_api.revisar_estatus_cancelacion",
+							args: { ffm_name: frm.doc.name },
+							freeze: true,
+							freeze_message: __("Consultando PAC..."),
+						});
+						const res = r && r.message;
+						if (res) {
+							frappe.msgprint({ title: __("Resultado"), message: __(res.message), indicator: res.indicator });
+							frm.reload_doc();
+						}
+					}
+				).addClass("btn-primary");
+			}
+
 			// Reponer botón de navegación SIEMPRE que exista Sales Invoice
 			if (frm.doc.sales_invoice) {
 				frm.add_custom_button(__("Ver Sales Invoice"), function () {

--- a/facturacion_mexico/facturacion_fiscal/tasks.py
+++ b/facturacion_mexico/facturacion_fiscal/tasks.py
@@ -336,15 +336,6 @@ def _attempt_timeout_recovery(task: dict[str, Any]) -> dict[str, Any]:
 			from facturacion_mexico.facturacion_fiscal.api_client import query_pac_status
 
 			pac_result = query_pac_status(response_log.factura_fiscal_mexico)
-		except ImportError:
-			# Si la función no existe aún, marcar como pendiente para implementación
-			frappe.logger().warning(
-				f"query_pac_status no implementado aún. Recovery task {task.name} se reprogramará."
-			)
-			return {
-				"success": False,
-				"error": "query_pac_status no está implementado. Pendiente de desarrollo.",
-			}
 		except Exception as e:
 			# Cualquier otro error al consultar PAC
 			frappe.logger().error(f"Error consultando PAC para recovery: {e!s}")

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -3011,6 +3011,62 @@ def get_sat_cancellation_motives():
 
 
 @frappe.whitelist()
+def revisar_estatus_cancelacion(ffm_name: str) -> dict:
+	"""Consulta FacturAPI para resolver estado PENDIENTE_CANCELACION."""
+	ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
+
+	if ffm.fm_fiscal_status != FiscalStates.PENDIENTE_CANCELACION:
+		frappe.throw(_("El documento no está en estado PENDIENTE_CANCELACION"))
+
+	from facturacion_mexico.facturacion_fiscal.api_client import query_pac_status
+
+	result = query_pac_status(ffm_name)
+
+	if not result.get("success"):
+		frappe.throw(_("Error al consultar PAC: {0}").format(result.get("error")))
+
+	data = result.get("data", {})
+	pac_status = data.get("status", "")
+	cancel_status = data.get("cancellation_status", "")
+
+	if pac_status == "canceled" or cancel_status == "accepted":
+		nuevo_estado = FiscalStates.CANCELADO
+		update_data = {"fm_fiscal_status": nuevo_estado, "cancellation_date": now_datetime()}
+		msg = _("Cancelación confirmada por el receptor. CFDI cancelado.")
+		indicator = "green"
+	elif cancel_status == "rejected":
+		nuevo_estado = FiscalStates.TIMBRADO
+		update_data = {"fm_fiscal_status": nuevo_estado, "fm_motivo_cancelacion": None}
+		msg = _("El receptor rechazó la cancelación. CFDI sigue vigente.")
+		indicator = "orange"
+	else:
+		nuevo_estado = FiscalStates.PENDIENTE_CANCELACION
+		update_data = {"fm_fiscal_status": nuevo_estado}
+		msg = _("Cancelación aún pendiente de aceptación por el receptor.")
+		indicator = "blue"
+
+	frappe.db.set_value("Factura Fiscal Mexico", ffm_name, update_data)
+	if ffm.sales_invoice:
+		frappe.db.set_value("Sales Invoice", ffm.sales_invoice, {"fm_fiscal_status": nuevo_estado})
+
+	# Registrar consulta en FacturAPI Response Log para trazabilidad
+	try:
+		write_pac_response(
+			sales_invoice_name=ffm.sales_invoice or "",
+			request_data=json.dumps({"action": "consulta_estatus", "ffm": ffm_name, "facturapi_id": ffm.facturapi_id}),
+			response_data=json.dumps({"success": True, "status_code": 200, "raw_response": data, "resultado_transicion": nuevo_estado}, default=str),
+			operation_type="consulta",
+		)
+	except Exception as log_err:
+		frappe.logger().warning(f"No se pudo registrar log de consulta estatus {ffm_name}: {log_err}")
+
+	frappe.db.commit()
+
+	return {"status": nuevo_estado, "message": msg, "indicator": indicator,
+		"cancellation_status": cancel_status}
+
+
+@frappe.whitelist()
 def test_connection():
 	"""Probar conexión con FacturAPI desde interfaz."""
 	try:

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -3060,8 +3060,18 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 	try:
 		write_pac_response(
 			sales_invoice_name=ffm.sales_invoice or "",
-			request_data=json.dumps({"action": "consulta_estatus", "ffm": ffm_name, "facturapi_id": ffm.facturapi_id}),
-			response_data=json.dumps({"success": True, "status_code": 200, "raw_response": data, "resultado_transicion": nuevo_estado}, default=str),
+			request_data=json.dumps(
+				{"action": "consulta_estatus", "ffm": ffm_name, "facturapi_id": ffm.facturapi_id}
+			),
+			response_data=json.dumps(
+				{
+					"success": True,
+					"status_code": 200,
+					"raw_response": data,
+					"resultado_transicion": nuevo_estado,
+				},
+				default=str,
+			),
 			operation_type="consulta",
 		)
 	except Exception as log_err:
@@ -3069,8 +3079,12 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 
 	frappe.db.commit()
 
-	return {"status": nuevo_estado, "message": msg, "indicator": indicator,
-		"cancellation_status": cancel_status}
+	return {
+		"status": nuevo_estado,
+		"message": msg,
+		"indicator": indicator,
+		"cancellation_status": cancel_status,
+	}
 
 
 @frappe.whitelist()

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -3077,7 +3077,7 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 	except Exception as log_err:
 		frappe.logger().warning(f"No se pudo registrar log de consulta estatus {ffm_name}: {log_err}")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit - Required to persist status transition immediately after PAC response
 
 	return {
 		"status": nuevo_estado,

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -2818,6 +2818,13 @@ def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
 			except Exception as e:
 				frappe.logger().error(f"Error cancelando SI original: {e}")
 
+			# Restaurar link sales_invoice en FFM original (limpiado por hardening preventivo)
+			try:
+				orig_ffm.db_set("sales_invoice", orig_si_name)
+				frappe.logger().info(f"Link sales_invoice restaurado en FFM {orig_ffm_name} → {orig_si_name}")
+			except Exception as e:
+				frappe.logger().warning(f"No se pudo restaurar link sales_invoice en FFM: {e}")
+
 			# 4) REORDER: Cancelar FFM original DESPUÉS (con reload)
 			try:
 				orig_ffm.reload()  # CONCURRENCY FIX: reload antes de cancelar

--- a/facturacion_mexico/public/js/si_post_fiscal_actions.js
+++ b/facturacion_mexico/public/js/si_post_fiscal_actions.js
@@ -183,6 +183,12 @@
 			// PRIMERO: Evaluar visibilidad botón Cancel nativo según estado fiscal
 			hide_native_cancel_conditionally(frm);
 
+			// Bloquear Amend en SI canceladas con historial fiscal (evita manipulación post-CFDI)
+			if (frm.doc.docstatus === 2 && frm.doc.fm_fiscal_status === "CANCELADO") {
+				if (frm.perm[0]) frm.perm[0].amend = 0;
+				frm.page.clear_primary_action();
+			}
+
 			// DESPUÉS: Lógica existente de botones contextuales
 			if (frm.doc.docstatus === 1) {
 				add_post_fiscal_actions(frm);


### PR DESCRIPTION
## Contexto

Post-verificación de los 4 motivos de cancelación SAT en v16. Se detectaron y resolvieron gaps en la arquitectura de cancelaciones. Todos los motivos verificados manualmente en `facturacion-v16.dev`.

---

## Cambio 1 — Botón "Revisar Estatus Cancelación"

**Problema:** `PENDIENTE_CANCELACION` era un estado huérfano. Cuando el receptor de un CFDI debe aceptar la cancelación, el sistema quedaba bloqueado sin ningún mecanismo para resolver el estado.

**Archivos:** `api_client.py`, `timbrado_api.py`, `factura_fiscal_mexico.js`, `tasks.py`

- `api_client.py` — fix en `query_pac_status`: leía campos del wrapper `{success, raw_response}` en lugar de `raw_response` directamente. Todos los campos devolvían `None`
- `timbrado_api.py` — nueva función `@frappe.whitelist() revisar_estatus_cancelacion(ffm_name)`:
  - Consulta `GET /v2/invoices/{facturapi_id}` a FacturAPI
  - Transiciona: `accepted/canceled → CANCELADO`, `rejected → TIMBRADO`, `pending → mantiene PENDIENTE_CANCELACION`
  - Sincroniza FFM y SI
  - Registra en `FacturAPI Response Log` con `operation_type="consulta"` para trazabilidad
- `factura_fiscal_mexico.js` — botón "Revisar Estatus Cancelación" visible solo en `PENDIENTE_CANCELACION`, color azul, congela UI, recarga doc al completar
- `tasks.py` — eliminado bloque `except ImportError` stale que dejaba `query_pac_status` inutilizable en el Recovery Worker

**Verificado:** transición correcta, SI bloqueada en PENDIENTE_CANCELACION, `FAPI-LOG-2026-00014` creado con `success=1` y `operation_type=Consulta Estado`

---

## Cambio 2 — Restaurar link `sales_invoice` en FFM original post-sustitución

**Problema:** El "hardening preventivo" en `_cascade_cancel_previous_after_substitute` limpiaba el link `sales_invoice` de la FFM original antes de la cancelación (para evitar `LinkExistsError`), pero nunca lo restauraba. La FFM cancelada quedaba sin link navegable hacia su SI, campo obligatorio vacío y sin botones de navegación.

**Archivo:** `timbrado_api.py`

- Después de `orig_si.cancel()`, se restaura con `orig_ffm.db_set("sales_invoice", orig_si_name)`

**Verificado:** `FFMX-2026-00014` post-sustitución tiene `sales_invoice = ACC-SINV-2026-00016` ✅

---

## Cambio 3 — Bloquear Amend en SI canceladas con historial fiscal

**Problema:** Una SI cancelada como parte del flujo de sustitución CFDI mostraba el botón "Amend" de Frappe, permitiendo crear un documento derivado que bypassea el proceso fiscal. La FFM tenía doble protección (Python + JS), el SI no tenía ninguna.

**Archivo:** `si_post_fiscal_actions.js`

- Cuando `docstatus === 2` y `fm_fiscal_status === "CANCELADO"`: setea `frm.perm[0].amend = 0` y llama `frm.page.clear_primary_action()` para retirar el botón ya renderizado por Frappe
- Solo afecta SIs con historial fiscal confirmado. SIs canceladas nativamente sin CFDI no se ven afectadas

**Verificado:** botón Amend desaparece en ACC-SINV-2026-00007 y ACC-SINV-2026-00001

---

## Verificación motivos de cancelación SAT

| Motivo | FFM | Resultado |
|---|---|---|
| 02 — Errores sin relación | Sesión anterior | ✅ |
| 03 — No se llevó a cabo | FFMX-2026-00010 | ✅ |
| 04 — Operación nominativa | FFMX-2026-00011 | ✅ |
| 01 — Sustitución con UUID | FFMX-2026-00012, FFMX-2026-00014 | ✅ |

## Trazabilidad Response Log (última sustitución)

| Log | FFM | Operación | Éxito |
|---|---|---|---|
| FAPI-LOG-2026-00018 | FFMX-2026-00014 | Timbrado | ✅ |
| FAPI-LOG-2026-00019 | FFMX-2026-00015 | Timbrado | ✅ |
| FAPI-LOG-2026-00020 | FFMX-2026-00014 | Solicitud Cancelación | ✅ |

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>