### PR TITLE
refactor(ffm): remove legacy fiscal status field

### DIFF
--- a/docs/adr/0018-ffm-status-fiscal-state-migration.md
+++ b/docs/adr/0018-ffm-status-fiscal-state-migration.md
@@ -1,6 +1,6 @@
 # ADR 0018 — Migración de estado fiscal FFM a status
 
-**Fecha:** 2026-05-07 | **Estado:** APROBADO — Etapa 1 implementada
+**Fecha:** 2026-05-07 | **Última revisión:** 2026-05-07 | **Estado:** APROBADO — Etapas 1 y 2 completadas
 
 ---
 
@@ -60,15 +60,16 @@ No se toca `status`/`docstatus` nativo de Sales Invoice.
 
 ---
 
-## Etapa 2 — PR siguiente
+## Etapa 2 — COMPLETADA
 
-Eliminar modo dual:
-
-- FFM usa solo `status` como fuente interna de estado fiscal
-- Eliminar `FFM.fm_fiscal_status` del DocType y del código
-- Mantener `SI.fm_fiscal_status` si sigue siendo necesario como snapshot operativo
-- Cambiar lecturas/escrituras internas de FFM a `status`
-- Validar timbrado, cancelación, widget SI, bloqueo SI y PPD
+- `FFM.fm_fiscal_status` eliminado del DocType JSON
+- Todas las lecturas/escrituras internas de FFM migradas a `status`
+- `SI.fm_fiscal_status` conservado como snapshot operativo — sin cambios
+- `sales_invoice_cancel_guard.py` actualizado: lee `status` en lugar de `fm_fiscal_status`
+- Columna física `fm_fiscal_status` sigue en BD — limpieza futura pendiente
+- Código muerto (`diagnose_migration.py`, `migrate_single_record.py`) — limpieza futura pendiente
+- Tests y GUI validados: BORRADOR → TIMBRADO → CANCELADO correcto
+- 0 divergencias `FFM.status != SI.fm_fiscal_status`
 
 ---
 

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -398,7 +398,6 @@ class PACResponseWriter:
 			# Solo actualizar estado fiscal si la operación lo requiere (new_status no es None)
 			if new_status is not None:
 				normalized_status = _norm_status(new_status)
-				update_fields["fm_fiscal_status"] = normalized_status
 				update_fields["status"] = normalized_status
 
 			# Actualizar UUID solo si es exitoso

--- a/facturacion_mexico/facturacion_fiscal/api_backup.py
+++ b/facturacion_mexico/facturacion_fiscal/api_backup.py
@@ -243,7 +243,7 @@ class PACResponseWriter:
 
 			# Solo actualizar estado si hay cambio
 			if new_status:
-				update_fields["fm_fiscal_status"] = new_status
+				update_fields["status"] = new_status
 
 			# Actualizar URLs si están en respuesta
 			if "download" in response_data:

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -60,7 +60,7 @@
 	function getCancellationMotivesForFFM(frm) {
 		const motives = getCancellationMotivesFromEnums();
 		const SUB_01 = getSubstitutionCodeFromEnums();
-		const status = String(frm.doc.fm_fiscal_status || "").toUpperCase();
+		const status = String(frm.doc.status || "").toUpperCase();
 		const hasLinkedSI = !!frm.doc.sales_invoice;
 
 		if (hasLinkedSI && status === "TIMBRADO") {
@@ -72,7 +72,7 @@
 	// [M3-FFM] Interceptar elección 01 en FFM y redirigir a SI
 	function interceptMotive01InFFM(frm, selectedCode) {
 		const SUB_01 = getSubstitutionCodeFromEnums();
-		const status = String(frm.doc.fm_fiscal_status || "").toUpperCase();
+		const status = String(frm.doc.status || "").toUpperCase();
 		if (String(selectedCode) === SUB_01 && frm.doc.sales_invoice && status === "TIMBRADO") {
 			frappe.msgprint({
 				title: __("Sustitución CFDI (01)"),
@@ -177,7 +177,7 @@
 	}
 
 	function applyFFMUi(frm) {
-		const status = norm(frm.doc.fm_fiscal_status);
+		const status = norm(frm.doc.status);
 
 		load_fiscal_states(function (states) {
 			if (!states) {
@@ -488,7 +488,7 @@
 			// === 2) Mostrar ayuda SOLO si la FFM está TIMBRADA (opcional, deja tu handler actual) ===
 			(function toggleHelpOnlyWhenTimbrada() {
 				const HELP_LABEL = __("¿Cómo sustituir?"); // ajustado al texto real
-				const fiscal = String(frm.doc.fm_fiscal_status || "").toUpperCase();
+				const fiscal = String(frm.doc.status || "").toUpperCase();
 				const isTimbrada = !!frm.doc.fm_uuid && fiscal === "TIMBRADO";
 
 				try {
@@ -596,7 +596,7 @@
 			validate_fiscal_data(frm);
 		},
 
-		fm_fiscal_status: function (frm) {
+		status: function (frm) {
 			// PUNTOS 8-9: Actualizar visibilidad cuando cambia el estado fiscal
 			control_field_visibility_by_status(frm);
 		},
@@ -611,7 +611,7 @@
 
 	function setup_fiscal_interface(frm) {
 		// Configurar interfaz específica para datos fiscales
-		if (frm.doc.fm_fiscal_status === "Timbrado") {
+		if (frm.doc.status === "Timbrado") {
 			frm.set_df_property("uuid", "read_only", 1);
 			frm.set_df_property("fm_serie_folio", "read_only", 1);
 		}
@@ -620,7 +620,7 @@
 	function setup_default_values(frm) {
 		// Establecer valores por defecto para nuevos documentos
 		if (frm.is_new()) {
-			frm.set_value("fm_fiscal_status", "BORRADOR"); // Migrado arquitectura resiliente
+			frm.set_value("status", "BORRADOR"); // Migrado arquitectura resiliente
 
 			// REMOVIDO: Auto-asignación PUE centralizada en validate_payment_method() Python
 			// El método de pago se asigna automáticamente desde settings en server-side
@@ -948,7 +948,7 @@
 
 				// [M3-FFM] Filtrar opciones (quitar 01 si aplica) del formato original que ya funciona
 				const SUB_01 = getSubstitutionCodeFromEnums();
-				const status = String(frm.doc.fm_fiscal_status || "").toUpperCase();
+				const status = String(frm.doc.status || "").toUpperCase();
 				const hasLinkedSI = !!frm.doc.sales_invoice;
 
 				let filtered_options = motives_config.select_options;
@@ -1180,7 +1180,7 @@
 							args: {
 								doctype: "Factura Fiscal Mexico",
 								filters: { name: sales_invoice_data.fm_factura_fiscal_mx },
-								fieldname: "fm_fiscal_status",
+								fieldname: "status",
 							},
 							callback: function (fiscal_r) {
 								// Usar estados centralizados para verificar si está timbrada
@@ -1188,9 +1188,7 @@
 									if (
 										fiscal_r.message &&
 										states &&
-										states.cancelable_states.includes(
-											fiscal_r.message.fm_fiscal_status
-										)
+										states.cancelable_states.includes(fiscal_r.message.status)
 									) {
 										frappe.msgprint({
 											title: __("Sales Invoice No Disponible"),
@@ -1555,8 +1553,8 @@
 	// ========================================
 
 	function control_field_visibility_by_status(frm) {
-		// Control dinámico de visibilidad según fm_fiscal_status
-		const fiscal_status = frm.doc.fm_fiscal_status || "BORRADOR"; // Migrado arquitectura resiliente
+		// Control dinámico de visibilidad según status
+		const fiscal_status = frm.doc.status || "BORRADOR"; // Migrado arquitectura resiliente
 
 		// Campos que vienen de FacturAPI response (Punto 8)
 		const facturapi_response_fields = [

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -34,7 +34,6 @@
   "facturapi_id",
   "uuid",
   "fm_cfdi_use",
-  "fm_fiscal_status",
   "fm_motivo_cancelacion",
   "fm_serie_folio",
   "fm_lugar_expedicion",
@@ -208,25 +207,13 @@
    "options": "Uso CFDI SAT"
   },
   {
-   "default": "BORRADOR",
-   "description": "FUENTE DE VERDAD: facturacion_mexico/config/fiscal_states_config.py - NO modificar aquí sin actualizar archivo fuente",
-   "fieldname": "fm_fiscal_status",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Estado Fiscal (legacy)",
-   "options": "BORRADOR\nPROCESANDO\nTIMBRADO\nERROR\nCANCELADO\nPENDIENTE_CANCELACION\nARCHIVADO",
-   "read_only": 1,
-   "allow_on_submit": 1,
-   "search_index": 1
-  },
-  {
    "fieldname": "fm_motivo_cancelacion",
    "fieldtype": "Select",
    "label": "Motivo Cancelación SAT",
    "options": "01\n02\n03\n04",
    "read_only": 1,
    "in_list_view": 0,
-   "depends_on": "eval:doc.fm_fiscal_status === 'CANCELADO'"
+   "depends_on": "eval:doc.status === 'CANCELADO'"
   },
   {
    "fieldname": "fm_serie_folio",

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -51,7 +51,7 @@ _SAT_UPDATABLE_FIELDS = [
 	"fm_pdf_url",  # URL PDF si PAC lo provee
 	"fm_xml_url",  # URL XML si PAC lo provee
 	# Estado y sincronización que el backend controla
-	"fm_fiscal_status",  # Estado fiscal (BORRADOR, ERROR, TIMBRADO, CANCELADO, …)
+	"status",  # Estado fiscal SAT (BORRADOR, ERROR, TIMBRADO, CANCELADO, …)
 	"fm_sync_status",  # synced/pending/error (normalizado a minúsculas en before_validate)
 	"fm_sync_error",  # último error textual de sincronización
 ]
@@ -321,7 +321,7 @@ class FacturaFiscalMexico(Document):
 				"sales_invoice": self.sales_invoice,
 				"name": ("!=", self.name),
 				"docstatus": 1,  # Solo enviadas
-				"fm_fiscal_status": ("in", ["TIMBRADO", "PENDIENTE_CANCELACION", "PROCESANDO"]),
+				"status": ("in", ["TIMBRADO", "PENDIENTE_CANCELACION", "PROCESANDO"]),
 			},
 		)
 
@@ -378,8 +378,8 @@ class FacturaFiscalMexico(Document):
 		if not old_doc:
 			return
 
-		old_status = old_doc.fm_fiscal_status if hasattr(old_doc, "fm_fiscal_status") else None
-		new_status = self.fm_fiscal_status
+		old_status = old_doc.status if hasattr(old_doc, "status") else None
+		new_status = self.status
 
 		# Si no hay cambio de estado, no validar
 		if old_status == new_status:
@@ -413,9 +413,7 @@ class FacturaFiscalMexico(Document):
 
 		if existing_fiscal_doc and existing_fiscal_doc != self.name:
 			# Verificar si el documento existente está timbrado
-			existing_status = frappe.db.get_value(
-				"Factura Fiscal Mexico", existing_fiscal_doc, "fm_fiscal_status"
-			)
+			existing_status = frappe.db.get_value("Factura Fiscal Mexico", existing_fiscal_doc, "status")
 
 			if existing_status == "TIMBRADO":
 				frappe.throw(
@@ -429,7 +427,7 @@ class FacturaFiscalMexico(Document):
 			"Factura Fiscal Mexico",
 			filters={
 				"sales_invoice": self.sales_invoice,
-				"fm_fiscal_status": "TIMBRADO",
+				"status": "TIMBRADO",
 				"name": ["!=", self.name or "new-doc"],
 			},
 		)
@@ -470,20 +468,20 @@ class FacturaFiscalMexico(Document):
 		# Crear evento fiscal
 		self.create_fiscal_event(
 			"create",
-			{"sales_invoice": self.sales_invoice, "company": self.company, "status": self.fm_fiscal_status},
+			{"sales_invoice": self.sales_invoice, "company": self.company, "status": self.status},
 		)
 
 	def on_update(self):
 		"""Ejecutar después de actualizar."""
 		# Si el estado cambió, crear evento fiscal
-		if self.has_value_changed("fm_fiscal_status"):
+		if self.has_value_changed("status"):
 			self.create_fiscal_event(
 				"status_change",
 				{
-					"old_status": self.get_doc_before_save().fm_fiscal_status
+					"old_status": self.get_doc_before_save().status
 					if self.get_doc_before_save()
 					else "BORRADOR",
-					"new_status": self.fm_fiscal_status,
+					"new_status": self.status,
 					"uuid": self.fm_uuid,
 					"facturapi_id": getattr(self, "facturapi_id", None),
 				},
@@ -572,7 +570,7 @@ class FacturaFiscalMexico(Document):
 				"Sales Invoice",
 				self.sales_invoice,
 				{
-					"fm_fiscal_status": status_map.get(self.fm_fiscal_status, "BORRADOR"),
+					"fm_fiscal_status": status_map.get(self.status, "BORRADOR"),  # SI snapshot
 					"fm_factura_fiscal_mx": self.name,
 				},
 			)
@@ -582,7 +580,6 @@ class FacturaFiscalMexico(Document):
 
 	def mark_as_stamped(self, facturapi_data):
 		"""Marcar como timbrada con datos de FacturAPI."""
-		self.fm_fiscal_status = "TIMBRADO"
 		self.status = "TIMBRADO"
 		self.facturapi_id = facturapi_data.get("id")
 		self.fm_uuid = facturapi_data.get("uuid")
@@ -602,7 +599,6 @@ class FacturaFiscalMexico(Document):
 
 	def mark_as_cancelled(self, cancellation_reason=None):
 		"""Marcar como cancelada."""
-		self.fm_fiscal_status = "CANCELADO"
 		self.status = "CANCELADO"
 		if cancellation_reason:
 			self.cancellation_reason = cancellation_reason
@@ -633,7 +629,7 @@ class FacturaFiscalMexico(Document):
 	@frappe.whitelist()
 	def request_stamping(self):
 		"""Solicitar timbrado fiscal."""
-		if self.fm_fiscal_status != "BORRADOR":
+		if self.status != "BORRADOR":
 			frappe.throw(_("Solo se pueden timbrar facturas en estado BORRADOR"))
 
 		# Aquí se integraría con FacturAPI.io
@@ -644,10 +640,9 @@ class FacturaFiscalMexico(Document):
 	@frappe.whitelist()
 	def request_cancellation(self):
 		"""Solicitar cancelación fiscal."""
-		if self.fm_fiscal_status != "TIMBRADO":
+		if self.status != "TIMBRADO":
 			frappe.throw(_("Solo se pueden cancelar facturas timbradas"))
 
-		self.fm_fiscal_status = "CANCELADO"
 		self.status = "CANCELADO"
 		self.save()
 		frappe.msgprint(_("Solicitud de cancelación enviada"))
@@ -704,7 +699,7 @@ class FacturaFiscalMexico(Document):
 	def validate_cfdi_use(self):
 		"""Validar uso de CFDI - MIGRADO desde Sales Invoice."""
 		# Solo validar si no es un documento nuevo en estado pendiente
-		if self.fm_fiscal_status == "BORRADOR" and self.is_new():
+		if self.status == "BORRADOR" and self.is_new():
 			# Permitir guardar documentos nuevos sin CFDI para configuración posterior
 			return
 
@@ -951,9 +946,9 @@ class FacturaFiscalMexico(Document):
 				new_status = "ERROR"
 
 			# Actualizar estado solo si cambió usando db_set (reconocido por semgrep)
-			if self.fm_fiscal_status != new_status:
-				old_status = self.fm_fiscal_status
-				self.db_set("fm_fiscal_status", new_status)
+			if self.status != new_status:
+				old_status = self.status
+				self.db_set("status", new_status)
 
 				frappe.logger().info(
 					f"Estado fiscal auto-calculado: {self.name} {old_status} → {new_status} "
@@ -1170,7 +1165,7 @@ class FacturaFiscalMexico(Document):
 			# No aplicar validaciones PAC; cancelación local permitida
 			return
 
-		if self.sales_invoice and self.fm_fiscal_status != "CANCELADO":
+		if self.sales_invoice and self.status != "CANCELADO":
 			frappe.throw(
 				_(
 					"No puede cancelarse la FFM: primero cancela fiscalmente en el PAC.<br><br>"

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico_list.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico_list.js
@@ -3,7 +3,7 @@
 frappe.listview_settings["Factura Fiscal Mexico"] = {
 	get_indicator: function (doc) {
 		return window.FM_ENUMS && FM_ENUMS.indicatorFor
-			? FM_ENUMS.indicatorFor(doc.fm_fiscal_status)
-			: [doc.fm_fiscal_status || __("Sin estado"), "gray", ""];
+			? FM_ENUMS.indicatorFor(doc.status)
+			: [doc.status || __("Sin estado"), "gray", ""];
 	},
 };

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/overrides.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/overrides.py
@@ -18,10 +18,7 @@ class FacturaFiscalMexico(FFMBase):
 		# Bloquear "Amend" - si intentan crear documento con amended_from poblado
 		if self.get("amended_from"):
 			frappe.throw(
-				_(
-					"No se permite 'Corregir' en Factura Fiscal México. "
-					"Cree un nuevo documento en su lugar."
-				)
+				_("No se permite 'Corregir' en Factura Fiscal México. Cree un nuevo documento en su lugar.")
 			)
 
 	def cancel(self):
@@ -31,7 +28,7 @@ class FacturaFiscalMexico(FFMBase):
 			return super().cancel()
 
 		# Guard: Solo permitir cancelar en Frappe si el estado fiscal ya es "cancelado" (PAC)
-		status = (self.get("fm_fiscal_status") or "").strip().upper()
+		status = (self.get("status") or "").strip().upper()
 		if status not in CANCELADO_FISCAL:
 			frappe.throw(
 				_(

--- a/facturacion_mexico/facturacion_fiscal/hooks_handlers/factura_fiscal_update.py
+++ b/facturacion_mexico/facturacion_fiscal/hooks_handlers/factura_fiscal_update.py
@@ -9,10 +9,10 @@ def register_status_changes(doc, method):
 		return
 
 	# Solo registrar si hay cambios en el estado fiscal
-	if doc.has_value_changed("fm_fiscal_status"):
+	if doc.has_value_changed("status"):
 		old_doc = doc.get_doc_before_save()
-		old_status = old_doc.fm_fiscal_status if old_doc else None
-		new_status = doc.fm_fiscal_status
+		old_status = old_doc.status if old_doc else None
+		new_status = doc.status
 
 		# Skip si no hay cambio real
 		if old_status == new_status:

--- a/facturacion_mexico/facturacion_fiscal/hooks_handlers/sales_invoice_cancel.py
+++ b/facturacion_mexico/facturacion_fiscal/hooks_handlers/sales_invoice_cancel.py
@@ -58,7 +58,7 @@ def _request_fiscal_cancellation(doc):
 
 		# LEGACY: FiscalEventMX eliminado - solo actualizar estados
 		# Actualizar estado a PENDIENTE_CANCELACION
-		factura_fiscal.fm_fiscal_status = "PENDIENTE_CANCELACION"
+		factura_fiscal.status = "PENDIENTE_CANCELACION"
 		factura_fiscal.save()
 
 		# Actualizar Sales Invoice
@@ -83,7 +83,7 @@ def _mark_as_cancelled_without_stamping(doc):
 	# Crear evento de cancelación
 	if doc.fm_factura_fiscal_mx:
 		factura_fiscal = frappe.get_doc("Factura Fiscal Mexico", doc.fm_factura_fiscal_mx)
-		factura_fiscal.fm_fiscal_status = "CANCELADO"
+		factura_fiscal.status = "CANCELADO"
 		factura_fiscal.save()
 
 		# LEGACY: FiscalEventMX eliminado - solo logging

--- a/facturacion_mexico/facturacion_fiscal/hooks_handlers/sales_invoice_submit.py
+++ b/facturacion_mexico/facturacion_fiscal/hooks_handlers/sales_invoice_submit.py
@@ -72,7 +72,6 @@ def _get_or_create_factura_fiscal(doc):
 	factura_fiscal.customer = doc.customer
 	factura_fiscal.total_amount = doc.grand_total
 	factura_fiscal.currency = doc.currency
-	factura_fiscal.fm_fiscal_status = FiscalStates.BORRADOR
 	factura_fiscal.status = FiscalStates.BORRADOR
 
 	# Agregar montos del Sales Invoice para validación posterior

--- a/facturacion_mexico/facturacion_fiscal/tasks.py
+++ b/facturacion_mexico/facturacion_fiscal/tasks.py
@@ -383,9 +383,7 @@ def _attempt_sync_recovery(task: dict[str, Any]) -> dict[str, Any]:
 
 		if calculated.get("status") != "Error":
 			# Estado calculado exitosamente
-			current_status = frappe.db.get_value(
-				"Factura Fiscal Mexico", factura_fiscal_name, "fm_fiscal_status"
-			)
+			current_status = frappe.db.get_value("Factura Fiscal Mexico", factura_fiscal_name, "status")
 
 			if should_override_status(current_status, calculated["status"], factura_fiscal_name):
 				# Actualizar estado
@@ -393,7 +391,7 @@ def _attempt_sync_recovery(task: dict[str, Any]) -> dict[str, Any]:
 					"Factura Fiscal Mexico",
 					factura_fiscal_name,
 					{
-						"fm_fiscal_status": calculated["status"],
+						"status": calculated["status"],
 						"fm_sub_status": calculated.get("sub_status"),
 						"fm_last_pac_sync": now(),
 						"fm_sync_status": "synced",

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -864,7 +864,6 @@ class TimbradoAPI:
 			fields_to_update = {
 				"fm_uuid": response.get("uuid"),
 				"facturapi_id": response.get("id"),
-				"fm_fiscal_status": FiscalStates.TIMBRADO,
 				"status": FiscalStates.TIMBRADO,
 				"fecha_timbrado": response.get("stamp", {}).get("date") or now_datetime(),
 			}
@@ -1225,7 +1224,6 @@ class TimbradoAPI:
 
 				# Actualizar FFM con estado correcto
 				update_data = {
-					"fm_fiscal_status": fiscal_status,
 					"status": fiscal_status,
 					"cancellation_reason": motivo_completo,
 				}
@@ -2490,13 +2488,13 @@ def _get_last_cancelled_ffm_for_si(si_name: str):
 	ffm_list = frappe.get_all(
 		"Factura Fiscal Mexico",
 		filters={"sales_invoice": si_name, "docstatus": ["in", [1, 2]]},
-		fields=["name", "cancellation_date", "fm_fiscal_status", "cancellation_reason"],
+		fields=["name", "cancellation_date", "status", "cancellation_reason"],
 		order_by="COALESCE(cancellation_date, modified) desc",
 		limit_page_length=5,
 	)
 	# Devuelve la primera que realmente esté CANCELADA fiscalmente
 	for r in ffm_list:
-		if (r.fm_fiscal_status or "").upper() == "CANCELADO":
+		if (r.status or "").upper() == "CANCELADO":
 			return frappe.get_doc("Factura Fiscal Mexico", r.name)
 	return None
 
@@ -2683,7 +2681,7 @@ def create_substitution_si(si_name: str):
 	# 1) Verificar que exista FFM vigente ligada (timbrada)
 	ffm = frappe.db.get_value(
 		"Factura Fiscal Mexico",
-		{"sales_invoice": si.name, "fm_fiscal_status": "TIMBRADO"},
+		{"sales_invoice": si.name, "status": "TIMBRADO"},
 		["name", "fm_uuid"],
 		as_dict=True,
 	)
@@ -2761,7 +2759,7 @@ def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
 		if orig_si.docstatus == 2 and orig_ffm.docstatus == 2:
 			return {"skipped": "already_cancelled"}
 
-		orig_status = frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "fm_fiscal_status")
+		orig_status = frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "status")
 		if (orig_status or "").upper() in {"CANCELADO", "CANCELADA"}:
 			return {"skipped": "already_cancelled"}
 
@@ -2788,7 +2786,7 @@ def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
 			# 2) REORDER: Marcar FFM original con estado fiscal CANCELADO (sin cancelar DocType aún)
 			try:
 				orig_ffm.reload()
-				orig_ffm.set("fm_fiscal_status", "CANCELADO")
+				orig_ffm.set("status", "CANCELADO")
 				orig_ffm.save()
 				frappe.logger().info(f"FFM {orig_ffm_name} marcada como CANCELADO fiscalmente")
 			except Exception as e:
@@ -3004,7 +3002,7 @@ def _guard_motive_01_only_from_substitution(ffm_doc, motive: str, substitution_u
 		return
 
 	has_linked_si = bool(getattr(ffm_doc, "sales_invoice", None))
-	status = (getattr(ffm_doc, "fm_fiscal_status", "") or "").upper()
+	status = (getattr(ffm_doc, "status", "") or "").upper()
 
 	# Regla: si FFM pertenece a un SI y está TIMBRADO, 01 solo desde flujo de sustitución (debe traer substitution_uuid)
 	if has_linked_si and status == "TIMBRADO" and not (substitution_uuid or "").strip():
@@ -3031,7 +3029,7 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 	"""Consulta FacturAPI para resolver estado PENDIENTE_CANCELACION."""
 	ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
 
-	if ffm.fm_fiscal_status != FiscalStates.PENDIENTE_CANCELACION:
+	if ffm.status != FiscalStates.PENDIENTE_CANCELACION:
 		frappe.throw(_("El documento no está en estado PENDIENTE_CANCELACION"))
 
 	from facturacion_mexico.facturacion_fiscal.api_client import query_pac_status
@@ -3048,7 +3046,6 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 	if pac_status == "canceled" or cancel_status == "accepted":
 		nuevo_estado = FiscalStates.CANCELADO
 		update_data = {
-			"fm_fiscal_status": nuevo_estado,
 			"status": nuevo_estado,
 			"cancellation_date": now_datetime(),
 		}
@@ -3057,7 +3054,6 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 	elif cancel_status == "rejected":
 		nuevo_estado = FiscalStates.TIMBRADO
 		update_data = {
-			"fm_fiscal_status": nuevo_estado,
 			"status": nuevo_estado,
 			"fm_motivo_cancelacion": None,
 		}
@@ -3065,7 +3061,7 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 		indicator = "orange"
 	else:
 		nuevo_estado = FiscalStates.PENDIENTE_CANCELACION
-		update_data = {"fm_fiscal_status": nuevo_estado, "status": nuevo_estado}
+		update_data = {"status": nuevo_estado}
 		msg = _("Cancelación aún pendiente de aceptación por el receptor.")
 		indicator = "blue"
 

--- a/facturacion_mexico/facturacion_fiscal/utils.py
+++ b/facturacion_mexico/facturacion_fiscal/utils.py
@@ -65,7 +65,7 @@ def get_invoice_fiscal_data(sales_invoice_name):
 		fiscal_data = frappe.db.get_value(
 			"Factura Fiscal Mexico",
 			fiscal_doc_name,
-			["uuid", "serie", "folio", "total_fiscal", "fm_fiscal_status", "facturapi_id", "fecha_timbrado"],
+			["uuid", "serie", "folio", "total_fiscal", "status", "facturapi_id", "fecha_timbrado"],
 			as_dict=True,
 		)
 
@@ -113,7 +113,7 @@ def is_invoice_stamped(sales_invoice_name):
 		fiscal_data = get_invoice_fiscal_data(sales_invoice_name)
 
 		# Verificar que tenga UUID y estado TIMBRADO
-		return fiscal_data.get("uuid") and fiscal_data.get("fm_fiscal_status") == FiscalStates.TIMBRADO
+		return fiscal_data.get("uuid") and fiscal_data.get("status") == FiscalStates.TIMBRADO
 
 	except Exception:
 		return False
@@ -416,7 +416,7 @@ def sync_status_to_sales_invoice(factura_fiscal_name: str) -> dict[str, Any]:
 			factura_fiscal_name,
 			[
 				"sales_invoice",
-				"fm_fiscal_status",
+				"status",
 				"fm_sub_status",
 				"fm_last_pac_sync",
 				"fm_sync_status",
@@ -448,7 +448,7 @@ def sync_status_to_sales_invoice(factura_fiscal_name: str) -> dict[str, Any]:
 
 		# Preparar datos para sincronización
 		sync_data = {
-			"fm_fiscal_status": fiscal_data.get("fm_fiscal_status", "Borrador"),
+			"fm_fiscal_status": fiscal_data.get("status", "Borrador"),  # SI snapshot
 		}
 
 		# Solo actualizar si hay cambio real
@@ -471,7 +471,7 @@ def sync_status_to_sales_invoice(factura_fiscal_name: str) -> dict[str, Any]:
 				"success": True,
 				"synced": True,
 				"previous_status": current_si_status,
-				"new_status": sync_data["fm_fiscal_status"],
+				"new_status": sync_data["fm_fiscal_status"],  # SI snapshot key
 				"sales_invoice": sales_invoice_name,
 				"factura_fiscal": factura_fiscal_name,
 				"timestamp": now(),
@@ -525,7 +525,7 @@ def bulk_sync_invoices(limit: int = 100, filters: dict[str, Any] | None = None) 
 		# Obtener documentos fiscales que necesitan sincronización
 		fiscal_docs = frappe.db.sql(
 			"""
-			SELECT name, sales_invoice, fm_fiscal_status, fm_last_pac_sync
+			SELECT name, sales_invoice, status, fm_last_pac_sync
 			FROM `tabFactura Fiscal Mexico`
 			WHERE fm_sync_status IN ('pending', 'error')
 			AND sales_invoice IS NOT NULL
@@ -673,9 +673,7 @@ def sync_single_invoice_status(sales_invoice_name: str, recalculate: bool = True
 		# Si se solicita recálculo, hacerlo antes de sincronizar
 		if recalculate:
 			calculated_status = calculate_current_status(factura_fiscal_name)
-			current_status = frappe.db.get_value(
-				"Factura Fiscal Mexico", factura_fiscal_name, "fm_fiscal_status"
-			)
+			current_status = frappe.db.get_value("Factura Fiscal Mexico", factura_fiscal_name, "status")
 
 			# Actualizar estado si debe overridearse
 			if should_override_status(current_status, calculated_status.get("status"), factura_fiscal_name):
@@ -683,7 +681,6 @@ def sync_single_invoice_status(sales_invoice_name: str, recalculate: bool = True
 					"Factura Fiscal Mexico",
 					factura_fiscal_name,
 					{
-						"fm_fiscal_status": calculated_status.get("status"),
 						"status": calculated_status.get("status"),
 						"fm_sub_status": calculated_status.get("sub_status"),
 						"fm_sync_status": "pending",  # Marcar para sincronizar

--- a/facturacion_mexico/ffm_cancel_ui_v2.js
+++ b/facturacion_mexico/ffm_cancel_ui_v2.js
@@ -5,7 +5,7 @@
 	const P = window.FiscalPolicy;
 
 	function set_readonly(frm) {
-		const st = P.normStatus(frm.doc.fm_fiscal_status || "");
+		const st = P.normStatus(frm.doc.status || "");
 		const ro = P.states.readonly_cancel.has(st);
 		["cancellation_reason", "cancellation_date"].forEach((f) =>
 			frm.set_df_property(f, "read_only", ro ? 1 : 0)
@@ -28,12 +28,12 @@
 			cleanup_cancel_button(frm); // no crear botón nuevo; solo limpiar residuo propio
 
 			// Indicador en header, reutilizando FM_ENUMS (sin hardcode)
-			const s = FM_ENUMS.norm(frm.doc.fm_fiscal_status || "");
+			const s = FM_ENUMS.norm(frm.doc.status || "");
 			const color = FM_ENUMS.StatusColor[s] || "gray";
 			const label = FM_ENUMS.StatusLabel[s] || s || __("Sin estado");
-			if (frm.doc.fm_fiscal_status) frm.page.set_indicator(label, color);
+			if (frm.doc.status) frm.page.set_indicator(label, color);
 		},
-		fm_fiscal_status(frm) {
+		status(frm) {
 			set_readonly(frm);
 			cleanup_cancel_button(frm);
 		},

--- a/facturacion_mexico/public/js/si_post_fiscal_actions.js
+++ b/facturacion_mexico/public/js/si_post_fiscal_actions.js
@@ -129,15 +129,18 @@
 	function add_fiscal_status_indicator(frm) {
 		const status = norm(frm.doc.fm_fiscal_status || "");
 
-		// Alert específico para estado post-cancelación fiscal
+		// Alert solo si NO hay FFM vinculada — si hay FFM, sales_invoice_block_cancel.js
+		// maneja el headline con mensaje más específico (no duplicar)
 		if (status === S.CANCELADO || status === "CANCELADO") {
-			frm.dashboard &&
-				frm.dashboard.set_headline_alert(
-					__(
-						"Fiscal Cancelado - Acciones Disponibles. La factura fiscal fue cancelada. Puede re-facturar o cancelar el Sales Invoice."
-					),
-					"orange"
-				);
+			if (!frm.doc.fm_factura_fiscal_mx) {
+				frm.dashboard &&
+					frm.dashboard.set_headline_alert(
+						__(
+							"Fiscal Cancelado - Acciones Disponibles. La factura fiscal fue cancelada. Puede re-facturar o cancelar el Sales Invoice."
+						),
+						"orange"
+					);
+			}
 		}
 	}
 

--- a/facturacion_mexico/tests/test_layer1_double_facturation_prevention.py
+++ b/facturacion_mexico/tests/test_layer1_double_facturation_prevention.py
@@ -21,11 +21,7 @@ class TestLayer1DoubleFacturationPrevention(unittest.TestCase):
 		frappe.clear_cache()
 
 		# Verificar que DocTypes críticos existen
-		cls.required_doctypes = [
-			"Sales Invoice",
-			"Factura Fiscal Mexico",
-			"Custom Field"
-		]
+		cls.required_doctypes = ["Sales Invoice", "Factura Fiscal Mexico", "Custom Field"]
 
 		for doctype in cls.required_doctypes:
 			if not frappe.db.exists("DocType", doctype):
@@ -45,24 +41,31 @@ class TestLayer1DoubleFacturationPrevention(unittest.TestCase):
 		meta = frappe.get_meta("Sales Invoice")
 
 		# Verificar que el campo existe (puede ser Custom Field en DB)
-		field_exists = (meta.has_field("fm_factura_fiscal_mx") or
-		               frappe.db.exists("Custom Field", "Sales Invoice-fm_factura_fiscal_mx"))
+		field_exists = meta.has_field("fm_factura_fiscal_mx") or frappe.db.exists(
+			"Custom Field", "Sales Invoice-fm_factura_fiscal_mx"
+		)
 
 		self.assertTrue(
 			field_exists,
-			"Campo fm_factura_fiscal_mx debe existir en Sales Invoice (como field o Custom Field)"
+			"Campo fm_factura_fiscal_mx debe existir en Sales Invoice (como field o Custom Field)",
 		)
 
 		# Obtener y validar configuración del campo (manejo flexible para field/Custom Field)
 		if meta.has_field("fm_factura_fiscal_mx"):
 			field = meta.get_field("fm_factura_fiscal_mx")
 			self.assertEqual(field.fieldtype, "Link", "Campo debe ser tipo Link")
-			self.assertEqual(field.options, "Factura Fiscal Mexico", "Campo debe apuntar a Factura Fiscal Mexico")
+			self.assertEqual(
+				field.options, "Factura Fiscal Mexico", "Campo debe apuntar a Factura Fiscal Mexico"
+			)
 			self.assertEqual(field.read_only, 1, "Campo debe ser read_only para prevenir edición manual")
 		elif frappe.db.exists("Custom Field", "Sales Invoice-fm_factura_fiscal_mx"):
 			custom_field = frappe.get_doc("Custom Field", "Sales Invoice-fm_factura_fiscal_mx")
 			self.assertEqual(custom_field.fieldtype, "Link", "Custom Field debe ser tipo Link")
-			self.assertEqual(custom_field.options, "Factura Fiscal Mexico", "Custom Field debe apuntar a Factura Fiscal Mexico")
+			self.assertEqual(
+				custom_field.options,
+				"Factura Fiscal Mexico",
+				"Custom Field debe apuntar a Factura Fiscal Mexico",
+			)
 			self.assertEqual(custom_field.read_only, 1, "Custom Field debe ser read_only")
 		else:
 			# Campo faltante - skip test pero avisar
@@ -83,26 +86,27 @@ class TestLayer1DoubleFacturationPrevention(unittest.TestCase):
 		- Recibe parámetros correctos
 		"""
 		# Verificar que el DocType tiene el método
-		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import FacturaFiscalMexico
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
 
 		self.assertTrue(
 			hasattr(FacturaFiscalMexico, "validate_no_duplicate_timbrado"),
-			"Método validate_no_duplicate_timbrado debe existir en FacturaFiscalMexico"
+			"Método validate_no_duplicate_timbrado debe existir en FacturaFiscalMexico",
 		)
 
 		# Verificar que el método es callable
 		method = getattr(FacturaFiscalMexico, "validate_no_duplicate_timbrado")
-		self.assertTrue(
-			callable(method),
-			"validate_no_duplicate_timbrado debe ser método ejecutable"
-		)
+		self.assertTrue(callable(method), "validate_no_duplicate_timbrado debe ser método ejecutable")
 
 		# Mock test - Crear documento y verificar que validate invoca el método
-		doc = frappe.get_doc({
-			"doctype": "Factura Fiscal Mexico",
-			"sales_invoice": "TEST-VALIDATION-001",  # Sales Invoice mock
-			"fm_fiscal_status": FiscalStates.BORRADOR
-		})
+		doc = frappe.get_doc(
+			{
+				"doctype": "Factura Fiscal Mexico",
+				"sales_invoice": "TEST-VALIDATION-001",  # Sales Invoice mock
+				"fm_fiscal_status": FiscalStates.BORRADOR,
+			}
+		)
 
 		# Mock del método para verificar invocación (sin ejecutar validación real)
 		original_method = doc.validate_no_duplicate_timbrado
@@ -127,8 +131,9 @@ class TestLayer1DoubleFacturationPrevention(unittest.TestCase):
 		# The important part is that the method exists and is integrated in validate()
 		# For now, verify the method exists and is callable
 		self.assertTrue(
-			hasattr(doc, 'validate_no_duplicate_timbrado') and callable(getattr(doc, 'validate_no_duplicate_timbrado')),
-			"validate_no_duplicate_timbrado debe existir y ser callable"
+			hasattr(doc, "validate_no_duplicate_timbrado")
+			and callable(getattr(doc, "validate_no_duplicate_timbrado")),
+			"validate_no_duplicate_timbrado debe existir y ser callable",
 		)
 
 		print("✅ Método validate_no_duplicate_timbrado correctamente integrado")
@@ -148,7 +153,7 @@ class TestLayer1DoubleFacturationPrevention(unittest.TestCase):
 
 		js_content = ""
 		try:
-			with open(js_file_path, 'r', encoding='utf-8') as f:
+			with open(js_file_path, "r", encoding="utf-8") as f:
 				js_content = f.read()
 		except FileNotFoundError:
 			self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
@@ -157,28 +162,28 @@ class TestLayer1DoubleFacturationPrevention(unittest.TestCase):
 		self.assertIn(
 			"function is_already_timbrada",
 			js_content,
-			"Función is_already_timbrada debe existir en sales_invoice.js"
+			"Función is_already_timbrada debe existir en sales_invoice.js",
 		)
 
 		# Verificar que se usa fm_factura_fiscal_mx para validación
 		self.assertIn(
 			"fm_factura_fiscal_mx",
 			js_content,
-			"JavaScript debe usar campo fm_factura_fiscal_mx para verificar timbrado"
+			"JavaScript debe usar campo fm_factura_fiscal_mx para verificar timbrado",
 		)
 
 		# Verificar que se asocia a evento refresh
 		self.assertIn(
 			"refresh: function (frm)",
 			js_content,
-			"Debe haber función refresh para manejar eventos de formulario"
+			"Debe haber función refresh para manejar eventos de formulario",
 		)
 
 		# Verificar lógica de prevención en refresh
 		self.assertIn(
 			"is_already_timbrada",
 			js_content,
-			"Función refresh debe usar is_already_timbrada para control de botones"
+			"Función refresh debe usar is_already_timbrada para control de botones",
 		)
 
 		print("✅ Funciones JavaScript de prevención correctamente implementadas")
@@ -196,16 +201,13 @@ class TestLayer1DoubleFacturationPrevention(unittest.TestCase):
 		meta = frappe.get_meta("Factura Fiscal Mexico")
 
 		# Verificar que is_submittable está configurado
-		self.assertTrue(
-			meta.is_submittable,
-			"DocType Factura Fiscal Mexico debe tener is_submittable = 1"
-		)
+		self.assertTrue(meta.is_submittable, "DocType Factura Fiscal Mexico debe tener is_submittable = 1")
 
 		# Verificar que el DocType soporta estados estándar de Frappe
 		# NOTA: docstatus se agrega automáticamente por Frappe a nivel DB, no aparece en meta.fields
 		# Verificar que existe método get_doc para confirmar funcionalidad submittable
 		test_doc = frappe.new_doc("Factura Fiscal Mexico")
-		self.assertTrue(hasattr(test_doc, 'docstatus'), "DocType submittable debe tener atributo docstatus")
+		self.assertTrue(hasattr(test_doc, "docstatus"), "DocType submittable debe tener atributo docstatus")
 
 		print("✅ DocType correctamente configurado como submittable")
 
@@ -220,46 +222,45 @@ class TestLayer1DoubleFacturationPrevention(unittest.TestCase):
 		"""
 		# Leer archivo JavaScript de Factura Fiscal Mexico
 		# Usar path relativo desde frappe-bench para compatibilidad CI
-		js_file_path = frappe.get_app_path("facturacion_mexico", "facturacion_fiscal", "doctype", "factura_fiscal_mexico", "factura_fiscal_mexico.js")
+		js_file_path = frappe.get_app_path(
+			"facturacion_mexico",
+			"facturacion_fiscal",
+			"doctype",
+			"factura_fiscal_mexico",
+			"factura_fiscal_mexico.js",
+		)
 
 		js_content = ""
 		try:
-			with open(js_file_path, 'r', encoding='utf-8') as f:
+			with open(js_file_path, "r", encoding="utf-8") as f:
 				js_content = f.read()
 		except FileNotFoundError:
 			self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
 
 		# Verificar que NO interfiere con botones nativos
 		self.assertIn(
-			"Timbrar con FacturAPI",
-			js_content,
-			"Código debe implementar botones específicos de FacturAPI"
+			"Timbrar con FacturAPI", js_content, "Código debe implementar botones específicos de FacturAPI"
 		)
 
 		# Verificar botones FacturAPI específicos
 		self.assertIn(
-			"Timbrar con FacturAPI",
-			js_content,
-			"Debe existir botón específico para timbrado FacturAPI"
+			"Timbrar con FacturAPI", js_content, "Debe existir botón específico para timbrado FacturAPI"
 		)
 
 		self.assertIn(
-			"Cancelar en FacturAPI",
-			js_content,
-			"Debe existir botón específico para cancelación FacturAPI"
+			"Cancelar en FacturAPI", js_content, "Debe existir botón específico para cancelación FacturAPI"
 		)
 
 		# Verificar lógica condicional según estados
 		self.assertIn(
 			"frm.doc.docstatus === 1",
 			js_content,
-			"Botones FacturAPI deben aparecer solo cuando documento está submitted"
+			"Botones FacturAPI deben aparecer solo cuando documento está submitted",
 		)
 
-		self.assertIn(
-			"fm_fiscal_status",
-			js_content,
-			"Lógica de botones debe considerar estado fiscal"
+		self.assertTrue(
+			"fm_fiscal_status" in js_content or "frm.doc.status" in js_content,
+			"Lógica de botones debe considerar estado fiscal (fm_fiscal_status en SI o status en FFM)",
 		)
 
 		print("✅ Arquitectura mixta de botones correctamente implementada")

--- a/facturacion_mexico/validaciones/sales_invoice_cancel_guard.py
+++ b/facturacion_mexico/validaciones/sales_invoice_cancel_guard.py
@@ -6,7 +6,7 @@ FFM_DOCTYPE = "Factura Fiscal Mexico"
 # Campo link en Sales Invoice:
 FFM_LINK_FIELD = "fm_factura_fiscal_mx"
 # Campo de estado fiscal en FFM (ajusta si tu campo se llama distinto)
-FFM_STATUS_FIELD = "fm_fiscal_status"
+FFM_STATUS_FIELD = "status"
 
 # Estados que PERMITEN cancelar la SI (cancela solo si FFM está totalmente cancelada)
 ALLOWED_FFM_CANCELLED_STATES = {"CANCELADO", "CANCELADA", "CANCELLED", "CANCELLED_OK", "CANCELED"}


### PR DESCRIPTION
## Objetivo

Eliminar el modo dual de estado fiscal en Factura Fiscal Mexico.

A partir de este PR, `Factura Fiscal Mexico.status` queda como única fuente interna del estado fiscal SAT.

## Cambios principales

- `fm_fiscal_status` eliminado del DocType `Factura Fiscal Mexico`.
- Código FFM migrado para leer/escribir `status`.
- Timbrado, cancelación, pending cancellation, errores y recálculos usan `status`.
- `Sales Invoice.fm_fiscal_status` se conserva como snapshot fiscal custom.
- Complemento Pago MX / PPD sigue leyendo `SI.fm_fiscal_status`, sin cambio.
- `sales_invoice_cancel_guard.py` ahora valida contra `FFM.status`.
- UI FFM usa `status`.
- List view / encabezado FFM muestran estado fiscal nativo.
- ADR 0018 actualizado con etapa 2 completada.

## Validaciones

- `bench migrate` OK.
- `bench build --app facturacion_mexico` OK.
- Timezone se mantuvo en `America/Mexico_City`.
- BD: 0 valores fuera de options. 0 divergencias `FFM.status` vs `SI.fm_fiscal_status`.
- GUI: BORRADOR → TIMBRADO → CANCELADO validado. Encabezado FFM muestra estado correcto. Sales Invoice cancelada muestra mensaje rojo único.
- Tests: 542 tests ejecutados. Fallo preexistente documentado: `test_custom_fields_naming_consistency`.

## Fuera de alcance

- No se elimina la columna física `fm_fiscal_status` de `tabFactura Fiscal Mexico`.
- No se tocan patches.
- No se toca Settings.
- No se toca Complemento Pago MX.
- No se elimina `SI.fm_fiscal_status`.

## Pendientes

- Limpieza futura de columna física `fm_fiscal_status` en BD.
- Limpieza futura de código muerto: `diagnose_migration.py`, `migrate_single_record.py`.
- Issue #95 timezone usuario / America_New_York sigue abierto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)