### PR TITLE
feat(pe): reclasificación fiscal nativa en Payment Entry

### DIFF
--- a/docs/adr/0016-reclasificacion-fiscal-payment-entry.md
+++ b/docs/adr/0016-reclasificacion-fiscal-payment-entry.md
@@ -1,0 +1,169 @@
+# ADR 0016 — Reclasificación Fiscal de Impuestos en Payment Entry
+
+**Fecha:** 2026-05-05
+**Estado:** APROBADO — implementado y probado en GUI
+**Autor:** Luis Montanaro Sánchez
+
+---
+
+## Contexto
+
+En México, el IVA se registra en dos momentos:
+
+1. **Al timbrar la factura** — el impuesto queda en una cuenta de "IVA pendiente por cobrar". Contablemente es devengado.
+2. **Al cobrar/pagar** — el impuesto se vuelve efectivo. Contablemente debe moverse a "IVA cobrado/pagado".
+
+ERPNext no genera este movimiento automáticamente al registrar un Payment Entry. Sin esta reclasificación, el IVA permanece en la cuenta "pendiente" aunque la factura esté completamente cobrada.
+
+El patrón fue identificado en `facturacion_mx` (bench v15, llantascs.dev), donde se usaba manualmente el template **"002 IVA Cobranza - LLCS"**. Este PR automatiza ese flujo existente.
+
+---
+
+## Decisión
+
+**Usar el mecanismo nativo de `Payment Entry.taxes` (AdvanceTaxesandCharges) de ERPNext.**
+
+Se cargan dos filas en `PE.taxes` en el evento `validate`, visibles desde Save. Al submit, ERPNext genera el GL nativo. Al cancel, ERPNext revierte todo automáticamente.
+
+---
+
+## Patrón implementado (comprobado en producción llantascs.dev)
+
+```
+charge_type          = On Paid Amount
+included_in_paid_amount = 1
+add_deduct_tax       = Add   (para ambas filas)
+
+Fila destino (IVA cobrado):
+  account_head = cuenta_destino
+  rate         = +rate_efectiva   → GL: Cr cuenta_destino
+
+Fila origen (IVA pendiente):
+  account_head = cuenta_origen
+  rate         = -rate_efectiva   → GL: Dr cuenta_origen (negativo = reverso)
+```
+
+**Por qué `included_in_paid_amount = 1`:**
+Con `included_in_paid_amount = 0`, ERPNext genera una contraparte contra `paid_to` (banco/caja). Con `included_in_paid_amount = 1`, solo genera la entrada del tax account — sin tocar banco. La combinación `Actual + included=1` está bloqueada por `validate_inclusive_tax`, pero `On Paid Amount + included=1` es válida.
+
+---
+
+## Fórmula de cálculo
+
+```
+monto_reclasificar = tax_amount_factura * (allocated_amount / grand_total)
+rate_efectiva      = monto_reclasificar / pe.paid_amount * 100
+```
+
+**Ejemplos:**
+
+| Caso | IVA factura | paid_amount | rate |
+|---|---|---|---|
+| IVA 16% puro ($1,740 total) | $240 | $1,740 | 13.793% |
+| IVA 16% parcial (54% pagado) | $384 × 0.538 = $207 | $1,500 | 13.793% |
+| Mezcla 16%+0% | calculado de tax_amount real | variable | variable |
+
+La rate se calcula siempre de los datos reales de la factura. No hay tasas hardcodeadas. Funciona con cualquier combinación de IVA, incluyendo facturas con ítems al 0%.
+
+---
+
+## GL resultante
+
+```
+Dr  Banco/Caja         paid_amount   ← pago normal (siempre presente)
+Cr  Clientes           paid_amount   ← pago normal
+
+Dr  IVA pendiente      monto_reclasificar   ← reclasificación
+Cr  IVA cobrado        monto_reclasificar   ← reclasificación
+```
+
+El Cash/Banco aparece UNA vez (el pago normal). Las filas de taxes no generan entradas adicionales de banco porque `included_in_paid_amount = 1`.
+
+---
+
+## Componentes implementados
+
+### DocType: Mapeo Reclasificacion Fiscal Payment Entry
+
+Configura la relación `cuenta_origen → cuenta_destino` por empresa y tipo de operación.
+
+| Campo | Descripción |
+|---|---|
+| `company` | Empresa |
+| `tipo_operacion` | Cobro (ventas) / Pago (compras) |
+| `cuenta_origen` | Cuenta de impuesto al timbrar (IVA pendiente) |
+| `cuenta_destino` | Cuenta de impuesto al cobrar/pagar (IVA efectivo) |
+| `activo` | Activar/desactivar sin eliminar |
+
+Validaciones: `account_type = Tax`, misma empresa, no grupo, no deshabilitada,
+sin duplicado activo por `company + tipo_operacion + cuenta_origen`.
+
+### Archivo: `payment_entry_reclasificacion.py`
+
+- `cargar_impuestos_en_payment_entry(doc)` — hook `validate`. Lee referencias, calcula montos proporcionales, carga filas en `PE.taxes`. Llama `doc.apply_taxes()` al final para forzar recálculo (el hook corre después del PE.validate de ERPNext).
+- `generar_reclasificacion_payment_entry` / `cancelar_reclasificacion_payment_entry` — no-ops. ERPNext maneja GL y reversión nativamente.
+
+### Archivo: `payment_entry_cancel.py`
+
+Stub creado — el módulo existía referenciado en hooks.py pero faltaba el archivo. Cancela el Complemento Pago MX vinculado si existe.
+
+---
+
+## Pruebas GUI aprobadas (2026-05-05)
+
+| SI | PE | Tipo | Pago | IVA reclasificado | GL |
+|---|---|---|---|---|---|
+| ACC-SINV-2026-00024 | ACC-PAY-2026-00017 | Total | $1,740 | **$240** | ✅ limpio |
+| ACC-SINV-2026-00025 | ACC-PAY-2026-00018 | Parcial (54%) | $1,500 de $2,784 | **$206.90** | ✅ limpio |
+| ACC-PAY-2026-00017 (cancel) | — | Cancel | — | **revertido** | ✅ |
+
+Taxes visibles desde Save (antes de Submit). GL generado por ERPNext al Submit.
+
+---
+
+## Alternativas descartadas
+
+| Opción | Razón de descarte |
+|---|---|
+| GL Entry directo (`make_gl_entries` en on_submit) | No visible en taxes del PE; usuario no puede verificar antes del submit |
+| `Actual + included=1` | Bloqueado por `validate_inclusive_tax` en ERPNext |
+| `Actual + included=0` | Genera entradas extras de banco/caja que se cancelan entre sí — "Cash extra" visible en GL |
+| Journal Entry | Pierde trazabilidad directa contra el PE |
+| Payment Entry Deduction | Diseñado para diferencias de tipo de cambio/descuentos, no reclasificación de IVA |
+
+---
+
+## Fuera de alcance (para implementación futura)
+
+| Item | Estado |
+|---|---|
+| IVA frontera 8% | No probado — no hay SIs de frontera en site dev |
+| Múltiples referencias con tasas distintas | No probado — requiere datos de prueba |
+| Purchase Invoice (Pago) | Implementado en código, no probado end-to-end |
+| Backfill de PEs históricos | No incluido — one-off bajo demanda |
+| Complemento Pago MX | Siguiente bloque |
+
+---
+
+## Hooks registrados
+
+```python
+"Payment Entry": {
+    "validate": [
+        "...payment_entry_validate.check_ppd_requirement",
+        "...payment_entry_reclasificacion.cargar_impuestos_en_payment_entry",
+    ],
+    "on_submit": "...payment_entry_submit.create_complement_if_required",
+    "on_cancel": "...payment_entry_cancel.cancel_related_complement",
+}
+```
+
+---
+
+## Referencias
+
+- `facturacion_fiscal/services/payment_entry_reclasificacion.py`
+- `facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/`
+- `complementos_pago/hooks_handlers/payment_entry_cancel.py`
+- Template "002 IVA Cobranza - LLCS" en llantascs.dev (patrón de referencia)
+- ERPNext `payment_entry.py:add_tax_gl_entries` — mecanismo nativo

--- a/facturacion_mexico/complementos_pago/hooks_handlers/payment_entry_cancel.py
+++ b/facturacion_mexico/complementos_pago/hooks_handlers/payment_entry_cancel.py
@@ -1,0 +1,21 @@
+"""
+Payment Entry cancel handler — Complemento Pago MX.
+Cancela el complemento vinculado si existe.
+"""
+
+import frappe
+
+
+def cancel_related_complement(doc, method=None):
+	"""Cancelar Complemento Pago MX vinculado al Payment Entry."""
+	complement_name = doc.get("fm_complemento_pago")
+	if not complement_name:
+		return
+
+	if not frappe.db.exists("Complemento Pago MX", complement_name):
+		return
+
+	complement = frappe.get_doc("Complemento Pago MX", complement_name)
+	if complement.docstatus == 1:
+		complement.cancel()
+		frappe.logger().info(f"Complemento {complement_name} cancelado por PE {doc.name}")

--- a/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.js
@@ -1,0 +1,17 @@
+frappe.ui.form.on("Mapeo Reclasificacion Fiscal Payment Entry", {
+	refresh(frm) {
+		_set_account_filters(frm);
+	},
+	company(frm) {
+		frm.set_value("cuenta_origen", null);
+		frm.set_value("cuenta_destino", null);
+		_set_account_filters(frm);
+	},
+});
+
+function _set_account_filters(frm) {
+	const base = { account_type: "Tax", is_group: 0, disabled: 0 };
+	const filters = frm.doc.company ? { ...base, company: frm.doc.company } : base;
+	frm.set_query("cuenta_origen", () => ({ filters }));
+	frm.set_query("cuenta_destino", () => ({ filters }));
+}

--- a/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.json
@@ -1,0 +1,76 @@
+{
+  "doctype": "DocType",
+  "name": "Mapeo Reclasificacion Fiscal Payment Entry",
+  "module": "Facturacion Fiscal",
+  "custom": 0,
+  "is_submittable": 0,
+  "editable_grid": 1,
+  "track_changes": 1,
+  "engine": "InnoDB",
+  "naming_rule": "Autoincrement",
+  "autoname": "MRFPE-.####",
+  "title_field": "cuenta_origen",
+  "permissions": [
+    {"role": "System Manager", "read": 1, "write": 1, "create": 1, "delete": 1},
+    {"role": "Accounts Manager", "read": 1, "write": 1, "create": 1, "delete": 1}
+  ],
+  "fields": [
+    {
+      "fieldname": "company",
+      "fieldtype": "Link",
+      "label": "Empresa",
+      "options": "Company",
+      "reqd": 1,
+      "in_list_view": 1,
+      "in_standard_filter": 1
+    },
+    {
+      "fieldname": "tipo_operacion",
+      "fieldtype": "Select",
+      "label": "Tipo de Operación",
+      "options": "\nCobro\nPago",
+      "reqd": 1,
+      "in_list_view": 1,
+      "in_standard_filter": 1,
+      "description": "Cobro = Sales / Pago = Purchase"
+    },
+    {
+      "fieldname": "col_break_cuentas",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "activo",
+      "fieldtype": "Check",
+      "label": "Activo",
+      "default": "1",
+      "in_list_view": 1
+    },
+    {
+      "fieldname": "section_cuentas",
+      "fieldtype": "Section Break",
+      "label": "Cuentas"
+    },
+    {
+      "fieldname": "cuenta_origen",
+      "fieldtype": "Link",
+      "label": "Cuenta Origen (al timbrar)",
+      "options": "Account",
+      "reqd": 1,
+      "in_list_view": 1,
+      "description": "Cobro: IVA pendiente por cobrar. Pago: IVA pendiente por acreditar."
+    },
+    {
+      "fieldname": "col_break_cuentas2",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "cuenta_destino",
+      "fieldtype": "Link",
+      "label": "Cuenta Destino (al cobrar/pagar)",
+      "options": "Account",
+      "reqd": 1,
+      "in_list_view": 1,
+      "description": "Cobro: IVA cobrado. Pago: IVA acreditable pagado."
+    }
+  ]
+}

--- a/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.py
@@ -88,25 +88,6 @@ class MapeoReclasificacionFiscalPaymentEntry(Document):
 			)
 
 
-@frappe.whitelist()
-def get_tax_accounts_query(doctype, txt, searchfield, start, page_len, filters):
-	"""Filtrar cuentas por empresa del documento padre (llamado desde get_query)."""
-	company = filters.get("company") if filters else None
-	conditions = "AND ac.disabled = 0 AND ac.is_group = 0"
-	if company:
-		conditions += f" AND ac.company = {frappe.db.escape(company)}"
-	return frappe.db.sql(
-		f"""
-		SELECT ac.name, ac.account_type, ac.company
-		FROM `tabAccount` ac
-		WHERE (ac.name LIKE %(txt)s OR ac.account_name LIKE %(txt)s)
-		{conditions}
-		LIMIT %(start)s, %(page_len)s
-		""",
-		{"txt": f"%{txt}%", "start": start, "page_len": page_len},
-	)
-
-
 def get_mapeo_reclasificacion(company: str, tipo_operacion: str, cuenta_origen: str) -> str | None:
 	"""
 	Obtener cuenta destino para reclasificación de impuesto.

--- a/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.py
@@ -79,9 +79,7 @@ class MapeoReclasificacionFiscalPaymentEntry(Document):
 		existente = frappe.db.get_value("Mapeo Reclasificacion Fiscal Payment Entry", filtros, "name")
 		if existente:
 			frappe.throw(
-				_(
-					"Ya existe un mapeo activo para {0} / {1} / {2}: {3}"
-				).format(
+				_("Ya existe un mapeo activo para {0} / {1} / {2}: {3}").format(
 					self.company,
 					self.tipo_operacion,
 					self.cuenta_origen,

--- a/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/mapeo_reclasificacion_fiscal_payment_entry.py
@@ -1,0 +1,133 @@
+"""
+Mapeo Reclasificacion Fiscal Payment Entry
+
+Define relaciones cuenta_origen → cuenta_destino para reclasificar
+impuestos cuando se registra un cobro o pago via Payment Entry.
+
+Cobro: IVA pendiente por cobrar → IVA efectivamente cobrado
+Pago:  IVA pendiente por acreditar → IVA efectivamente pagado
+"""
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class MapeoReclasificacionFiscalPaymentEntry(Document):
+	def validate(self):
+		self._validar_cuentas_distintas()
+		self._validar_cuenta("cuenta_origen")
+		self._validar_cuenta("cuenta_destino")
+		self._validar_sin_duplicado_activo()
+
+	def _validar_cuentas_distintas(self):
+		if self.cuenta_origen and self.cuenta_destino and self.cuenta_origen == self.cuenta_destino:
+			frappe.throw(_("Cuenta Origen y Cuenta Destino no pueden ser la misma cuenta."))
+
+	def _validar_cuenta(self, fieldname: str):
+		cuenta = self.get(fieldname)
+		if not cuenta:
+			return
+
+		label = self.meta.get_field(fieldname).label
+
+		data = frappe.db.get_value(
+			"Account",
+			cuenta,
+			["account_type", "company", "is_group", "disabled"],
+			as_dict=True,
+		)
+
+		if not data:
+			frappe.throw(_("{0}: la cuenta {1} no existe.").format(label, cuenta))
+
+		if data.account_type != "Tax":
+			frappe.throw(
+				_("{0}: la cuenta {1} debe ser tipo Tax. Tipo actual: {2}.").format(
+					label, cuenta, data.account_type or "Sin tipo"
+				)
+			)
+
+		if data.company != self.company:
+			frappe.throw(
+				_("{0}: la cuenta {1} pertenece a {2}, no a {3}.").format(
+					label, cuenta, data.company, self.company
+				)
+			)
+
+		if data.is_group:
+			frappe.throw(
+				_("{0}: {1} es una cuenta grupo. Seleccione una cuenta específica.").format(label, cuenta)
+			)
+
+		if data.disabled:
+			frappe.throw(_("{0}: la cuenta {1} está deshabilitada.").format(label, cuenta))
+
+	def _validar_sin_duplicado_activo(self):
+		if not self.activo:
+			return
+
+		filtros = {
+			"company": self.company,
+			"tipo_operacion": self.tipo_operacion,
+			"cuenta_origen": self.cuenta_origen,
+			"activo": 1,
+		}
+		if self.name:
+			filtros["name"] = ["!=", self.name]
+
+		existente = frappe.db.get_value("Mapeo Reclasificacion Fiscal Payment Entry", filtros, "name")
+		if existente:
+			frappe.throw(
+				_(
+					"Ya existe un mapeo activo para {0} / {1} / {2}: {3}"
+				).format(
+					self.company,
+					self.tipo_operacion,
+					self.cuenta_origen,
+					existente,
+				)
+			)
+
+
+@frappe.whitelist()
+def get_tax_accounts_query(doctype, txt, searchfield, start, page_len, filters):
+	"""Filtrar cuentas por empresa del documento padre (llamado desde get_query)."""
+	company = filters.get("company") if filters else None
+	conditions = "AND ac.disabled = 0 AND ac.is_group = 0"
+	if company:
+		conditions += f" AND ac.company = {frappe.db.escape(company)}"
+	return frappe.db.sql(
+		f"""
+		SELECT ac.name, ac.account_type, ac.company
+		FROM `tabAccount` ac
+		WHERE (ac.name LIKE %(txt)s OR ac.account_name LIKE %(txt)s)
+		{conditions}
+		LIMIT %(start)s, %(page_len)s
+		""",
+		{"txt": f"%{txt}%", "start": start, "page_len": page_len},
+	)
+
+
+def get_mapeo_reclasificacion(company: str, tipo_operacion: str, cuenta_origen: str) -> str | None:
+	"""
+	Obtener cuenta destino para reclasificación de impuesto.
+
+	Args:
+		company: Empresa
+		tipo_operacion: "Cobro" o "Pago"
+		cuenta_origen: Cuenta de impuesto al timbrar
+
+	Returns:
+		Nombre de la cuenta destino, o None si no hay mapeo activo
+	"""
+	return frappe.db.get_value(
+		"Mapeo Reclasificacion Fiscal Payment Entry",
+		{
+			"company": company,
+			"tipo_operacion": tipo_operacion,
+			"cuenta_origen": cuenta_origen,
+			"activo": 1,
+		},
+		"cuenta_destino",
+	)

--- a/facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py
+++ b/facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py
@@ -1,0 +1,202 @@
+"""
+Reclasificación fiscal de impuestos en Payment Entry.
+
+Patrón comprobado en producción (llantascs.dev — template "002 IVA Cobranza"):
+
+  charge_type          = On Paid Amount
+  included_in_paid_amount = 1          → sin Cash/Bank counterpart
+  add_deduct_tax       = Add           → para ambas filas
+  rate destino         = +rate_neta    → Cr cuenta_destino
+  rate origen          = -rate_neta    → Dr cuenta_origen (negativo = reverso)
+
+Fórmula de rate:
+  monto_reclasificar = tax_amount * (allocated / grand_total)
+  rate = monto_reclasificar / pe.paid_amount * 100
+
+  Esto maneja automáticamente:
+  - IVA puro 16%:         rate ≈ 13.793%
+  - IVA frontera 8%:      rate ≈ 7.407%
+  - Mezcla 16%+0%:        rate = lo que resulte de los montos reales
+  - Múltiples facturas:   rate ponderada sobre paid_amount total
+
+GL resultante (sin Cash extra):
+  Dr  cuenta_origen   monto_reclasificar
+  Cr  cuenta_destino  monto_reclasificar
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import frappe
+from frappe.utils import flt
+
+_RECLAS_MARKER = "[RECLAS-MX]"
+
+_DOCTYPES_SOPORTADOS = {
+	"Sales Invoice": "Cobro",
+	"Purchase Invoice": "Pago",
+}
+
+
+# ---------------------------------------------------------------------------
+# Hook principal
+# ---------------------------------------------------------------------------
+
+
+def cargar_impuestos_en_payment_entry(doc, method=None):
+	"""Hook validate — carga filas de reclasificación en PE.taxes."""
+	_limpiar_filas_reclas(doc)
+
+	paid_amount = flt(doc.paid_amount)
+	if paid_amount <= 0:
+		return
+
+	grupos = _calcular_grupos_desde_doc(doc)
+	if not grupos:
+		return
+
+	for (cuenta_origen, cuenta_destino, tipo_op), monto in grupos.items():
+		monto = round(flt(monto), 6)
+		if monto <= 0:
+			continue
+
+		# Rate efectiva: monto a reclasificar como % del paid_amount total
+		rate = round(monto / paid_amount * 100, 6)
+		calc_amount = round(rate / 100 * paid_amount, 2)
+		desc = f"{_RECLAS_MARKER} {tipo_op} | {cuenta_origen} → {cuenta_destino}"
+
+		# Fila destino: rate positivo → Cr cuenta_destino en GL
+		doc.append(
+			"taxes",
+			{
+				"charge_type": "On Paid Amount",
+				"account_head": cuenta_destino,
+				"description": desc,
+				"add_deduct_tax": "Add",
+				"included_in_paid_amount": 1,
+				"rate": rate,
+				"tax_amount": calc_amount,
+				"base_tax_amount": calc_amount,
+			},
+		)
+
+		# Fila origen: rate negativo → Dr cuenta_origen en GL
+		doc.append(
+			"taxes",
+			{
+				"charge_type": "On Paid Amount",
+				"account_head": cuenta_origen,
+				"description": desc,
+				"add_deduct_tax": "Add",
+				"included_in_paid_amount": 1,
+				"rate": -rate,
+				"tax_amount": -calc_amount,
+				"base_tax_amount": -calc_amount,
+			},
+		)
+
+	# Recalcular para que totals/base_tax_amount queden correctos antes del GL
+	doc.apply_taxes()
+
+
+def generar_reclasificacion_payment_entry(doc, method=None):
+	"""Hook on_submit — no-op. ERPNext genera GL desde PE.taxes nativo."""
+	pass
+
+
+def cancelar_reclasificacion_payment_entry(doc, method=None):
+	"""Hook on_cancel — no-op. ERPNext reversa GL nativo al cancelar."""
+	pass
+
+
+# ---------------------------------------------------------------------------
+# Cálculo de grupos
+# ---------------------------------------------------------------------------
+
+
+def _limpiar_filas_reclas(doc):
+	"""Elimina filas de reclasificación previas para recalcular."""
+	doc.taxes = [t for t in doc.get("taxes", []) if _RECLAS_MARKER not in (t.description or "")]
+
+
+def _calcular_grupos_desde_doc(doc) -> dict:
+	"""
+	Devuelve {(cuenta_origen, cuenta_destino, tipo_op): monto_total}
+	con los montos proporcionales reales a reclasificar.
+	"""
+	grupos: dict = {}
+	company = doc.company
+
+	for ref in doc.get("references", []):
+		if flt(ref.allocated_amount) <= 0:
+			continue
+
+		tipo_operacion = _DOCTYPES_SOPORTADOS.get(ref.reference_doctype)
+		if not tipo_operacion:
+			continue
+
+		try:
+			invoice = frappe.get_doc(ref.reference_doctype, ref.reference_name)
+		except Exception:
+			continue
+
+		grand_total = flt(invoice.grand_total)
+		if not grand_total:
+			continue
+
+		proporcion = flt(ref.allocated_amount) / grand_total
+
+		for tax in invoice.get("taxes", []):
+			tax_amount = flt(tax.tax_amount)
+			if tax_amount == 0:
+				continue
+
+			cuenta_destino = frappe.db.get_value(
+				"Mapeo Reclasificacion Fiscal Payment Entry",
+				{
+					"company": company,
+					"tipo_operacion": tipo_operacion,
+					"cuenta_origen": tax.account_head,
+					"activo": 1,
+				},
+				"cuenta_destino",
+			)
+			if not cuenta_destino:
+				continue
+
+			key = (tax.account_head, cuenta_destino, tipo_operacion)
+			monto = round(tax_amount * proporcion, 6)
+			grupos[key] = grupos.get(key, 0.0) + monto
+
+	return grupos
+
+
+# ---------------------------------------------------------------------------
+# Diagnóstico (solo lectura)
+# ---------------------------------------------------------------------------
+
+
+@frappe.whitelist()
+def analizar_payment_entry_whitelisted(payment_entry_name: str) -> dict:
+	"""Diagnóstico desde bench console — no modifica nada."""
+	pe = frappe.get_doc("Payment Entry", payment_entry_name)
+	paid_amount = flt(pe.paid_amount)
+	grupos = _calcular_grupos_desde_doc(pe)
+
+	resultado = {
+		"payment_entry": pe.name,
+		"paid_amount": paid_amount,
+		"grupos": [],
+	}
+	for (origen, destino, tipo), monto in grupos.items():
+		rate = round(monto / paid_amount * 100, 6) if paid_amount else 0
+		resultado["grupos"].append(
+			{
+				"cuenta_origen": origen,
+				"cuenta_destino": destino,
+				"tipo_operacion": tipo,
+				"monto_reclasificar": round(monto, 2),
+				"rate_efectiva": rate,
+			}
+		)
+	return resultado

--- a/facturacion_mexico/hooks.py
+++ b/facturacion_mexico/hooks.py
@@ -363,9 +363,12 @@ doc_events = {
 	# =============================================================================
 	# COMPLEMENTOS DE PAGO - AUTOMATIZACIÓN SAT
 	# =============================================================================
-	# Payment Entry PPD - Complementos automáticos
+	# Payment Entry PPD - Complementos automáticos + Reclasificación fiscal
 	"Payment Entry": {
-		"validate": "facturacion_mexico.complementos_pago.hooks_handlers.payment_entry_validate.check_ppd_requirement",
+		"validate": [
+			"facturacion_mexico.complementos_pago.hooks_handlers.payment_entry_validate.check_ppd_requirement",
+			"facturacion_mexico.facturacion_fiscal.services.payment_entry_reclasificacion.cargar_impuestos_en_payment_entry",
+		],
 		"on_submit": "facturacion_mexico.complementos_pago.hooks_handlers.payment_entry_submit.create_complement_if_required",
 		"on_cancel": "facturacion_mexico.complementos_pago.hooks_handlers.payment_entry_cancel.cancel_related_complement",
 	},


### PR DESCRIPTION
## Resumen

Implementa la reclasificación automática IVA pendiente → IVA cobrado/pagado al registrar un Payment Entry, usando el mecanismo nativo de Taxes and Charges de ERPNext.

Patrón comprobado en producción desde llantascs.dev (template "002 IVA Cobranza - LLCS"). Este PR automatiza ese flujo manual.

**Mecanismo:**
- Hook `validate` carga dos filas en `PE.taxes` con `charge_type=On Paid Amount` + `included_in_paid_amount=1`
- Rate positivo para cuenta destino → `Cr IVA cobrado`
- Rate negativo para cuenta origen → `Dr IVA pendiente`
- Sin Cash extra, sin GL directo, sin Journal Entry
- Taxes visibles desde Save, GL generado por ERPNext al Submit, reversión nativa al Cancel

**Fórmula:**
```
monto_reclasificar = tax_amount_factura × (allocated / grand_total)
rate = monto_reclasificar / paid_amount × 100
```

Maneja IVA puro, mezcla 16%+0%, y pagos parciales sin configuración adicional.

## Cambios

- **DocType nuevo:** `Mapeo Reclasificacion Fiscal Payment Entry` — mapea `cuenta_origen → cuenta_destino` por company y tipo de operación
- **Servicio:** `payment_entry_reclasificacion.py` — lógica de cálculo y carga de taxes
- **Fix:** `payment_entry_cancel.py` — módulo referenciado en hooks pero faltaba el archivo
- **ADR 0016** — documenta decisión, patrón, fórmula y pruebas

## Test plan

- [ ] `bench --site facturacion-v16.dev migrate` sin errores
- [ ] Crear Payment Entry contra SI timbrada → taxes aparecen en Save
- [ ] Submit → GL limpio: Dr IVA pendiente / Cr IVA cobrado (sin Cash extra)
- [ ] Cancel → GL revertido completamente
- [ ] SI sin mapeo activo → PE funciona sin taxes, sin error
- [ ] Pago parcial → IVA proporcional correcto

## Probado en GUI

| SI | PE | Tipo | Pago | IVA reclasificado |
|---|---|---|---|---|
| ACC-SINV-2026-00024 | ACC-PAY-2026-00017 | Total | $1,740 | $240 ✅ |
| ACC-SINV-2026-00025 | ACC-PAY-2026-00018 | Parcial 54% | $1,500 | $206.90 ✅ |
| Cancel ACC-PAY-2026-00017 | — | Cancel | — | revertido ✅ |

## Fuera de alcance

- IVA frontera 8% (no probado — sin SIs de frontera en site dev)
- Purchase Invoice (implementado, no probado end-to-end)
- Múltiples referencias con tasas distintas
- Backfill de PEs históricos
- Complemento Pago MX (siguiente bloque)

🤖 Generated with [Claude Code](https://claude.com/claude-code)