### PR TITLE
chore(patches): remove unused root patches file

### DIFF
--- a/patches.txt
+++ b/patches.txt
@@ -1,1 +1,0 @@
-facturacion_mexico.patches.eliminate_duplicate_fiscal_logging


### PR DESCRIPTION
## Objetivo

Eliminar el archivo `./patches.txt` de la raíz del repo porque Frappe no lo lee.

## Cambios principales

- Se elimina únicamente el `patches.txt` fantasma en raíz.
- No se modifica el `facturacion_mexico/patches.txt` canónico.
- No se eliminan patches en RC1.

## Validaciones realizadas

No ejecutado — cambio es solo eliminación de archivo no funcional.

## Fuera de alcance

- Limpieza del patches.txt canónico.
- Eliminación de patches redundantes.
- Validación de instalación limpia RC2.

## Riesgos / pendientes

Sin riesgo. Frappe nunca leyó este archivo (ubicación incorrecta fuera del paquete Python).
Confirmado en auditoría de patches pre-RC1: el archivo contenía únicamente `facturacion_mexico.patches.eliminate_duplicate_fiscal_logging`, patch que nunca corrió en el site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)