### PR TITLE
chore(patches): disable legacy patches for RC2

### DIFF
--- a/facturacion_mexico/patches.txt
+++ b/facturacion_mexico/patches.txt
@@ -5,21 +5,16 @@
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 
-# Custom Fields Migration - Add fm_ prefix to prevent conflicts with other Mexican tax apps
-facturacion_mexico.patches.migrate_custom_field_prefixes
-# Issue #31 Critical Migration - Create missing Item custom fields
-facturacion_mexico.patches.create_missing_item_custom_fields
-# SAT Catalogs Migration - Migrate from install.py to fixtures architecture
-facturacion_mexico.patches.migrate_sat_catalogs_to_fixtures
-# CRITICAL FIX - Register missing Facturacion Fiscal module in BD
-facturacion_mexico.patches.v1.register_facturacion_fiscal_module
-# CRITICAL FIX - Restore corrupted FacturAPI Response Item DocType after module migration
-facturacion_mexico.patches.v1.restore_facturapi_response_item
-# ARQUITECTURA RESILIENTE - Migrar estados fiscales legacy a arquitectura resiliente (TAREA 2.4)
-facturacion_mexico.patches.v2_0.migrate_fiscal_status_to_architecture
-# NAMESPACING - Renombrar campo uuid a fm_uuid siguiendo best practices Frappe
-facturacion_mexico.patches.v2_0.rename_uuid_field_to_fm_uuid
-# TAX CATEGORY MIGRATION - Migrar Customer.tax_category → Customer.fm_tax_regime
-facturacion_mexico.patches.v1_0.migrate_customer_tax_category_to_fm_tax_regime
-# ESTADO FISCAL - Renombrar complement_status → status en Complemento Pago MX
-facturacion_mexico.patches.v2_0.rename_complement_status_to_status
+# RC2: no active patches.
+# New installations must be created from DocType JSON, fixtures and setup only.
+
+# --- Historical patches (v0.1 migration path) — retained for reference, not active ---
+# facturacion_mexico.patches.migrate_custom_field_prefixes
+# facturacion_mexico.patches.create_missing_item_custom_fields
+# facturacion_mexico.patches.migrate_sat_catalogs_to_fixtures
+# facturacion_mexico.patches.v1.register_facturacion_fiscal_module
+# facturacion_mexico.patches.v1.restore_facturapi_response_item
+# facturacion_mexico.patches.v2_0.migrate_fiscal_status_to_architecture
+# facturacion_mexico.patches.v2_0.rename_uuid_field_to_fm_uuid
+# facturacion_mexico.patches.v1_0.migrate_customer_tax_category_to_fm_tax_regime
+# facturacion_mexico.patches.v2_0.rename_complement_status_to_status


### PR DESCRIPTION
## Objetivo

Preparar RC2 sin patches activos. Las instalaciones nuevas deben nacer desde DocType JSON, fixtures y setup, no desde migraciones históricas.

## Cambios principales

- Desactiva los patches canónicos en `facturacion_mexico/patches.txt`.
- Conserva los patches históricos comentados como referencia.
- No elimina archivos `.py` de patches.

## Validaciones realizadas

- `bench --site test-facturacion.localhost migrate` OK.
- `bench build --app facturacion_mexico` OK.
- `ci_pre_tests.run` OK.
- Tests: 541 pasan / 1 fallo preexistente por campos UAE en test site (no relacionado con este cambio).
- Confirmado: no corrieron patches activos durante migrate.

## Fuera de alcance

- No se borran archivos de patches.
- No se limpia el fallo preexistente de UAE fields.
- No se toca schema, fixtures ni código funcional.
- No se limpian columnas físicas legacy.

## Riesgos / pendientes

- Validar instalación limpia final de RC2.
- Resolver/aislar test site contaminado con UAE fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)