### PR TITLE
feat(ppd): attach PDF and XML for payment complements

### DIFF
--- a/facturacion_mexico/complementos_pago/api.py
+++ b/facturacion_mexico/complementos_pago/api.py
@@ -290,7 +290,10 @@ def timbrar_complemento_pago(complemento_name: str) -> dict:
 		},
 	)
 
-	frappe.get_doc("Complemento Pago MX", complemento_name).submit()
+	comp_submitted = frappe.get_doc("Complemento Pago MX", complemento_name)
+	comp_submitted.submit()
+
+	_attach_files_complemento(comp_submitted, facturapi_id, uuid)
 
 	frappe.logger().info(f"Complemento {complemento_name} timbrado. UUID: {uuid}")
 	return {"uuid": uuid, "folio_fiscal": uuid, "serie_folio": f"{serie}-{folio}"}
@@ -436,6 +439,58 @@ def revisar_estatus_cancelacion_complemento(complemento_name: str) -> dict:
 
 	frappe.logger().info(f"Estatus {complemento_name} revisado. Status: {nuevo_status}")
 	return {"status": nuevo_status}
+
+
+@frappe.whitelist()
+def descargar_archivos_complemento(complemento_name: str) -> dict:
+	"""Descarga manual de PDF/XML — equivalente al botón en FFM."""
+	comp = frappe.get_doc("Complemento Pago MX", complemento_name)
+	if not comp.facturapi_id:
+		frappe.throw(_("El complemento no tiene ID de FacturAPI."))
+	_attach_files_complemento(comp, comp.facturapi_id, comp.uuid_sat or comp.name)
+	return {"success": True}
+
+
+def _attach_files_complemento(comp_doc, facturapi_id: str, uuid_sat: str):
+	"""Descarga y adjunta PDF y XML del Complemento desde FacturAPI. Igual que FFM.
+	Si falla la descarga no interrumpe el timbrado — solo registra el error."""
+	from frappe.utils.file_manager import save_file
+
+	from facturacion_mexico.facturacion_fiscal.api_client import get_facturapi_client
+
+	try:
+		client = get_facturapi_client()
+		update = {}
+
+		try:
+			pdf_content = client.download_pdf(facturapi_id)
+			filename_pdf = f"{comp_doc.name}_{uuid_sat}.pdf"
+			file_doc = save_file(filename_pdf, pdf_content, comp_doc.doctype, comp_doc.name, is_private=1)
+			update["pdf_file"] = file_doc.file_url
+		except Exception as e:
+			frappe.log_error(
+				f"Error descargando PDF complemento {comp_doc.name}: {e}", "File Attachment Error"
+			)
+
+		try:
+			xml_content = client.download_xml(facturapi_id)
+			filename_xml = f"{comp_doc.name}_{uuid_sat}.xml"
+			file_doc = save_file(
+				filename_xml, xml_content.encode("utf-8"), comp_doc.doctype, comp_doc.name, is_private=1
+			)
+			update["xml_file"] = file_doc.file_url
+		except Exception as e:
+			frappe.log_error(
+				f"Error descargando XML complemento {comp_doc.name}: {e}", "File Attachment Error"
+			)
+
+		if update:
+			frappe.db.set_value("Complemento Pago MX", comp_doc.name, update)
+
+	except Exception as e:
+		frappe.log_error(
+			f"Error adjuntando archivos complemento {comp_doc.name}: {e}", "File Attachment Error"
+		)
 
 
 def _interpretar_respuesta_cancelacion(response_data: dict) -> tuple:

--- a/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
+++ b/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
@@ -10,6 +10,7 @@ frappe.ui.form.on("Complemento Pago MX", {
 		_setup_timbrar_btn(frm);
 		_setup_cancelar_btn(frm);
 		_setup_revisar_estatus_btn(frm);
+		_setup_descargar_btn(frm);
 		_setup_pe_link(frm);
 	},
 });
@@ -45,6 +46,36 @@ function _setup_status_indicators(frm) {
 				`<strong>${frappe.utils.escape_html(status)}</strong>`
 		);
 	}
+}
+
+function _setup_descargar_btn(frm) {
+	if (frm.doc.docstatus !== 1) return;
+	if (!["Timbrado", "Cancelado"].includes(frm.doc.status)) return;
+	if (!frm.doc.facturapi_id) return;
+
+	frm.add_custom_button(__("Descargar PDF+XML"), function () {
+		frappe.call({
+			method: "facturacion_mexico.complementos_pago.api.descargar_archivos_complemento",
+			args: { complemento_name: frm.doc.name },
+			callback: function (r) {
+				if (r.message && r.message.success) {
+					frappe.show_alert(
+						{ message: __("PDF y XML adjuntados correctamente."), indicator: "green" },
+						5
+					);
+					frm.reload_doc();
+				} else {
+					frappe.show_alert(
+						{
+							message: __("Error al descargar archivos. Revisar Error Log."),
+							indicator: "red",
+						},
+						6
+					);
+				}
+			},
+		});
+	});
 }
 
 function _setup_pe_link(frm) {

--- a/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.json
+++ b/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.json
@@ -34,6 +34,8 @@
   "version_cfdi",
   "facturapi_id",
   "fm_ultimo_response_log",
+  "pdf_file",
+  "xml_file",
   "section_bancario",
   "num_operacion",
   "rfc_emisor_cta_ord",
@@ -226,6 +228,24 @@
    "label": "FacturAPI ID",
    "read_only": 1,
    "description": "ID interno de FacturAPI para cancelación"
+  },
+  {
+   "fieldname": "pdf_file",
+   "fieldtype": "Attach",
+   "label": "PDF",
+   "read_only": 1,
+   "allow_on_submit": 1,
+   "print_hide": 1,
+   "no_copy": 1
+  },
+  {
+   "fieldname": "xml_file",
+   "fieldtype": "Attach",
+   "label": "XML",
+   "read_only": 1,
+   "allow_on_submit": 1,
+   "print_hide": 1,
+   "no_copy": 1
   },
   {
    "fieldname": "fm_ultimo_response_log",


### PR DESCRIPTION
## Objetivo
Guardar PDF y XML del Complemento Pago MX al timbrar, usando el mismo patrón que Factura Fiscal Mexico.

## Cambios principales
- `_attach_files_complemento()`: descarga PDF/XML tras timbrado exitoso usando `client.download_pdf()`/`download_xml()` — mismo patrón que FFM
- Campos `pdf_file`/`xml_file` (Attach, privado) en DocType Complemento Pago MX
- `descargar_archivos_complemento()`: API whitelisted para retry manual
- Botón "Descargar PDF+XML" en JS — visible en status Timbrado/Cancelado
- Errores de descarga no interrumpen el timbrado (`frappe.log_error`)

## Validaciones realizadas
- Timbrado automático: PDF y XML se adjuntan al Complemento ✅
- Botón manual "Descargar PDF+XML" funciona ✅
- Timbrado no se interrumpe si falla descarga ✅

## Fuera de alcance
- FFM→status migration
- Motivo 01/sustitución
- Patches

## Riesgos / pendientes
- Requiere `bench --site <site> migrate` (campos nuevos pdf_file/xml_file)
- Requiere `bench build --app facturacion_mexico`

🤖 Generated with [Claude Code](https://claude.com/claude-code)