### PR TITLE
feat(fiscal-state): capa UI centralizada + migración de 4 doctypes a fiscal_state

### DIFF
--- a/docs/adr/0021-fiscal-state-capa-ui-centralizada.md
+++ b/docs/adr/0021-fiscal-state-capa-ui-centralizada.md
@@ -1,0 +1,139 @@
+# ADR-0021 — Capa fiscal_state: UI centralizada via endpoint Python
+
+**Fecha:** 2026-05-10
+**Estado:** Implementado (PR #122)
+**Branch:** feat/beta-release-fixes
+
+---
+
+## Contexto
+
+Antes de este ADR, la lógica de decisión de UI (qué botones mostrar, qué mensajes emitir, qué acciones habilitar) estaba distribuida en tres capas sin coordinación:
+
+1. **JS directo** — cada archivo `.js` consultaba campos individuales del documento y tomaba decisiones locales
+2. **Múltiples llamadas async** — cada botón disparaba su propio `frappe.call` para verificar prerrequisitos
+3. **`fm_require_complement`** — campo en Payment Entry calculado de forma inconsistente desde tres rutas distintas (PE creation, on_submit, en_validate)
+
+Esto generaba:
+- Inconsistencias entre lo que mostraba la UI y lo que permitía el backend
+- Decisiones de roles hardcodeadas en JS (listas de nombres de roles)
+- Múltiples puntos donde agregar lógica nueva requería tocar N archivos
+- El bug C1: `complemento_state.py` habilitaba el botón de descarga con `has_xml/has_pdf`, pero la API lanzaba error si faltaba `facturapi_id`
+
+---
+
+## Decisión
+
+Crear una capa `fiscal_state/` como **fuente única de verdad** para decisiones de UI fiscal.
+
+### Principios
+
+- **Read-only** — los módulos de estado solo leen, nunca modifican documentos
+- **Tres capas** — `facts` (observaciones), `actions` (acciones posibles), `messages` (mensajes de UI)
+- **Un solo endpoint whitelisted** — `get_fiscal_ui_state(doctype, name)` enruta a los módulos específicos
+- **Sin roles hardcodeados** — permisos delegados a `frappe.model.can_cancel()` (DocPerm configurable por cliente)
+- **Permission check en el gateway** — `frappe.has_permission(doctype, "read", name)` antes de cualquier cómputo
+
+### Estructura implementada
+
+```
+facturacion_mexico/fiscal_state/
+    __init__.py
+    api.py                      # endpoint whitelisted
+    payment_entry_state.py      # facts/actions/messages para Payment Entry
+    sales_invoice_state.py      # facts/actions/messages para Sales Invoice
+    ffm_state.py                # facts/actions/messages para Factura Fiscal Mexico
+    complemento_state.py        # facts/actions/messages para Complemento Pago MX
+```
+
+### DocTypes migrados a fiscal_state
+
+| DocType | Archivo JS | Qué se migró |
+|---|---|---|
+| Complemento Pago MX | `complemento_pago_mx.js` | Todos los botones y mensajes |
+| Payment Entry | `payment_entry.js` | Botones, cancel guard, mensajes |
+| Factura Fiscal Mexico | `factura_fiscal_mexico.js` | `applyFFMUi()` reemplazado por `_apply_ffm_buttons/messages()` |
+| Sales Invoice | `sales_invoice.js` | Botón Timbrar, Ver Factura Fiscal, guards |
+
+### check_ppd_requirement — implementación real
+
+`payment_entry_validate.check_ppd_requirement()` era un no-op. Se implementó para establecer `fm_require_complement` como fuente única de verdad en BD:
+
+- Solo aplica a PE de tipo `Receive`
+- Busca SIs referenciadas con `fm_es_ppd=1` y `fm_fiscal_status=TIMBRADO`
+- Usa `ignore_permissions=True` para evitar falsos negativos por permisos restringidos
+- Usa `flt(allocated_amount)` para robustez ante `None`
+
+### Gap identificado — can_register_payment
+
+Se detectó durante la auditoría que Sales Invoice con FFM cancelada seguía mostrando el botón de registro de pago. Se agregó `can_register_payment` a `sales_invoice_state.py`:
+
+```python
+can_register_payment = is_submitted and not is_cancelled and (not has_ffm or has_active_ffm)
+```
+
+---
+
+## Alternativas descartadas
+
+### A) Mantener lógica en JS con más llamadas async
+Descartada: amplifica el problema de N fuentes de verdad. Cada caso nuevo requiere tocar múltiples archivos.
+
+### B) Calcular todo en `validate` y guardar en campos
+Descartada: genera escrituras innecesarias en BD en cada validación, complica el historial de cambios, y mezcla preocupaciones.
+
+### C) Un endpoint por DocType
+Descartada: el gateway único `get_fiscal_ui_state` con routing interno permite evolucionar la firma sin tocar JS.
+
+---
+
+## Consecuencias
+
+**Positivas:**
+- Lógica fiscal centralizada y auditable en Python
+- JS reducido a aplicar el estado recibido (sin decisiones)
+- Roles de cancelación configurables por cliente sin tocar código
+- Bug C1 corregido (can_download ahora depende de `has_facturapi_id`)
+- Base para futuras features: agregar un hecho o acción nueva no requiere cambios en JS
+
+**Negativas / Trade-offs:**
+- Un `frappe.call` adicional en cada `refresh()` de los 4 doctypes
+- 3 llamadas separadas en Sales Invoice refresh (SI + Opciones Fiscales + Sustituir CFDI) — pendiente consolidar (H1 CodeRabbit)
+- `sales_invoice_block_cancel.js` no migrado (tiene eventos realtime — fuera de alcance)
+
+---
+
+## Hardening post-merge (PR #123)
+
+CodeRabbit identificó 10 issues en PR #122, todos aplicados en `fix/coderabbit-hardening-pr122`:
+
+| Fix | Descripción |
+|---|---|
+| C1 | `complemento_state` — `can_download` usa `has_facturapi_id` |
+| M1 | `payment_entry_validate` — `ignore_permissions=True` |
+| Q1 | `complemento_pago_mx.js` — destructuring defensivo |
+| Q2 | `payment_entry_validate` — `flt(allocated_amount)` |
+| Q3 | `factura_fiscal_mexico.js` — destructuring defensivo |
+| Q4 | `factura_fiscal_mexico.js` — eliminar bloque if vacío |
+| Q5 | `ffm_state` — `startswith` con tuple |
+| Q6 | `payment_entry.js` — destructuring defensivo |
+| Q8 | `si_post_fiscal_actions.js` — optional chaining |
+| O1 | `factura_fiscal_mexico.js` — eliminar dead code (2 funciones sin callers) |
+
+---
+
+## Tests
+
+- `facturacion_mexico.tests.test_check_ppd_requirement` — 5/5 ✅
+- `facturacion_mexico.tests.test_fiscal_state_payment_entry` — suite completa ✅
+- `facturacion_mexico.tests.test_refacturar_workflow` — 8/8 ✅ (regresión)
+- CI primera corrida: ✅ aprobado
+
+---
+
+## Referencias
+
+- PR #122: feat(fiscal-state): capa UI centralizada + migración de 4 doctypes a fiscal_state
+- PR #123: fix(fiscal-state): hardening CodeRabbit PR #122 — 10 fixes
+- `docs/development/fiscal-ui-state-audit.md` — auditoría previa que originó esta decisión
+- `frappe-infrastructure/checkpoints/coderabbit-pr122-review.md` — análisis CodeRabbit

--- a/docs/development/fiscal-ui-state-audit.md
+++ b/docs/development/fiscal-ui-state-audit.md
@@ -1,0 +1,346 @@
+# Audit: Estado Fiscal UI — Inventario de botones, mensajes y banderas
+
+**Fecha:** 2026-05-10  
+**Alcance:** SI, FFM, PE, Complemento Pago MX  
+**Objetivo:** Inventariar toda la lógica de mostrar/ocultar/habilitar para diseñar una fuente única de verdad (`get_fiscal_ui_state`)
+
+---
+
+## SALES INVOICE
+
+### Botones
+
+| Botón | Archivo:línea | Condición de visibilidad | Campos que lee | Acción |
+|---|---|---|---|---|
+| Timbrar Factura | sales_invoice.js:96 | `docstatus===1` AND `fm_fiscal_status` ∈ {BORRADOR,ERROR,""} AND RFC validado | `docstatus`, `fm_fiscal_status`, `fm_factura_fiscal_mx`, `customer` | Crea FFM o redirige si existe |
+| Ver Factura Fiscal | sales_invoice.js:102 | `docstatus===1` AND `fm_factura_fiscal_mx` vinculada | `fm_factura_fiscal_mx` | Navega a FFM |
+| 🔄 Nueva factura fiscal | si_post_fiscal_actions.js:66 | `docstatus===1` AND `fm_fiscal_status==="CANCELADO"` AND NO hay PE activo | `fm_fiscal_status`, `fm_factura_fiscal_mx` | Desvincula SI de FFM cancelada |
+| ❌ Cancelar documento | si_post_fiscal_actions.js:132 | `docstatus===1` AND `fm_fiscal_status==="CANCELADO"` AND `can_cancel()` | `fm_fiscal_status` | Cancela SI y limpia vínculos |
+| 🔄 Sustituir CFDI (01) | si_post_fiscal_actions.js:181 | `docstatus===1` AND `fm_fiscal_status==="TIMBRADO"` | `fm_fiscal_status` | Crea SI sustituto TipoRelación 04 |
+
+### Mensajes / Alerts
+
+| Mensaje | Archivo:línea | Condición | Campos que lee | Color |
+|---|---|---|---|---|
+| "No puedes timbrar: RFC no validado" | sales_invoice.js:631 | RFC no validado con SAT | `fm_rfc_validated` en Customer | orange/headline |
+| "Ya Timbrada" | sales_invoice.js:122 | Intento retimbrar FFM en TIMBRADO | `fm_fiscal_status` FFM | orange/msgprint |
+| "Centro de Costos asignado" | sales_invoice.js:327 | Customer tiene `fm_customer_default_cost_center` | `fm_customer_default_cost_center` | green/alert 6s |
+| "Cliente sin Centro de Costos" | sales_invoice.js:339 | Customer sin cost center | `fm_customer_default_cost_center` | orange/alert 6s |
+| "CC limpiado: no pertenece a Company" | sales_invoice.js:485 | Company cambia y CC no pertenece | `company` en Cost Center | orange/alert 6s |
+| "Lista de precios asignada" | sales_invoice.js:429 | Autoasignación desde Customer o CC | `selling_price_list` | green/alert 6s |
+| "Centro de Costos obligatorio" | sales_invoice.js:449 | `validate()` sin `cost_center` | `cost_center` | frappe.validated=false |
+| "Factura cancelada ante el SAT" | sales_invoice_block_cancel.js:76 | FFM con `fm_fiscal_status==="CANCELADO"` | `fm_factura_fiscal_mx`, `fm_fiscal_status` | red/headline |
+| "Cancelación bloqueada" | sales_invoice_block_cancel.js:23 | `can_cancel_sales_invoice()` → `allowed:false` | resultado API | orange/headline |
+| "Documento fiscal creado exitosamente" | sales_invoice.js:257 | FFM creada OK | resultado insert | green/alert 3s |
+
+### Banderas (flags)
+
+| Bandera | Archivo:línea | Cómo se calcula | Campos que lee | Qué controla |
+|---|---|---|---|---|
+| `is_already_timbrada()` | sales_invoice.js:76 | `!!fm_factura_fiscal_mx` AND `fm_fiscal_status==="TIMBRADO"` | `fm_factura_fiscal_mx`, `fm_fiscal_status` | "Ver" vs "Timbrar" |
+| `should_show_timbrar_button()` | sales_invoice.js:86 | `docstatus===1` AND estado ∈ {BORRADOR,ERROR,""} | `docstatus`, `fm_fiscal_status` | Mostrar "Timbrar Factura" |
+| RFC validado | sales_invoice.js:619 | `fm_rfc_validated===1` en Customer | `fm_rfc_validated` | Visibilidad botón timbrar |
+| FFM vinculada | si_post_fiscal_actions.js:13 | `!!fm_factura_fiscal_mx` | `fm_factura_fiscal_mx` | Ocultar Cancel nativo |
+| `fiscal_status===CANCELADO` | si_post_fiscal_actions.js:47 | `norm(fm_fiscal_status)==="CANCELADO"` | `fm_fiscal_status` | Mostrar acciones post-cancelación |
+
+### Campos ocultos/mostrados (set_df_property)
+
+| Campo | Archivo:línea | Condición | Propiedad | Valor |
+|---|---|---|---|---|
+| cost_center | sales_invoice.js:296 | refresh() | reqd | 1 |
+| cost_center | sales_invoice.js:508 | refresh() (duplicado) | reqd | 1 |
+
+### Permisos modificados en runtime
+
+| Permiso | Archivo:línea | Condición | Valor | Efecto |
+|---|---|---|---|---|
+| amend | si_post_fiscal_actions.js:221 | `docstatus===2` AND `fm_fiscal_status==="CANCELADO"` | 0 | Bloquea enmiendas SI canceladas |
+
+### Realtime events
+
+| Evento | Archivo:línea | Qué hace |
+|---|---|---|
+| `fiscal_status_changed` | sales_invoice_block_cancel.js:40 | Recarga SI si cambia estado fiscal de FFM vinculada |
+
+### setTimeouts
+
+| Archivo:línea | Delay | Qué hace |
+|---|---|---|
+| sales_invoice.js:265 | 1000ms | Navega a FFM recién creada |
+| sales_invoice_block_cancel.js:56 | 300ms | Sobrescribe headline con mensaje rojo |
+| sales_invoice_block_cancel.js:29 | 0ms | Limpia headline si se permite cancelar |
+
+---
+
+## FACTURA FISCAL MEXICO
+
+### Botones
+
+| Botón | Archivo:línea | Condición de visibilidad | Campos que lee | Acción |
+|---|---|---|---|---|
+| Timbrar / Reintentar | factura_fiscal_mexico.js:151 | `docstatus===1` AND status ∈ `timbrable_states` AND `fm_tax_system` válido | `docstatus`, `status`, `fm_tax_system` | Llama `timbrar_factura(frm)` |
+| Cancelar en FacturAPI | factura_fiscal_mexico.js:229 | `docstatus===1` AND status ∈ `cancelable_states` AND `fm_sync_status!=="pending"` AND NO PE bloqueante | `docstatus`, `status`, `fm_sync_status`, PE activo | Abre diálogo motivos SAT |
+| Revisar Estatus Cancelación | factura_fiscal_mexico.js:330 | `docstatus===1` AND `status==="PENDIENTE_CANCELACION"` | `docstatus`, `status` | Consulta estado en PAC |
+| Descargar PDF+XML | factura_fiscal_mexico.js:244 | `docstatus===1` AND `fm_uuid` | `docstatus`, `fm_uuid` | Descarga archivos del SAT |
+| Enviar por email | factura_fiscal_mexico.js:269 | `docstatus===1` AND `fm_uuid` | `docstatus`, `fm_uuid` | Envía CFDI por email |
+| ¿Cómo sustituir? | factura_fiscal_mexico.js:307 | `sales_invoice` vinculada AND `docstatus===1` AND `fm_uuid` | `sales_invoice`, `docstatus`, `fm_uuid` | Muestra ayuda sustitución |
+| Ver Sales Invoice | factura_fiscal_mexico.js:355 | `sales_invoice` vinculada | `sales_invoice` | Navega a SI |
+| Cancelar FFM (liberar SI) | factura_fiscal_mexico.js:2671 | `docstatus===1` AND sin `fm_uuid` (deadlock) | `docstatus`, `fm_uuid` | Cancela FFM liberando SI |
+
+### Mensajes / Alerts
+
+| Mensaje | Archivo:línea | Condición | Campos que lee | Color |
+|---|---|---|---|---|
+| "No se puede cancelar: Pago activo" | factura_fiscal_mexico.js:222 | PE activo bloqueante | PE activo | orange/headline |
+| "Error cargando motivos SAT" | factura_fiscal_mexico.js:956 | `get_sat_cancellation_motives()` falla | error | red/msgprint |
+| "Factura timbrada exitosamente" | factura_fiscal_mexico.js:905 | Timbrado OK | `success` | green/alert 6s |
+| "Error al Timbrar" | factura_fiscal_mexico.js:914 | Fallo timbrado | `user_error` o `error` | red/msgprint |
+| "✅ Factura cancelada exitosamente" | factura_fiscal_mexico.js:1054 | Cancelación OK | `ok` | green/alert 6s |
+| "Cancelación exitosa (detalles)" | factura_fiscal_mexico.js:1077 | Cancelación completada | `ffm`, `status_ffm`, `uuid`, `cancellation_date` | green/msgprint |
+| "✅ DATOS FISCALES VALIDADOS" | factura_fiscal_mexico.js:1829 | RFC validado en Customer | `fm_rfc_validated` | green |
+| "🔴 FALTA: [campos]" | factura_fiscal_mexico.js:1839 | Campos obligatorios vacíos | `fm_cp_cliente`, `fm_rfc_cliente`, `fm_direccion_principal_display` | red |
+| "🟡 LISTO PARA VALIDAR RFC/CSF" | factura_fiscal_mexico.js:1843 | Datos completos sin RFC validado | campos rellenados | yellow |
+| "🔴 SELECCIONA UN CLIENTE" | factura_fiscal_mexico.js:1804 | Sin `customer` | `customer` | red |
+| "⚠️ Cliente Fiscal Diferente" | factura_fiscal_mexico.js:2331 | `customer` != customer de SI | `customer`, `sales_invoice` | yellow/HTML |
+| "No puede cambiar PUE/PPD en enviados" | factura_fiscal_mexico.js:1342 | Radio cambia con `docstatus===1` | `docstatus` | alert/msgprint |
+| "✅ Método cambiado a PPD" | factura_fiscal_mexico.js:1429 | Usuario selecciona PPD | radio change | orange/alert 6s |
+| "✅ Método cambiado a PUE" | factura_fiscal_mexico.js:1438 | Usuario selecciona PUE | radio change | green/alert 6s |
+| "Forma de pago asignada: 99" | factura_fiscal_mexico.js:1477 | Cambio a PPD | `fm_forma_pago_timbrado` | orange/alert 6s |
+
+### Banderas (flags)
+
+| Bandera | Archivo:línea | Cómo se calcula | Campos que lee | Qué controla |
+|---|---|---|---|---|
+| `isValidTaxSystem()` | factura_fiscal_mexico.js:135 | !startsWith("⚠️") AND !startsWith("❌") | `fm_tax_system` | Habilitar/deshabilitar timbrado |
+| `canTimbrar` | factura_fiscal_mexico.js:189 | `docstatus===1` AND status ∈ `timbrable_states` AND tax system válido | `docstatus`, `status`, `fm_tax_system` | Mostrar botón timbrar |
+| `showCancel` | factura_fiscal_mexico.js:194 | status ∈ `cancelable_states` OR `final_states` | `status` | Mostrar/ocultar sección cancelación |
+| `canCancelar` | factura_fiscal_mexico.js:209 | `docstatus===1` AND status ∈ `cancelable_states` AND `fm_sync_status!=="pending"` | `docstatus`, `status`, `fm_sync_status` | Mostrar botón cancelar |
+| `is_stamped` | factura_fiscal_mexico.js:240 | `!!frm.doc.fm_uuid` | `fm_uuid` | Mostrar botones descarga/email |
+| `current_value==="PUE"` | factura_fiscal_mexico.js:1303 | Lectura directa | `fm_payment_method_sat` | Resaltado visual radio PUE (verde) |
+| `current_value==="PPD"` | factura_fiscal_mexico.js:1303 | Lectura directa | `fm_payment_method_sat` | Resaltado visual radio PPD (naranja) |
+
+### Campos ocultos/mostrados
+
+| Campo | Archivo:línea | Condición | Propiedad | Valor |
+|---|---|---|---|---|
+| fm_tipo_comprobante | factura_fiscal_mexico.js:523 | refresh() | read_only | 1 |
+| fm_forma_pago_timbrado | factura_fiscal_mexico.js:1468 | `payment_method==="PPD"` | hidden | 1 |
+| fm_forma_pago_timbrado | factura_fiscal_mexico.js:1486 | `payment_method==="PUE"` | hidden | 0 |
+| fiscal_fields (grupo) | factura_fiscal_mexico.js:383 | `docstatus===1` | read_only | 1 |
+| uuid, serie, folio | factura_fiscal_mexico.js:1624 | status ∈ `timbrable_states` | hidden | 1 |
+| uuid, serie, folio | factura_fiscal_mexico.js:1631 | status ∈ `cancelable_states` | hidden | 0 |
+| cancellation_fields | factura_fiscal_mexico.js:1633 | status ∈ `cancelable_states` | hidden | 1 |
+| cancellation_fields | factura_fiscal_mexico.js:1640 | status ∈ `final_states` | hidden | 0 |
+| fm_lugar_expedicion, fm_branch | factura_fiscal_mexico.js:1734 | multi-sucursal enabled | hidden | 0 |
+| fm_lugar_expedicion, fm_branch | factura_fiscal_mexico.js:1762 | multi-sucursal disabled | hidden | 1 |
+
+### Permisos modificados en runtime
+
+| Permiso | Archivo:línea | Condición | Valor | Efecto |
+|---|---|---|---|---|
+| cancel | factura_fiscal_mexico.js:455 | refresh() | 0 | Bloquea cancelación nativa FFM |
+| amend | factura_fiscal_mexico.js:456 | refresh() | 0 | Bloquea enmiendas FFM |
+
+### setTimeouts
+
+| Archivo:línea | Delay | Qué hace |
+|---|---|---|
+| factura_fiscal_mexico.js:542 | 1500ms | Verifica y colorea sección datos |
+| factura_fiscal_mexico.js:544 | 1500ms | Verifica si cliente fiscal es diferente |
+| factura_fiscal_mexico.js:1266 | 500ms | Convierte Select a Radio en DOM |
+| factura_fiscal_mexico.js:568 | 1000ms | Verifica Payment Entry existente |
+| factura_fiscal_mexico.js:2254 | 500ms | Aplica colores a campos |
+| factura_fiscal_mexico.js:496 | 0ms | Remueve botón Cancel nativo |
+
+### Llamadas Python desde JS
+
+| Endpoint | Archivo:línea | Para qué | Retorna |
+|---|---|---|---|
+| `timbrado_api.get_sat_cancellation_motives` | factura_fiscal_mexico.js:952 | Motivos SAT | `{select_options:[]}` |
+| `facturacion_fiscal.api.get_fiscal_states` | factura_fiscal_mexico.js:123 | Config estados | estados y transiciones |
+| `timbrado_api.timbrar_factura` | factura_fiscal_mexico.js:898 | Timbrar | `{success, user_error, error}` |
+| `timbrado_api.cancelar_factura` | factura_fiscal_mexico.js:1027 | Cancelar CFDI | `{ok, ffm, status_ffm, uuid, cancellation_date}` |
+| `timbrado_api.revisar_estatus_cancelacion` | factura_fiscal_mexico.js:336 | Verificar cancelación | `{message, indicator}` |
+| `timbrado_api.create_substitution_si` | factura_fiscal_mexico.js:192 | Crear SI sustituto | `{new_si}` |
+| `doctype.factura_fiscal_mexico.check_si_customer_rfc_validated` | factura_fiscal_mexico.js:1150 | Validar RFC | `{ok}` |
+| `doctype.factura_fiscal_mexico.get_payment_entry_for_javascript` | factura_fiscal_mexico.js:2416 | PE para auto-cargar forma pago | `{success, data[]}` |
+| `doctype.factura_fiscal_mexico.cancel_ffm_keep_si` | factura_fiscal_mexico.js:2675 | Cancelar FFM (deadlock) | success message |
+| `complementos_pago.api.get_active_pe_for_si` | factura_fiscal_mexico.js (interno) | PE bloqueante | nombre PE o null |
+
+---
+
+## PAYMENT ENTRY
+
+### Botones
+
+| Botón | Archivo:línea | Condición de visibilidad | Campos que lee | Acción |
+|---|---|---|---|---|
+| Crear Complemento de Pago | payment_entry.js:207 | `docstatus===1` AND `payment_type==="Receive"` AND SI PPD timbrada referenciada | `docstatus`, `payment_type`, `references`, `fm_es_ppd` (de SI) | Crea Complemento Pago MX |
+| Ver Complemento de Pago | payment_entry.js:181 | `docstatus===1` AND `fm_complemento_pago` vinculado | `fm_complemento_pago` | Navega a Complemento |
+
+### Mensajes / Alerts
+
+| Mensaje | Archivo:línea | Condición | Campos que lee | Color |
+|---|---|---|---|---|
+| "Sin facturas vinculadas" | payment_entry.js:54 | `docstatus===1` AND sin references con allocated > 0 | `references` | grey/info (injection) |
+| "Pago PUE — No requiere Complemento" | payment_entry.js:72 | SIs sin `fm_es_ppd===1` | `fm_es_ppd` en SI | grey/info (injection) |
+| "Complemento de Pago pendiente" | payment_entry.js:77 | SIs con `fm_es_ppd===1` | `fm_es_ppd` en SI | orange/info (injection) |
+| "Este PE tiene Complemento activo" | payment_entry.js:35 | `fm_complemento_pago` con status!=="Cancelado" | `fm_complemento_pago`, `status` | orange/headline |
+
+### Banderas (flags)
+
+| Bandera | Archivo:línea | Cómo se calcula | Campos que lee | Qué controla |
+|---|---|---|---|---|
+| Tiene SI PPD referenciada | payment_entry.js:196 | Consulta SI con `fm_es_ppd===1` en `references` | `references[].reference_name`, `fm_es_ppd` | "Crear" vs "Ver" Complemento |
+| Complemento activo | payment_entry.js:28 | `!!fm_complemento_pago` AND status!=="Cancelado" | `fm_complemento_pago`, `status` | Ocultar botón Cancel |
+
+### Campos ocultos
+
+| Campo | Archivo:línea | Condición | Propiedad | Valor |
+|---|---|---|---|---|
+| fm_require_complement | payment_entry.js:22 | refresh() — siempre | hidden | 1 ⚠️ siempre oculto |
+| fm_complement_generated | payment_entry.js:23 | refresh() — siempre | hidden | 1 ⚠️ siempre oculto |
+
+### HTML injection de estado
+
+| Ubicación | Archivo:línea | Contenido | Condición |
+|---|---|---|---|
+| `fm_comp_summary_html` | payment_entry.js:54-83 | Resumen estado complemento con colores | `docstatus===1` |
+
+### Llamadas Python desde JS
+
+| Endpoint | Archivo:línea | Para qué | Retorna |
+|---|---|---|---|
+| `complementos_pago.api.get_active_pe_for_si` | payment_entry.js:52 | Verificar PE activo para SI | nombre PE o null |
+| `api.complemento_summary.get_complemento_summary` | payment_entry.js:92 | Resumen del Complemento | `{status, uuid_sat, fecha_timbrado, serie, folio}` |
+| `complementos_pago.api.crear_complemento_pago_desde_pe` | payment_entry.js:211 | Crear Complemento | `{complemento_name}` |
+
+### Python hooks
+
+| Hook | Archivo:línea | Estado | Qué hace |
+|---|---|---|---|
+| `check_ppd_requirement()` | payment_entry_validate.py:12 | ⚠️ NO-OP | Nada — pendiente Bloque 3B |
+| `create_complement_if_required()` | payment_entry_submit.py | ⚠️ NO-OP | Nada — pendiente Bloque 3B |
+| `block_cancel_if_complemento_activo()` | payment_entry_cancel.py:13 | ✅ Activo | Bloquea cancel si complemento activo |
+| `cancel_related_complement()` | payment_entry_cancel.py:33 | ⚠️ NO-OP | Nada — pendiente implementación |
+
+---
+
+## COMPLEMENTO PAGO MX
+
+### Botones
+
+| Botón | Archivo:línea | Condición de visibilidad | Campos que lee | Acción |
+|---|---|---|---|---|
+| Timbrar Complemento | complemento_pago_mx.js:94 | `docstatus===0` AND status ∈ {Pendiente,Error} AND sin `uuid_sat` | `docstatus`, `status`, `uuid_sat` | Llama `timbrar_complemento_pago()` |
+| Revisar Estatus Cancelación | complemento_pago_mx.js:148 | `docstatus===1` AND `status==="Pendiente Cancelación"` | `docstatus`, `status` | Consulta estado en PAC |
+| Cancelar Complemento | complemento_pago_mx.js:181 | `docstatus===1` AND `status==="Timbrado"` AND roles específicos | `docstatus`, `status`, user roles | Diálogo motivo + cancela |
+| Descargar PDF+XML | complemento_pago_mx.js:56 | `docstatus===1` AND status ∈ {Timbrado,Cancelado} AND `facturapi_id` | `docstatus`, `status`, `facturapi_id` | Descarga archivos fiscales |
+| Ver Payment Entry | complemento_pago_mx.js:83 | `payment_entry` vinculado | `payment_entry` | Navega a PE |
+
+### Mensajes / Alerts
+
+| Mensaje | Archivo:línea | Condición | Campos que lee | Color |
+|---|---|---|---|---|
+| "Estado: [status]" | complemento_pago_mx.js:157 | Después de revisar estatus | `status` retornado | verde/naranja/rojo |
+| "Complemento timbrado. UUID: [uuid]" | complemento_pago_mx.js:109 | Timbrado exitoso | `uuid` retornado | green/alert 8s |
+| "PDF y XML adjuntados correctamente" | complemento_pago_mx.js:62 | Descarga exitosa | `success` retornado | green/alert 5s |
+| "Error al descargar archivos" | complemento_pago_mx.js:70 | Fallo en descarga | error | red/alert 6s |
+
+### Banderas (flags)
+
+| Bandera | Archivo:línea | Cómo se calcula | Campos que lee | Qué controla |
+|---|---|---|---|---|
+| Puede timbrar | complemento_pago_mx.js:90 | `docstatus===0` AND status ∈ {Pendiente,Error} AND sin UUID | `docstatus`, `status`, `uuid_sat` | Mostrar "Timbrar" |
+| Status ∈ {Timbrado,Cancelado} | complemento_pago_mx.js:53 | String matching | `status` | Mostrar "Descargar" |
+| En cancelación pendiente | complemento_pago_mx.js:146 | `status==="Pendiente Cancelación"` | `status` | Mostrar "Revisar Estatus" |
+| Puede cancelar | complemento_pago_mx.js:169 | `docstatus===1` AND `status==="Timbrado"` AND roles | `docstatus`, `status`, user roles | Mostrar "Cancelar" |
+
+### Llamadas Python desde JS
+
+| Endpoint | Archivo:línea | Para qué | Retorna |
+|---|---|---|---|
+| `complementos_pago.api.timbrar_complemento_pago` | complemento_pago_mx.js:100 | Timbrar | `{uuid}` |
+| `complementos_pago.api.revisar_estatus_cancelacion_complemento` | complemento_pago_mx.js:150 | Verificar cancelación | `{status}` |
+| `complementos_pago.api.cancelar_complemento_pago` | complemento_pago_mx.js:205 | Cancelar | `{status}` |
+| `complementos_pago.api.descargar_archivos_complemento` | complemento_pago_mx.js:57 | Descargar PDF+XML | `{success}` |
+
+---
+
+## RESUMEN: Variables que aparecen en múltiples doctypes
+
+| Variable | SI | FFM | PE | Complemento | Problema |
+|---|---|---|---|---|---|
+| `docstatus` | ✅ | ✅ | ✅ | ✅ | Consistente — nativo Frappe |
+| Estado fiscal | `fm_fiscal_status` | `status` | — | `status` | ⚠️ **3 nombres para el mismo concepto** |
+| Tiene UUID | via `fm_factura_fiscal_mx` | `fm_uuid` | — | `uuid_sat` | ⚠️ Fragmentado |
+| Es PPD/PUE | `fm_es_ppd` | `fm_payment_method_sat` | (lee SI) | — | ⚠️ PE recalcula desde SI |
+| Tiene PE activo | (llama API) | (llama API) | — | — | ⚠️ **Ambos llaman misma API independientemente** |
+| Tiene complemento | — | — | `fm_complemento_pago` | `payment_entry` | Inversos del mismo link |
+| Sync pendiente | — | `fm_sync_status` | — | — | Solo en FFM |
+
+## Problemas estructurales identificados
+
+1. **Mismo dato computado en N lugares:** `fm_es_ppd` lo calcula JS de PE consultando SI por API, JS de SI lo tiene directo, JS de FFM tiene `fm_payment_method_sat`.
+
+2. **8 setTimeouts como parche de sincronización:** 0ms, 300ms, 500ms, 1000ms, 1500ms. Indica que la UI no tiene fuente ordenada de verdad.
+
+3. **Estado fiscal sin nombre canónico:** `fm_fiscal_status` (SI) ≠ `status` (FFM) ≠ `status` (Complemento) aunque representan lo mismo. JS normaliza con `norm()`.
+
+4. **`fm_require_complement` — campo fantasma:** Existe en fixture y hooks filter, se escribe en 2 momentos (crear/cancelar complemento), nunca al crear PE. UI lo ignora completamente, siempre oculto.
+
+5. **HTML injection para mostrar estado:** `_inject_complemento_summary()` inserta HTML directamente en el DOM en lugar de usar campos Frappe reales.
+
+6. **Llamada duplicada a `get_active_pe_for_si`:** Tanto SI como FFM llaman este endpoint independientemente al hacer refresh.
+
+---
+
+## Set mínimo de variables centrales propuesto
+
+```
+UNIVERSALES:
+├── is_submitted          ← docstatus == 1
+├── is_cancelled          ← docstatus == 2
+└── fiscal_status         ← BORRADOR/TIMBRADO/CANCELADO/ERROR/PENDIENTE_CANCELACION
+
+ESTADO FISCAL:
+├── has_uuid              ← fm_uuid o uuid_sat != null
+├── has_xml               ← archivo xml adjunto
+├── has_pdf               ← archivo pdf adjunto
+└── sync_pending          ← fm_sync_status == "pending"
+
+MÉTODO DE PAGO:
+├── is_ppd                ← metodo_pago == "PPD"
+└── is_pue                ← metodo_pago == "PUE"
+
+VÍNCULOS CROSS-DOCUMENT:
+├── has_ffm               ← fm_factura_fiscal_mx existe
+├── ffm_fiscal_status     ← status de la FFM vinculada
+├── has_active_pe         ← existe PE submitted vinculado a la SI
+├── has_complement        ← fm_complemento_pago existe
+└── complement_status     ← status del complemento vinculado
+
+ACCIONES DERIVADAS (calcula el servidor):
+├── can_stamp             ← is_submitted AND fiscal_status ∈ {BORRADOR,ERROR} AND NOT sync_pending
+├── can_cancel_fiscal     ← has_uuid AND fiscal_status==TIMBRADO AND NOT has_active_pe
+├── can_substitute        ← has_uuid AND fiscal_status==TIMBRADO (motivo 01)
+├── can_refacturar        ← fiscal_status==CANCELADO AND motivo ∈ {02,03,04}
+├── can_download          ← has_uuid AND (has_xml OR has_pdf)
+├── can_generate_complement ← is_submitted AND is_ppd AND has_ffm AND NOT has_complement
+└── can_cancel_complement ← has_complement AND complement_status==Timbrado
+```
+
+**Total: 17 variables.** El JS actual calcula implícitamente ~40+ condiciones dispersas en 6 archivos.
+
+---
+
+## Plan de implementación
+
+| Fase | Alcance | Estimado |
+|---|---|---|
+| **Fase 0** | Fix `check_ppd_requirement()` — campo `fm_require_complement` consistente | 1-2 días |
+| **Fase 1** | Crear `fiscal_state/payment_entry_state.py` + endpoint `get_fiscal_ui_state` para PE | 1 semana |
+| **Fase 2** | Migrar `fiscal_state/` para SI | 1 semana |
+| **Fase 3** | Migrar `fiscal_state/` para FFM y Complemento | 1 semana |
+| **Fase 4** | Tests por estado, no por botón | 3-4 días |
+| **Fase 5** | Eliminar setTimeouts, HTML injection, lógica duplicada | 2-3 días |

--- a/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
+++ b/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
@@ -156,15 +156,8 @@ function _setup_revisar_estatus_btn(frm) {
 }
 
 function _setup_cancelar_btn(frm) {
-	if (
-		!frappe.user.has_role([
-			"Facturacion Mexico Manager",
-			"Facturacion Mexico System Manager",
-			"Accounts Manager",
-			"System Manager",
-		])
-	)
-		return;
+	// Rol controlado por DocPerm de Frappe (configurable por cliente)
+	if (!frappe.model.can_cancel("Complemento Pago MX")) return;
 
 	frm.add_custom_button(__("Cancelar Complemento"), function () {
 		frappe.prompt(

--- a/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
+++ b/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
@@ -1,19 +1,48 @@
 /**
  * Complemento Pago MX — UI
- * Botón de timbrado manual (Bloque 3E).
+ * Botones y mensajes controlados por fiscal_state centralizado.
  */
 
 frappe.ui.form.on("Complemento Pago MX", {
 	refresh(frm) {
 		_hide_standard_actions(frm);
 		_setup_status_indicators(frm);
-		_setup_timbrar_btn(frm);
-		_setup_cancelar_btn(frm);
-		_setup_revisar_estatus_btn(frm);
-		_setup_descargar_btn(frm);
 		_setup_pe_link(frm);
+
+		// Estado fiscal centralizado — una sola llamada controla todos los botones y mensajes
+		frappe.call({
+			method: "facturacion_mexico.fiscal_state.api.get_fiscal_ui_state",
+			args: { doctype: "Complemento Pago MX", name: frm.doc.name },
+			callback(r) {
+				if (!r.message) return;
+				const { actions, messages } = r.message;
+				_apply_buttons(frm, actions);
+				_apply_messages(frm, messages);
+			},
+		});
 	},
 });
+
+// ── Aplicar botones desde fiscal_state ─────────────────────────────────────
+
+function _apply_buttons(frm, actions) {
+	if (actions.can_stamp) _setup_timbrar_btn(frm);
+	if (actions.can_retry_cancel) _setup_revisar_estatus_btn(frm);
+	if (actions.can_cancel) _setup_cancelar_btn(frm);
+	if (actions.can_download_xml || actions.can_download_pdf) _setup_descargar_btn(frm);
+}
+
+// ── Aplicar mensajes desde fiscal_state ────────────────────────────────────
+
+function _apply_messages(frm, messages) {
+	frm.dashboard.clear_headline();
+	if (!messages || !messages.length) return;
+	const level_color = { success: "green", warning: "orange", error: "red", info: "blue" };
+	const primary = messages[0];
+	frm.dashboard.set_headline_alert(primary.text, level_color[primary.level] || "grey");
+}
+
+// ── Indicador de color de estado (cosmético, sin lógica fiscal) ────────────
 
 function _status_color(status) {
 	switch (status) {
@@ -36,9 +65,6 @@ function _setup_status_indicators(frm) {
 	const status = frm.doc.status;
 	if (!status) return;
 	const color = _status_color(status);
-
-	// Cuerpo: inyecta dot de color junto al valor del campo Estado
-	// El encabezado lo maneja Frappe nativamente via states + status_field
 	const $val = frm.fields_dict.status?.$wrapper?.find(".control-value");
 	if ($val && $val.length) {
 		$val.html(
@@ -48,35 +74,25 @@ function _setup_status_indicators(frm) {
 	}
 }
 
-function _setup_descargar_btn(frm) {
-	if (frm.doc.docstatus !== 1) return;
-	if (!["Timbrado", "Cancelado"].includes(frm.doc.status)) return;
-	if (!frm.doc.facturapi_id) return;
+// ── Ocultar acciones estándar de Frappe (sin cambio) ───────────────────────
 
-	frm.add_custom_button(__("Descargar PDF+XML"), function () {
-		frappe.call({
-			method: "facturacion_mexico.complementos_pago.api.descargar_archivos_complemento",
-			args: { complemento_name: frm.doc.name },
-			callback: function (r) {
-				if (r.message && r.message.success) {
-					frappe.show_alert(
-						{ message: __("PDF y XML adjuntados correctamente."), indicator: "green" },
-						5
-					);
-					frm.reload_doc();
-				} else {
-					frappe.show_alert(
-						{
-							message: __("Error al descargar archivos. Revisar Error Log."),
-							indicator: "red",
-						},
-						6
-					);
-				}
-			},
-		});
-	});
+function _hide_standard_actions(frm) {
+	if (frm.page && frm.page.btn_primary) frm.page.btn_primary.addClass("hidden");
+	frm.page.wrapper.find('.btn[data-label="Submit"]').addClass("hidden");
+	if (frm.page && frm.page.btn_cancel) frm.page.btn_cancel.addClass("hidden");
+	frm.page.wrapper.find('.btn[data-label="Cancel"]').addClass("hidden");
+	frm.page.wrapper
+		.find('.btn[data-label="Amend"], .btn[data-label="Corregir"]')
+		.addClass("hidden");
+	frm.page.wrapper
+		.find(
+			'.menu-items .dropdown-item:contains("Amend"), .menu-items .dropdown-item:contains("Corregir")'
+		)
+		.addClass("disabled")
+		.css("pointer-events", "none");
 }
+
+// ── Botones — callbacks sin cambio ─────────────────────────────────────────
 
 function _setup_pe_link(frm) {
 	if (frm.doc.payment_entry) {
@@ -87,10 +103,6 @@ function _setup_pe_link(frm) {
 }
 
 function _setup_timbrar_btn(frm) {
-	if (frm.doc.docstatus !== 0) return;
-	if (!["Pendiente", "Error"].includes(frm.doc.status)) return;
-	if (frm.doc.uuid_sat) return;
-
 	frm.add_custom_button(__("Timbrar Complemento de Pago"), function () {
 		frappe.confirm(
 			__(
@@ -122,29 +134,7 @@ function _setup_timbrar_btn(frm) {
 	}).addClass("btn-primary");
 }
 
-function _hide_standard_actions(frm) {
-	// Submit estándar — el timbrado llama submit() internamente
-	if (frm.page && frm.page.btn_primary) frm.page.btn_primary.addClass("hidden");
-	frm.page.wrapper.find('.btn[data-label="Submit"]').addClass("hidden");
-	// Cancel estándar de Frappe — la cancelación va por API cancelar_complemento_pago
-	if (frm.page && frm.page.btn_cancel) frm.page.btn_cancel.addClass("hidden");
-	frm.page.wrapper.find('.btn[data-label="Cancel"]').addClass("hidden");
-	// Amend — no permitir enmiendas en complementos cancelados
-	frm.page.wrapper
-		.find('.btn[data-label="Amend"], .btn[data-label="Corregir"]')
-		.addClass("hidden");
-	frm.page.wrapper
-		.find(
-			'.menu-items .dropdown-item:contains("Amend"), .menu-items .dropdown-item:contains("Corregir")'
-		)
-		.addClass("disabled")
-		.css("pointer-events", "none");
-}
-
 function _setup_revisar_estatus_btn(frm) {
-	if (frm.doc.docstatus !== 1) return;
-	if (frm.doc.status !== "Pendiente Cancelación") return;
-
 	frm.add_custom_button(__("Revisar Estatus Cancelación"), function () {
 		frappe.call({
 			method: "facturacion_mexico.complementos_pago.api.revisar_estatus_cancelacion_complemento",
@@ -166,8 +156,6 @@ function _setup_revisar_estatus_btn(frm) {
 }
 
 function _setup_cancelar_btn(frm) {
-	if (frm.doc.docstatus !== 1) return;
-	if (frm.doc.status !== "Timbrado") return;
 	if (
 		!frappe.user.has_role([
 			"Facturacion Mexico Manager",
@@ -223,4 +211,30 @@ function _setup_cancelar_btn(frm) {
 			__("Solicitar")
 		);
 	}).addClass("btn-danger");
+}
+
+function _setup_descargar_btn(frm) {
+	frm.add_custom_button(__("Descargar PDF+XML"), function () {
+		frappe.call({
+			method: "facturacion_mexico.complementos_pago.api.descargar_archivos_complemento",
+			args: { complemento_name: frm.doc.name },
+			callback: function (r) {
+				if (r.message && r.message.success) {
+					frappe.show_alert(
+						{ message: __("PDF y XML adjuntados correctamente."), indicator: "green" },
+						5
+					);
+					frm.reload_doc();
+				} else {
+					frappe.show_alert(
+						{
+							message: __("Error al descargar archivos. Revisar Error Log."),
+							indicator: "red",
+						},
+						6
+					);
+				}
+			},
+		});
+	});
 }

--- a/facturacion_mexico/complementos_pago/hooks_handlers/payment_entry_validate.py
+++ b/facturacion_mexico/complementos_pago/hooks_handlers/payment_entry_validate.py
@@ -1,13 +1,51 @@
 """
 Payment Entry validate hook — Complemento Pago MX.
 
-ESTADO: no-op hasta Bloque 3B.
-La detección PPD usa fm_es_ppd (campo en Sales Invoice).
+Detecta si el PE referencia Sales Invoices PPD timbradas y actualiza
+fm_require_complement como fuente única de verdad en BD.
 """
 
 import frappe
 
 
 def check_ppd_requirement(doc, method=None):
-	"""Hook validate — pendiente implementación en Bloque 3B."""
-	pass
+	"""Actualiza fm_require_complement según SIs PPD timbradas referenciadas.
+
+	Regla:
+	  fm_require_complement = 1  si existe al menos una SI referenciada con
+	                              fm_es_ppd=1 Y con FFM en status TIMBRADO.
+	  fm_require_complement = 0  en cualquier otro caso.
+
+	Solo aplica a Payment Entry de tipo Receive (cobros).
+	"""
+	if doc.payment_type != "Receive":
+		doc.fm_require_complement = 0
+		return
+
+	if doc.docstatus == 2:
+		doc.fm_require_complement = 0
+		return
+
+	si_names = [
+		ref.reference_name
+		for ref in doc.get("references", [])
+		if ref.reference_doctype == "Sales Invoice" and ref.allocated_amount > 0
+	]
+
+	if not si_names:
+		doc.fm_require_complement = 0
+		return
+
+	# Buscar SIs PPD con FFM timbrada
+	ppd_timbradas = frappe.get_all(
+		"Sales Invoice",
+		filters={
+			"name": ["in", si_names],
+			"fm_es_ppd": 1,
+			"fm_fiscal_status": "TIMBRADO",
+		},
+		fields=["name"],
+		limit=1,
+	)
+
+	doc.fm_require_complement = 1 if ppd_timbradas else 0

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -177,187 +177,184 @@
 	}
 
 	function applyFFMUi(frm) {
-		const status = norm(frm.doc.status);
+		// Estado fiscal centralizado — una sola llamada reemplaza load_fiscal_states
+		// + _check_active_pe_blocking_cancel (antes eran 2 llamadas async anidadas)
+		frappe.call({
+			method: "facturacion_mexico.fiscal_state.api.get_fiscal_ui_state",
+			args: { doctype: "Factura Fiscal Mexico", name: frm.doc.name },
+			callback(r) {
+				if (!r.message) {
+					console.warn("[FFM] No fiscal state, usando fallback");
+					handleButtonsWithFallback(frm, norm(frm.doc.status));
+					return;
+				}
+				const { actions, messages, facts } = r.message;
+				if (frm.clear_custom_buttons) frm.clear_custom_buttons();
+				_apply_ffm_buttons(frm, actions, facts);
+				_apply_ffm_messages(frm, messages, facts);
+			},
+		});
+	}
 
-		load_fiscal_states(function (states) {
-			if (!states) {
-				console.warn("[FFM] No fiscal states config, usando fallback");
-				handleButtonsWithFallback(frm, status);
-				return;
+	function _apply_ffm_buttons(frm, actions, facts) {
+		// Sección cancelación: visible si puede cancelar o ya está en estado final/pendiente
+		const showCancelSection =
+			actions.can_cancel || facts.is_cancelado || facts.is_pendiente_cancelacion;
+		controlCancelSection(frm, showCancelSection);
+
+		// Timbrar / Reintentar
+		if (actions.can_stamp) {
+			const label = facts.is_error ? __("Reintentar Timbrado") : __("Timbrar con FacturAPI");
+			frm.add_custom_button(label, function () {
+				timbrar_factura(frm);
+			}).addClass("btn-primary");
+		}
+
+		// Cancelar — rol controlado por DocPerm de Frappe (configurable por cliente)
+		if (actions.can_cancel) {
+			if (facts.has_active_payment_entry) {
+				// El mensaje lo maneja _apply_ffm_messages
+			} else if (frappe.model.can_cancel("Factura Fiscal Mexico")) {
+				frm.add_custom_button(__("Cancelar en FacturAPI"), function () {
+					cancelar_timbrado(frm);
+				}).addClass("btn-danger");
 			}
+		}
 
-			// Usa fuente central: states.timbrable_states / cancelable_states / final_states
-			const canTimbrar =
-				frm.doc.docstatus === 1 &&
-				states.timbrable_states.includes(status) &&
-				isValidTaxSystem(frm.doc.fm_tax_system);
-
-			const showCancel =
-				states.cancelable_states.includes(status) || states.final_states.includes(status);
-
-			controlCancelSection(frm, showCancel);
-			if (frm.clear_custom_buttons) frm.clear_custom_buttons();
-			if (canTimbrar) addTimbrarButton(frm, status);
-
-			// --- BOTÓN DE CANCELACIÓN (repuesto) ---
-			const syncStatus = (frm.doc.fm_sync_status || "").trim().toLowerCase();
-
-			// Puede cancelar si:
-			// 1) el doc está enviado (docstatus=1)
-			// 2) el estado fiscal actual está en la lista de cancelables (desde API centralizada)
-			// 3) NO está en pendiente de cancelación (evita duplicar solicitudes)
-			const canCancelar =
-				frm.doc.docstatus === 1 &&
-				states.cancelable_states.includes(status) &&
-				syncStatus !== "pending";
-
-			// Muestra/oculta sección de cancelación y agrega botón
-			const cancelSection = frm.get_field("section_break_cancelacion");
-			if (canCancelar) {
-				if (cancelSection && cancelSection.$wrapper) cancelSection.$wrapper.show();
-
-				_check_active_pe_blocking_cancel(frm, function (blocking_pe) {
-					if (blocking_pe) {
-						frm.dashboard &&
-							frm.dashboard.set_headline_alert(
-								__(
-									"No se puede cancelar: existe un Pago activo ({0}). Cancela primero el Pago y luego regresa a cancelar la factura.",
-									[blocking_pe]
-								),
-								"orange"
-							);
-					} else {
-						frm.add_custom_button(__("Cancelar en FacturAPI"), function () {
-							cancelar_timbrado(frm);
-						}).addClass("btn-danger");
-					}
+		// Revisar estatus cancelación
+		if (actions.can_retry_cancel) {
+			frm.add_custom_button(__("Revisar Estatus Cancelación"), async () => {
+				frappe.show_alert({
+					message: __("Consultando estado en FacturAPI..."),
+					indicator: "blue",
 				});
-			} else {
-				if (cancelSection && cancelSection.$wrapper) cancelSection.$wrapper.hide();
-			}
+				const r = await frappe.call({
+					method: "facturacion_mexico.facturacion_fiscal.timbrado_api.revisar_estatus_cancelacion",
+					args: { ffm_name: frm.doc.name },
+					freeze: true,
+					freeze_message: __("Consultando PAC..."),
+				});
+				const res = r && r.message;
+				if (res) {
+					frappe.msgprint({
+						title: __("Resultado"),
+						message: __(res.message),
+						indicator: res.indicator,
+					});
+					frm.reload_doc();
+				}
+			}).addClass("btn-primary");
+		}
 
-			// --- BOTONES DESCARGA Y EMAIL (mismo patrón que Cancelar) ---
-			const is_submitted = frm.doc.docstatus === 1;
-			const is_stamped = !!frm.doc.fm_uuid;
+		// Descargar PDF+XML
+		if (actions.can_download_xml || actions.can_download_pdf) {
+			frm.add_custom_button(
+				__("Descargar PDF+XML"),
+				async () => {
+					try {
+						await frappe.call({
+							method: "facturacion_mexico.facturacion_fiscal.api_client.download_xml",
+							args: { ffm_name: frm.doc.name },
+						});
+						await frappe.call({
+							method: "facturacion_mexico.facturacion_fiscal.api_client.download_pdf",
+							args: { ffm_name: frm.doc.name },
+						});
+					} catch (e) {
+						frappe.msgprint({
+							title: __("Error de descarga"),
+							message: __(String(e)),
+							indicator: "red",
+						});
+					}
+				},
+				__("Comprobantes")
+			);
+		}
 
-			if (is_submitted && is_stamped) {
-				// 1) Descargar CFDI (PDF+XML) - Agrupado en "Comprobantes"
-				frm.add_custom_button(
-					__("Descargar PDF+XML"),
-					async () => {
-						try {
-							await frappe.call({
-								method: "facturacion_mexico.facturacion_fiscal.api_client.download_xml",
-								args: { ffm_name: frm.doc.name },
-							});
-							await frappe.call({
-								method: "facturacion_mexico.facturacion_fiscal.api_client.download_pdf",
-								args: { ffm_name: frm.doc.name },
-							});
-						} catch (e) {
+		// Enviar por email
+		if (actions.can_send_email) {
+			frm.add_custom_button(
+				__("Enviar por email"),
+				async () => {
+					try {
+						const r = await frappe.call({
+							method: "facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico.action_send_cfdi_email",
+							args: { ffm_name: frm.doc.name, to: null },
+						});
+						const res = r && r.message;
+						if (res && res.sent) {
 							frappe.msgprint({
-								title: __("Error de descarga"),
-								message: __(String(e)),
+								message: __("CFDI enviado a: {0}", [res.to]),
+								indicator: "green",
+							});
+						} else if (res && res.reason === "no-recipient") {
+							frappe.msgprint({
+								message: __("No se envió: no hay destinatario (FFM ni Settings)."),
+								indicator: "orange",
+							});
+						} else {
+							frappe.msgprint({
+								message: __("No se pudo enviar: {0}", [(res && res.error) || ""]),
 								indicator: "red",
 							});
 						}
-					},
-					__("Comprobantes")
-				);
+					} catch (e) {
+						frappe.msgprint({ message: __(String(e)), indicator: "red" });
+					}
+				},
+				__("Comprobantes")
+			);
+		}
 
-				// 2) Enviar CFDI por email - Agrupado en "Comprobantes"
-				frm.add_custom_button(
-					__("Enviar por email"),
-					async () => {
-						try {
-							const r = await frappe.call({
-								method: "facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico.action_send_cfdi_email",
-								args: { ffm_name: frm.doc.name, to: null },
-							});
-							const res = r && r.message;
-							if (res && res.sent) {
-								frappe.msgprint({
-									message: __("CFDI enviado a: {0}", [res.to]),
-									indicator: "green",
-								});
-							} else if (res && res.reason === "no-recipient") {
-								frappe.msgprint({
-									message: __(
-										"No se envió: no hay destinatario (FFM ni Settings)."
-									),
-									indicator: "orange",
-								});
-							} else {
-								frappe.msgprint({
-									message: __("No se pudo enviar: {0}", [
-										(res && res.error) || "",
-									]),
-									indicator: "red",
-								});
-							}
-						} catch (e) {
-							frappe.msgprint({ message: __(String(e)), indicator: "red" });
-						}
-					},
-					__("Comprobantes")
-				);
-			}
-
-			// --- BOTÓN AYUDA (mismo patrón que Cancelar/Descarga/Email) ---
-			if (frm.doc.sales_invoice && frm.doc.docstatus === 1 && frm.doc.fm_uuid) {
-				frm.add_custom_button(
-					__("¿Cómo sustituir?"),
-					() => {
-						const siName = frm.doc.sales_invoice;
-						frappe.msgprint({
-							title: __("Ayuda: Sustitución CFDI"),
-							message: __(
-								`<strong>Para sustituir este CFDI (motivo 01):</strong><br><br>` +
-									`1️⃣ Vaya al Sales Invoice: <strong>${siName}</strong><br>` +
-									`2️⃣ Use el botón "🔄 Sustituir CFDI (01)"<br>` +
-									`3️⃣ Se creará un SI de reemplazo para correcciones<br>` +
-									`4️⃣ El sistema manejará la relación TipoRelación 04 automáticamente<br><br>` +
-									`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`
-							),
-							indicator: "blue",
-						});
-					},
-					__("Ayuda")
-				);
-			}
-
-			// --- BOTÓN REVISAR ESTATUS (solo cuando PENDIENTE_CANCELACION) ---
-			if (frm.doc.docstatus === 1 && status === states.states.PENDIENTE_CANCELACION) {
-				frm.add_custom_button(__("Revisar Estatus Cancelación"), async () => {
-					frappe.show_alert({
-						message: __("Consultando estado en FacturAPI..."),
+		// Ayuda sustitución (solo cuando timbrado con SI vinculada)
+		if (actions.can_view_sales_invoice && facts.has_uuid && facts.is_timbrado) {
+			const siName = frm.doc.sales_invoice;
+			frm.add_custom_button(
+				__("¿Cómo sustituir?"),
+				() => {
+					frappe.msgprint({
+						title: __("Ayuda: Sustitución CFDI"),
+						message: __(
+							`<strong>Para sustituir este CFDI (motivo 01):</strong><br><br>` +
+								`1️⃣ Vaya al Sales Invoice: <strong>${siName}</strong><br>` +
+								`2️⃣ Use el botón "🔄 Sustituir CFDI (01)"<br>` +
+								`3️⃣ Se creará un SI de reemplazo para correcciones<br>` +
+								`4️⃣ El sistema manejará la relación TipoRelación 04 automáticamente<br><br>` +
+								`<em>La cancelación desde aquí es solo para motivos 02/03/04.</em>`
+						),
 						indicator: "blue",
 					});
-					const r = await frappe.call({
-						method: "facturacion_mexico.facturacion_fiscal.timbrado_api.revisar_estatus_cancelacion",
-						args: { ffm_name: frm.doc.name },
-						freeze: true,
-						freeze_message: __("Consultando PAC..."),
-					});
-					const res = r && r.message;
-					if (res) {
-						frappe.msgprint({
-							title: __("Resultado"),
-							message: __(res.message),
-							indicator: res.indicator,
-						});
-						frm.reload_doc();
-					}
-				}).addClass("btn-primary");
-			}
+				},
+				__("Ayuda")
+			);
+		}
 
-			// Reponer botón de navegación SIEMPRE que exista Sales Invoice
-			if (frm.doc.sales_invoice) {
-				frm.add_custom_button(__("Ver Sales Invoice"), function () {
-					frappe.set_route("Form", "Sales Invoice", frm.doc.sales_invoice);
-				});
-			}
-		});
+		// Ver Sales Invoice (siempre si existe)
+		if (actions.can_view_sales_invoice) {
+			frm.add_custom_button(__("Ver Sales Invoice"), function () {
+				frappe.set_route("Form", "Sales Invoice", frm.doc.sales_invoice);
+			});
+		}
+	}
+
+	function _apply_ffm_messages(frm, messages, facts) {
+		frm.dashboard.clear_headline();
+		if (!messages || !messages.length) return;
+		const level_color = { success: "green", warning: "orange", error: "red", info: "blue" };
+
+		// PE bloqueante tiene prioridad sobre el mensaje principal
+		if (
+			facts.has_active_payment_entry &&
+			(facts.is_timbrado || facts.is_pendiente_cancelacion)
+		) {
+			// prettier-ignore
+			frm.dashboard.set_headline_alert(__("No se puede cancelar: existe un Pago activo. Cancela primero el Pago y luego regresa a cancelar la factura."), "orange");
+			return;
+		}
+
+		const primary = messages[0];
+		frm.dashboard.set_headline_alert(primary.text, level_color[primary.level] || "grey");
 	}
 
 	function freeze_fiscal_fields_after_submit(frm) {

--- a/facturacion_mexico/fiscal_state/api.py
+++ b/facturacion_mexico/fiscal_state/api.py
@@ -48,6 +48,11 @@ def get_fiscal_ui_state(doctype: str, name: str) -> dict:
 
 		return get_ffm_fiscal_state(name)
 
+	if doctype == "Complemento Pago MX":
+		from facturacion_mexico.fiscal_state.complemento_state import get_complemento_fiscal_state
+
+		return get_complemento_fiscal_state(name)
+
 	frappe.throw(
 		_("fiscal_state: doctype '{0}' no está soportado aún.").format(doctype),
 		title=_("No implementado"),

--- a/facturacion_mexico/fiscal_state/api.py
+++ b/facturacion_mexico/fiscal_state/api.py
@@ -1,0 +1,42 @@
+"""
+fiscal_state/api.py
+
+Endpoint único para obtener el estado fiscal de cualquier doctype soportado.
+Read-only — no modifica ningún documento.
+"""
+
+import frappe
+from frappe import _
+
+
+@frappe.whitelist()
+def get_fiscal_ui_state(doctype: str, name: str) -> dict:
+	"""
+	Retorna el estado fiscal centralizado para un documento.
+
+	Args:
+		doctype: DocType del documento (ej. "Payment Entry")
+		name: Nombre del documento
+
+	Returns:
+		dict con facts, actions y messages para consumo de la UI.
+
+	Raises:
+		frappe.PermissionError: Si el usuario no tiene permiso de lectura.
+		frappe.DoesNotExistError: Si el documento no existe.
+		NotImplementedError: Si el doctype no está soportado aún.
+	"""
+	if not frappe.has_permission(doctype, "read", name):
+		frappe.throw(_("Sin permisos para leer {0}: {1}").format(doctype, name), frappe.PermissionError)
+
+	if doctype == "Payment Entry":
+		from facturacion_mexico.fiscal_state.payment_entry_state import (
+			get_payment_entry_fiscal_state,
+		)
+
+		return get_payment_entry_fiscal_state(name)
+
+	frappe.throw(
+		_("fiscal_state: doctype '{0}' no está soportado aún.").format(doctype),
+		title=_("No implementado"),
+	)

--- a/facturacion_mexico/fiscal_state/api.py
+++ b/facturacion_mexico/fiscal_state/api.py
@@ -43,6 +43,11 @@ def get_fiscal_ui_state(doctype: str, name: str) -> dict:
 
 		return get_sales_invoice_fiscal_state(name)
 
+	if doctype == "Factura Fiscal Mexico":
+		from facturacion_mexico.fiscal_state.ffm_state import get_ffm_fiscal_state
+
+		return get_ffm_fiscal_state(name)
+
 	frappe.throw(
 		_("fiscal_state: doctype '{0}' no está soportado aún.").format(doctype),
 		title=_("No implementado"),

--- a/facturacion_mexico/fiscal_state/api.py
+++ b/facturacion_mexico/fiscal_state/api.py
@@ -36,6 +36,13 @@ def get_fiscal_ui_state(doctype: str, name: str) -> dict:
 
 		return get_payment_entry_fiscal_state(name)
 
+	if doctype == "Sales Invoice":
+		from facturacion_mexico.fiscal_state.sales_invoice_state import (
+			get_sales_invoice_fiscal_state,
+		)
+
+		return get_sales_invoice_fiscal_state(name)
+
 	frappe.throw(
 		_("fiscal_state: doctype '{0}' no está soportado aún.").format(doctype),
 		title=_("No implementado"),

--- a/facturacion_mexico/fiscal_state/complemento_state.py
+++ b/facturacion_mexico/fiscal_state/complemento_state.py
@@ -107,9 +107,9 @@ def _compute_actions(facts: dict) -> dict:
 
 	can_stamp = facts["is_draft"] and facts["status"] in _TIMBRABLE_STATUSES
 
-	can_cancel = facts["is_draft"] and facts["is_timbrado"] and facts["has_uuid"]
+	can_cancel = facts["is_submitted"] and facts["is_timbrado"] and facts["has_uuid"]
 
-	can_retry_cancel = facts["is_draft"] and facts["is_pendiente_cancelacion"]
+	can_retry_cancel = facts["is_submitted"] and facts["is_pendiente_cancelacion"]
 
 	return {
 		"can_stamp": can_stamp,

--- a/facturacion_mexico/fiscal_state/complemento_state.py
+++ b/facturacion_mexico/fiscal_state/complemento_state.py
@@ -1,0 +1,205 @@
+"""
+fiscal_state/complemento_state.py
+
+Calcula el estado fiscal de un Complemento Pago MX de forma centralizada.
+Read-only — no modifica ningún documento ni comportamiento existente.
+
+Propósito inicial: auditoría y comparación contra la lógica actual de UI.
+"""
+
+import frappe
+from frappe import _
+
+_TIMBRADO = "Timbrado"
+_CANCELADO = "Cancelado"
+_PENDIENTE = "Pendiente"
+_ERROR = "Error"
+_PENDIENTE_CANCELACION = "Pendiente Cancelación"
+
+_TIMBRABLE_STATUSES = {_PENDIENTE, _ERROR}
+
+
+def get_complemento_fiscal_state(comp_name: str) -> dict:
+	"""
+	Retorna el estado fiscal completo de un Complemento Pago MX.
+
+	Returns:
+		dict con facts, actions y messages.
+	"""
+	comp = frappe.get_doc("Complemento Pago MX", comp_name)
+
+	facts = _compute_facts(comp)
+	actions = _compute_actions(facts)
+	messages = _compute_messages(facts)
+
+	return {
+		"doctype": "Complemento Pago MX",
+		"name": comp_name,
+		"facts": facts,
+		"actions": actions,
+		"messages": messages,
+	}
+
+
+# ── Facts ──────────────────────────────────────────────────────────────────
+
+
+def _compute_facts(comp) -> dict:
+	"""Observa el estado real del documento y sus vínculos. Solo lee."""
+
+	status = comp.get("status") or _PENDIENTE
+
+	facts = {
+		# ── Estado documental ──────────────────────────────────────────────
+		"is_draft": comp.docstatus == 0,
+		"is_submitted": comp.docstatus == 1,
+		"is_cancelled": comp.docstatus == 2,
+		# ── Estado fiscal ─────────────────────────────────────────────────
+		"status": status,
+		"is_timbrado": status == _TIMBRADO,
+		"is_cancelado": status == _CANCELADO,
+		"is_pendiente": status == _PENDIENTE,
+		"is_error": status == _ERROR,
+		"is_pendiente_cancelacion": status == _PENDIENTE_CANCELACION,
+		# ── UUID y archivos ───────────────────────────────────────────────
+		"has_uuid": bool(comp.get("uuid_sat")),
+		"has_facturapi_id": bool(comp.get("facturapi_id")),
+		"has_xml": bool(comp.get("xml_file")),
+		"has_pdf": bool(comp.get("pdf_file")),
+		# ── Vínculo con Payment Entry ─────────────────────────────────────
+		"has_payment_entry": bool(comp.get("payment_entry")),
+		"payment_entry": comp.get("payment_entry") or "",
+		# ── Datos del pago ────────────────────────────────────────────────
+		"monto_p": float(comp.get("monto_p") or 0),
+		"moneda_p": comp.get("moneda_p") or "",
+		"forma_pago_p": comp.get("forma_pago_p") or "",
+		# ── Documentos relacionados ───────────────────────────────────────
+		"has_documentos_relacionados": bool(comp.get("documentos_relacionados")),
+	}
+
+	# ── PE activo o cancelado (para contexto) ────────────────────────────
+	pe_submitted = False
+	pe_cancelled = False
+
+	if facts["has_payment_entry"]:
+		pe_data = frappe.get_all(
+			"Payment Entry",
+			filters={"name": facts["payment_entry"]},
+			fields=["docstatus"],
+			limit=1,
+		)
+		if pe_data:
+			ds = pe_data[0].get("docstatus")
+			pe_submitted = ds == 1
+			pe_cancelled = ds == 2
+
+	facts["pe_submitted"] = pe_submitted
+	facts["pe_cancelled"] = pe_cancelled
+
+	return facts
+
+
+# ── Actions ────────────────────────────────────────────────────────────────
+
+
+def _compute_actions(facts: dict) -> dict:
+	"""Deriva acciones posibles desde facts. No consulta BD."""
+
+	can_stamp = facts["is_draft"] and facts["status"] in _TIMBRABLE_STATUSES
+
+	can_cancel = facts["is_draft"] and facts["is_timbrado"] and facts["has_uuid"]
+
+	can_retry_cancel = facts["is_draft"] and facts["is_pendiente_cancelacion"]
+
+	return {
+		"can_stamp": can_stamp,
+		"can_cancel": can_cancel,
+		"can_retry_cancel": can_retry_cancel,
+		"can_download_xml": facts["has_uuid"] and facts["has_xml"],
+		"can_download_pdf": facts["has_uuid"] and facts["has_pdf"],
+		"can_view_payment_entry": facts["has_payment_entry"],
+	}
+
+
+# ── Messages ───────────────────────────────────────────────────────────────
+
+
+def _compute_messages(facts: dict) -> list:
+	"""Genera mensajes para la UI basados en facts."""
+	msgs = []
+
+	if facts["is_error"]:
+		msgs.append(
+			{
+				"code": "STAMP_ERROR",
+				"level": "error",
+				"text": _("Error al timbrar el complemento. Revisa los datos y reintenta."),
+			}
+		)
+		return msgs
+
+	if facts["is_pendiente"]:
+		if not facts["has_documentos_relacionados"]:
+			msgs.append(
+				{
+					"code": "MISSING_RELATED_DOCS",
+					"level": "warning",
+					"text": _("Faltan documentos relacionados — completa la configuración antes de timbrar."),
+				}
+			)
+		else:
+			msgs.append(
+				{
+					"code": "PENDING_STAMP",
+					"level": "warning",
+					"text": _("Complemento pendiente de timbrar."),
+				}
+			)
+		return msgs
+
+	if facts["is_timbrado"]:
+		msgs.append(
+			{
+				"code": "CFDI_STAMPED",
+				"level": "success",
+				"text": _("Complemento de pago timbrado correctamente."),
+			}
+		)
+		if facts["has_uuid"] and not (facts["has_xml"] or facts["has_pdf"]):
+			msgs.append(
+				{
+					"code": "FILES_MISSING",
+					"level": "info",
+					"text": _("XML/PDF pendientes de descargar."),
+				}
+			)
+		if facts["pe_cancelled"]:
+			msgs.append(
+				{
+					"code": "PE_CANCELLED",
+					"level": "warning",
+					"text": _("El Payment Entry origen fue cancelado."),
+				}
+			)
+		return msgs
+
+	if facts["is_pendiente_cancelacion"]:
+		msgs.append(
+			{
+				"code": "CANCELLATION_PENDING",
+				"level": "warning",
+				"text": _("Cancelación pendiente de confirmación del SAT."),
+			}
+		)
+		return msgs
+
+	if facts["is_cancelado"]:
+		msgs.append(
+			{
+				"code": "CFDI_CANCELLED",
+				"level": "warning",
+				"text": _("Complemento de pago cancelado ante el SAT."),
+			}
+		)
+
+	return msgs

--- a/facturacion_mexico/fiscal_state/ffm_state.py
+++ b/facturacion_mexico/fiscal_state/ffm_state.py
@@ -1,0 +1,249 @@
+"""
+fiscal_state/ffm_state.py
+
+Calcula el estado fiscal de una Factura Fiscal Mexico (FFM) de forma centralizada.
+Read-only — no modifica ningún documento ni comportamiento existente.
+
+Propósito inicial: auditoría y comparación contra la lógica actual de UI.
+"""
+
+import frappe
+from frappe import _
+
+_TIMBRADO = "TIMBRADO"
+_CANCELADO = "CANCELADO"
+_PENDIENTE_CANCELACION = "PENDIENTE_CANCELACION"
+_BORRADOR = "BORRADOR"
+_ERROR = "ERROR"
+
+_TIMBRABLE_STATUSES = {_BORRADOR, _ERROR, ""}
+_CANCELABLE_STATUSES = {_TIMBRADO}
+_FINAL_STATUSES = {_CANCELADO}
+
+
+def get_ffm_fiscal_state(ffm_name: str) -> dict:
+	"""
+	Retorna el estado fiscal completo de una Factura Fiscal Mexico.
+
+	Returns:
+		dict con facts, actions y messages.
+	"""
+	ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
+
+	facts = _compute_facts(ffm)
+	actions = _compute_actions(facts)
+	messages = _compute_messages(facts)
+
+	return {
+		"doctype": "Factura Fiscal Mexico",
+		"name": ffm_name,
+		"facts": facts,
+		"actions": actions,
+		"messages": messages,
+	}
+
+
+# ── Facts ──────────────────────────────────────────────────────────────────
+
+
+def _compute_facts(ffm) -> dict:
+	"""Observa el estado real del documento y sus vínculos. Solo lee."""
+
+	status = (ffm.get("status") or "").upper()
+	sync_status = (ffm.get("fm_sync_status") or "").lower()
+	tipo_comprobante = ffm.get("fm_tipo_comprobante") or ""
+	payment_method = ffm.get("fm_payment_method_sat") or ""
+
+	facts = {
+		# ── Estado documental ──────────────────────────────────────────────
+		"is_draft": ffm.docstatus == 0,
+		"is_submitted": ffm.docstatus == 1,
+		"is_cancelled": ffm.docstatus == 2,
+		# ── Estado fiscal ─────────────────────────────────────────────────
+		"status": status,
+		"is_timbrado": status == _TIMBRADO,
+		"is_cancelado": status == _CANCELADO,
+		"is_pendiente_cancelacion": status == _PENDIENTE_CANCELACION,
+		"is_borrador": status in (_BORRADOR, ""),
+		"is_error": status == _ERROR,
+		"sync_pending": sync_status == "pending",
+		# ── CFDI ──────────────────────────────────────────────────────────
+		"has_uuid": bool(ffm.get("fm_uuid")),
+		"has_facturapi_id": bool(ffm.get("facturapi_id")),
+		"tipo_comprobante": tipo_comprobante,
+		"is_ingreso": tipo_comprobante.startswith("I"),
+		"is_egreso": tipo_comprobante.startswith("E"),
+		"payment_method": payment_method,
+		"is_ppd": payment_method == "PPD",
+		"is_pue": payment_method == "PUE",
+		# ── Archivos ──────────────────────────────────────────────────────
+		"has_xml": bool(ffm.get("fm_xml_url")),
+		"has_pdf": bool(ffm.get("fm_pdf_url")),
+		# ── Cancelación ───────────────────────────────────────────────────
+		"motivo_cancelacion": ffm.get("fm_motivo_cancelacion") or "",
+		"cancellation_reason": ffm.get("cancellation_reason") or "",
+		# ── Sales Invoice vinculada ───────────────────────────────────────
+		"has_sales_invoice": bool(ffm.get("sales_invoice")),
+		"sales_invoice": ffm.get("sales_invoice") or "",
+	}
+
+	# ── Payment Entry activo que bloquea cancelación ─────────────────────
+	has_active_pe = False
+	if facts["has_sales_invoice"]:
+		pe_refs = frappe.get_all(
+			"Payment Entry Reference",
+			filters={"reference_doctype": "Sales Invoice", "reference_name": facts["sales_invoice"]},
+			fields=["parent"],
+		)
+		if pe_refs:
+			pe_names = [r.get("parent") for r in pe_refs if r.get("parent")]
+			if pe_names:
+				submitted_pe = frappe.get_all(
+					"Payment Entry",
+					filters={"name": ["in", pe_names], "docstatus": 1},
+					fields=["name"],
+					limit=1,
+				)
+				has_active_pe = bool(submitted_pe)
+
+	facts["has_active_payment_entry"] = has_active_pe
+
+	# ── Tax system (para validar si puede timbrar) ────────────────────────
+	tax_system = ffm.get("fm_tax_system") or ""
+	facts["tax_system_valid"] = bool(tax_system) and not (
+		tax_system.startswith("⚠️") or tax_system.startswith("❌")
+	)
+
+	return facts
+
+
+# ── Actions ────────────────────────────────────────────────────────────────
+
+
+def _compute_actions(facts: dict) -> dict:
+	"""Deriva acciones posibles desde facts. No consulta BD."""
+	status = facts["status"]
+	is_submitted = facts["is_submitted"]
+
+	can_stamp = (
+		is_submitted
+		and status in _TIMBRABLE_STATUSES
+		and facts["tax_system_valid"]
+		and not facts["sync_pending"]
+	)
+
+	can_cancel = (
+		is_submitted
+		and status in _CANCELABLE_STATUSES
+		and facts["has_uuid"]
+		and not facts["has_active_payment_entry"]
+		and not facts["sync_pending"]
+	)
+
+	can_retry_cancel = is_submitted and facts["is_pendiente_cancelacion"] and not facts["sync_pending"]
+
+	return {
+		"can_stamp": can_stamp,
+		"can_cancel": can_cancel,
+		"can_retry_cancel": can_retry_cancel,
+		"can_download_xml": facts["has_uuid"] and facts["has_xml"],
+		"can_download_pdf": facts["has_uuid"] and facts["has_pdf"],
+		"can_send_email": facts["has_uuid"] and facts["has_facturapi_id"],
+		"can_view_sales_invoice": facts["has_sales_invoice"],
+	}
+
+
+# ── Messages ───────────────────────────────────────────────────────────────
+
+
+def _compute_messages(facts: dict) -> list:
+	"""Genera mensajes para la UI basados en facts."""
+	msgs = []
+
+	if not facts["is_submitted"]:
+		return msgs
+
+	status = facts["status"]
+
+	if facts["sync_pending"]:
+		msgs.append(
+			{
+				"code": "SYNC_PENDING",
+				"level": "info",
+				"text": _("Operación en progreso — espera a que complete."),
+			}
+		)
+		return msgs
+
+	# ERROR tiene prioridad — muestra error de timbrado aunque sea "retriable"
+	if status == _ERROR:
+		msgs.append(
+			{
+				"code": "STAMP_ERROR",
+				"level": "error",
+				"text": _("Error en el timbrado. Revisa los datos y reintenta."),
+			}
+		)
+
+	elif status in (_BORRADOR, ""):
+		if not facts["tax_system_valid"]:
+			msgs.append(
+				{
+					"code": "TAX_SYSTEM_INVALID",
+					"level": "error",
+					"text": _("Configuración fiscal incompleta — no se puede timbrar."),
+				}
+			)
+		else:
+			msgs.append(
+				{
+					"code": "PENDING_STAMP",
+					"level": "warning",
+					"text": _("CFDI pendiente de timbrar."),
+				}
+			)
+
+	elif status == _TIMBRADO:
+		msgs.append(
+			{
+				"code": "CFDI_STAMPED",
+				"level": "success",
+				"text": _("CFDI timbrado correctamente."),
+			}
+		)
+		if facts["has_uuid"] and not (facts["has_xml"] or facts["has_pdf"]):
+			msgs.append(
+				{
+					"code": "FILES_MISSING",
+					"level": "info",
+					"text": _("XML/PDF pendientes de descargar."),
+				}
+			)
+		if facts["has_active_payment_entry"]:
+			msgs.append(
+				{
+					"code": "CANCEL_BLOCKED_ACTIVE_PE",
+					"level": "warning",
+					"text": _("No se puede cancelar: existe un pago activo. Cancela primero el pago."),
+				}
+			)
+
+	elif status == _PENDIENTE_CANCELACION:
+		msgs.append(
+			{
+				"code": "CANCELLATION_PENDING",
+				"level": "warning",
+				"text": _("Cancelación pendiente de confirmación del SAT."),
+			}
+		)
+
+	elif status == _CANCELADO:
+		msgs.append(
+			{
+				"code": "CFDI_CANCELLED",
+				"level": "warning",
+				"text": _("CFDI cancelado ante el SAT."),
+			}
+		)
+
+	return msgs

--- a/facturacion_mexico/fiscal_state/ffm_state.py
+++ b/facturacion_mexico/fiscal_state/ffm_state.py
@@ -146,8 +146,10 @@ def _compute_actions(facts: dict) -> dict:
 		"can_stamp": can_stamp,
 		"can_cancel": can_cancel,
 		"can_retry_cancel": can_retry_cancel,
-		"can_download_xml": facts["has_uuid"] and facts["has_xml"],
-		"can_download_pdf": facts["has_uuid"] and facts["has_pdf"],
+		# Descargar requiere UUID + facturapi_id — el API obtiene el archivo de FacturAPI.
+		# Los archivos adjuntos (fm_xml_url/fm_pdf_url) son opcionales y pueden no estar seteados.
+		"can_download_xml": facts["has_uuid"] and facts["has_facturapi_id"],
+		"can_download_pdf": facts["has_uuid"] and facts["has_facturapi_id"],
 		"can_send_email": facts["has_uuid"] and facts["has_facturapi_id"],
 		"can_view_sales_invoice": facts["has_sales_invoice"],
 	}

--- a/facturacion_mexico/fiscal_state/payment_entry_state.py
+++ b/facturacion_mexico/fiscal_state/payment_entry_state.py
@@ -1,0 +1,230 @@
+"""
+fiscal_state/payment_entry_state.py
+
+Calcula el estado fiscal de un Payment Entry de forma centralizada.
+Read-only — no modifica ningún documento.
+
+Propósito inicial: auditoría y comparación contra la lógica actual de UI.
+No reemplaza todavía los botones/mensajes existentes.
+"""
+
+import frappe
+from frappe import _
+
+
+def get_payment_entry_fiscal_state(pe_name: str) -> dict:
+	"""
+	Retorna el estado fiscal completo de un Payment Entry.
+
+	Returns:
+		dict con:
+		  facts   — hechos observables del documento y sus vínculos
+		  actions — acciones que el usuario puede ejecutar (derivadas de facts)
+		  messages — mensajes que la UI debería mostrar (derivados de facts)
+	"""
+	pe = frappe.get_doc("Payment Entry", pe_name)
+
+	facts = _compute_facts(pe)
+	actions = _compute_actions(facts)
+	messages = _compute_messages(facts)
+
+	return {
+		"doctype": "Payment Entry",
+		"name": pe_name,
+		"facts": facts,
+		"actions": actions,
+		"messages": messages,
+	}
+
+
+# ── Facts ──────────────────────────────────────────────────────────────────
+
+
+def _compute_facts(pe) -> dict:
+	"""Observa el estado real del documento y sus vínculos. Solo lee, no decide."""
+
+	# ── Estado documental ──────────────────────────────────────────────────
+	facts = {
+		"is_draft": pe.docstatus == 0,
+		"is_submitted": pe.docstatus == 1,
+		"is_cancelled": pe.docstatus == 2,
+		"payment_type": pe.payment_type,
+		"party_type": pe.party_type,
+	}
+
+	# ── Referencias a Sales Invoice ────────────────────────────────────────
+	si_refs = [ref for ref in pe.get("references", []) if ref.reference_doctype == "Sales Invoice"]
+	allocated_si_refs = [ref for ref in si_refs if ref.allocated_amount > 0]
+	si_names = [ref.reference_name for ref in allocated_si_refs]
+
+	facts["has_sales_invoice_references"] = bool(si_refs)
+	facts["has_allocated_sales_invoice_references"] = bool(allocated_si_refs)
+
+	# ── Estado PPD de las SIs referenciadas ───────────────────────────────
+	has_ppd = False
+	has_ppd_stamped = False
+
+	if si_names:
+		si_data = frappe.get_all(
+			"Sales Invoice",
+			filters={"name": ["in", si_names]},
+			fields=["name", "fm_es_ppd", "fm_fiscal_status"],
+		)
+		for si in si_data:
+			if si.get("fm_es_ppd"):
+				has_ppd = True
+				if si.get("fm_fiscal_status") == "TIMBRADO":
+					has_ppd_stamped = True
+
+	facts["has_ppd_invoice"] = has_ppd
+	facts["has_ppd_stamped_invoice"] = has_ppd_stamped
+
+	# ── Estado del complemento ─────────────────────────────────────────────
+	# fm_require_complement es ahora confiable gracias al hook implementado
+	facts["requires_complement"] = bool(pe.get("fm_require_complement"))
+	facts["has_complement"] = bool(pe.get("fm_complemento_pago"))
+
+	has_active = False
+	has_cancelled = False
+	has_error = False
+	complement_status = None
+	complement_has_uuid = False
+	complement_has_file = False
+
+	if pe.get("fm_complemento_pago"):
+		comp = frappe.get_all(
+			"Complemento Pago MX",
+			filters={"name": pe.fm_complemento_pago},
+			fields=["name", "status", "uuid_sat", "facturapi_id"],
+			limit=1,
+		)
+		if comp:
+			c = comp[0]
+			complement_status = c.get("status")
+			complement_has_uuid = bool(c.get("uuid_sat"))
+			complement_has_file = bool(c.get("facturapi_id"))
+
+			if complement_status == "Cancelado":
+				has_cancelled = True
+			elif complement_status == "Error":
+				has_error = True
+			else:
+				has_active = True
+
+	facts["has_active_complement"] = has_active
+	facts["has_cancelled_complement"] = has_cancelled
+	facts["has_complement_error"] = has_error
+	facts["complement_status"] = complement_status
+	facts["complement_has_uuid"] = complement_has_uuid
+	facts["complement_has_file"] = complement_has_file
+
+	return facts
+
+
+# ── Actions ────────────────────────────────────────────────────────────────
+
+
+def _compute_actions(facts: dict) -> dict:
+	"""Deriva las acciones posibles a partir de los hechos. No consulta BD."""
+	return {
+		"can_create_complement": (
+			facts["is_submitted"]
+			and facts["payment_type"] == "Receive"
+			and facts["requires_complement"]
+			and not facts["has_active_complement"]
+			and not facts["has_cancelled_complement"]
+		),
+		"can_view_complement": facts["has_complement"],
+		"can_cancel_complement": (
+			facts["has_active_complement"] and facts["complement_status"] == "Timbrado"
+		),
+		"can_download_complement_xml": (facts["has_active_complement"] and facts["complement_has_file"]),
+		"can_download_complement_pdf": (facts["has_active_complement"] and facts["complement_has_file"]),
+		"can_retry_complement": facts["has_complement_error"],
+	}
+
+
+# ── Messages ───────────────────────────────────────────────────────────────
+
+
+def _compute_messages(facts: dict) -> list:
+	"""
+	Genera los mensajes que la UI debería mostrar.
+	Retorna lista de {code, level, text} para que el JS los consuma.
+	"""
+	msgs = []
+
+	if not facts["is_submitted"]:
+		return msgs
+
+	if facts["payment_type"] != "Receive":
+		return msgs
+
+	# Bloqueo: tiene SIs PPD pero ninguna está timbrada
+	if facts["has_ppd_invoice"] and not facts["has_ppd_stamped_invoice"]:
+		msgs.append(
+			{
+				"code": "COMPLEMENT_BLOCKED_NO_STAMPED_SI",
+				"level": "warning",
+				"text": _("No se puede generar complemento: ninguna factura PPD referenciada está timbrada."),
+			}
+		)
+		return msgs
+
+	# Sin facturas PPD → no requiere complemento
+	if not facts["requires_complement"]:
+		msgs.append(
+			{
+				"code": "COMPLEMENT_NOT_REQUIRED",
+				"level": "info",
+				"text": _(
+					"Este pago no requiere Complemento de Pago (no referencia facturas PPD timbradas)."
+				),
+			}
+		)
+		return msgs
+
+	# Requiere complemento y tiene uno activo
+	if facts["has_active_complement"]:
+		msgs.append(
+			{
+				"code": "COMPLEMENT_EXISTS",
+				"level": "success",
+				"text": _("Complemento de Pago generado y vigente."),
+			}
+		)
+		return msgs
+
+	# Requiere complemento y el que tenía fue cancelado
+	if facts["has_cancelled_complement"]:
+		msgs.append(
+			{
+				"code": "COMPLEMENT_CANCELLED",
+				"level": "warning",
+				"text": _("El Complemento de Pago anterior fue cancelado. Puedes generar uno nuevo."),
+			}
+		)
+		return msgs
+
+	# Error en el complemento
+	if facts["has_complement_error"]:
+		msgs.append(
+			{
+				"code": "COMPLEMENT_ERROR",
+				"level": "error",
+				"text": _("El Complemento de Pago tiene un error. Usa 'Reintentar' para timbrar de nuevo."),
+			}
+		)
+		return msgs
+
+	# Requiere complemento y no tiene ninguno
+	if facts["requires_complement"]:
+		msgs.append(
+			{
+				"code": "COMPLEMENT_REQUIRED",
+				"level": "warning",
+				"text": _("Este pago requiere un Complemento de Pago (REP). Usa 'Crear Complemento'."),
+			}
+		)
+
+	return msgs

--- a/facturacion_mexico/fiscal_state/sales_invoice_state.py
+++ b/facturacion_mexico/fiscal_state/sales_invoice_state.py
@@ -1,0 +1,306 @@
+"""
+fiscal_state/sales_invoice_state.py
+
+Calcula el estado fiscal de una Sales Invoice de forma centralizada.
+Read-only — no modifica ningún documento ni comportamiento existente.
+
+Propósito inicial: auditoría y comparación contra la lógica actual de UI.
+"""
+
+import frappe
+from frappe import _
+
+_TIMBRABLE_STATUSES = {"", "BORRADOR", "ERROR"}
+_CANCELADO = "CANCELADO"
+_TIMBRADO = "TIMBRADO"
+_PENDIENTE_CANCELACION = "PENDIENTE_CANCELACION"
+
+
+def get_sales_invoice_fiscal_state(si_name: str) -> dict:
+	"""
+	Retorna el estado fiscal completo de una Sales Invoice.
+
+	Returns:
+		dict con facts, actions y messages.
+	"""
+	si = frappe.get_doc("Sales Invoice", si_name)
+
+	facts = _compute_facts(si)
+	actions = _compute_actions(facts)
+	messages = _compute_messages(facts)
+
+	return {
+		"doctype": "Sales Invoice",
+		"name": si_name,
+		"facts": facts,
+		"actions": actions,
+		"messages": messages,
+	}
+
+
+# ── Facts ──────────────────────────────────────────────────────────────────
+
+
+def _compute_facts(si) -> dict:
+	"""Observa el estado real del documento y sus vínculos. Solo lee."""
+
+	fiscal_status = (si.get("fm_fiscal_status") or "").upper()
+
+	facts = {
+		# ── Estado documental ──────────────────────────────────────────────
+		"is_draft": si.docstatus == 0,
+		"is_submitted": si.docstatus == 1,
+		"is_cancelled": si.docstatus == 2,
+		"is_return": bool(si.get("is_return")),
+		# ── Método de pago ────────────────────────────────────────────────
+		"is_ppd": bool(si.get("fm_es_ppd")),
+		"is_pue": not bool(si.get("fm_es_ppd")),
+		# ── Estado fiscal ────────────────────────────────────────────────
+		"fiscal_status": fiscal_status,
+	}
+
+	# ── FFM vinculada ─────────────────────────────────────────────────────
+	ffm_name = si.get("fm_factura_fiscal_mx") or ""
+	facts["has_ffm"] = bool(ffm_name)
+
+	has_active_ffm = False
+	has_cancelled_ffm = False
+	has_stamped_ffm = False
+	has_uuid = False
+	has_xml = False
+	has_pdf = False
+	ffm_motivo = None
+
+	if ffm_name:
+		ffm_data = frappe.get_all(
+			"Factura Fiscal Mexico",
+			filters={"name": ffm_name},
+			fields=["name", "status", "fm_uuid", "fm_motivo_cancelacion", "docstatus"],
+			limit=1,
+		)
+		if ffm_data:
+			ffm = ffm_data[0]
+			ffm_status = (ffm.get("status") or "").upper()
+			has_uuid = bool(ffm.get("fm_uuid"))
+			ffm_motivo = ffm.get("fm_motivo_cancelacion")
+
+			if ffm_status == _CANCELADO:
+				has_cancelled_ffm = True
+			elif ffm.get("docstatus") == 1:
+				has_active_ffm = True
+
+			has_stamped_ffm = has_uuid
+
+			# Archivos: verificar adjuntos con extensión xml/pdf en la FFM
+			if has_uuid:
+				attachments = frappe.get_all(
+					"File",
+					filters={"attached_to_doctype": "Factura Fiscal Mexico", "attached_to_name": ffm_name},
+					fields=["file_name"],
+				)
+				for att in attachments:
+					name = (att.get("file_name") or "").lower()
+					if name.endswith(".xml"):
+						has_xml = True
+					if name.endswith(".pdf"):
+						has_pdf = True
+
+	facts.update(
+		{
+			"has_active_ffm": has_active_ffm,
+			"has_cancelled_ffm": has_cancelled_ffm,
+			"has_stamped_ffm": has_stamped_ffm,
+			"has_uuid": has_uuid,
+			"has_xml": has_xml,
+			"has_pdf": has_pdf,
+			"ffm_motivo_cancelacion": ffm_motivo,
+		}
+	)
+
+	# ── Estado de pago ────────────────────────────────────────────────────
+	outstanding = float(si.get("outstanding_amount") or 0)
+	grand_total = float(si.get("grand_total") or 0)
+
+	facts["outstanding_amount"] = outstanding
+	facts["is_paid"] = si.docstatus == 1 and outstanding == 0
+	facts["is_partially_paid"] = si.docstatus == 1 and 0 < outstanding < grand_total
+
+	# ── Payment Entries ───────────────────────────────────────────────────
+	pe_refs = frappe.get_all(
+		"Payment Entry Reference",
+		filters={"reference_doctype": "Sales Invoice", "reference_name": si.name},
+		fields=["parent"],
+	)
+	pe_names = [r.get("parent") for r in pe_refs if r.get("parent")]
+
+	has_pe = bool(pe_names)
+	has_submitted_pe = False
+
+	if pe_names:
+		submitted = frappe.get_all(
+			"Payment Entry",
+			filters={"name": ["in", pe_names], "docstatus": 1},
+			fields=["name"],
+			limit=1,
+		)
+		has_submitted_pe = bool(submitted)
+
+	facts["has_payment_entries"] = has_pe
+	facts["has_submitted_payment_entries"] = has_submitted_pe
+
+	# ── Estado de complemento ─────────────────────────────────────────────
+	requires_complement = facts["is_ppd"] and has_stamped_ffm and has_submitted_pe
+	facts["requires_complement"] = requires_complement
+
+	has_complement = False
+	has_active_complement = False
+
+	if has_submitted_pe:
+		submitted_pe_names = [
+			r["name"]
+			for r in frappe.get_all(
+				"Payment Entry",
+				filters={"name": ["in", pe_names], "docstatus": 1},
+				fields=["name"],
+			)
+		]
+		if submitted_pe_names:
+			comps = frappe.get_all(
+				"Complemento Pago MX",
+				filters={"payment_entry": ["in", submitted_pe_names]},
+				fields=["name", "status"],
+			)
+			if comps:
+				has_complement = True
+				active = [c for c in comps if c.get("status") not in ("Cancelado", "Error")]
+				has_active_complement = bool(active)
+
+	facts["has_complement"] = has_complement
+	facts["has_active_complement"] = has_active_complement
+
+	return facts
+
+
+# ── Actions ────────────────────────────────────────────────────────────────
+
+
+def _compute_actions(facts: dict) -> dict:
+	"""Deriva acciones posibles desde facts. No consulta BD."""
+	fiscal_status = facts["fiscal_status"]
+	is_submitted = facts["is_submitted"]
+
+	can_stamp = is_submitted and fiscal_status in _TIMBRABLE_STATUSES and not facts["has_active_ffm"]
+
+	can_cancel_cfdi = (
+		is_submitted
+		and fiscal_status == _TIMBRADO
+		and facts["has_stamped_ffm"]
+		and not facts["has_active_complement"]
+	)
+
+	can_refacturar = (
+		is_submitted
+		and fiscal_status == _CANCELADO
+		and facts["has_cancelled_ffm"]
+		and (facts["ffm_motivo_cancelacion"] or "") in ("02", "03", "04")
+	)
+
+	can_substitute = is_submitted and fiscal_status == _TIMBRADO and facts["has_stamped_ffm"]
+
+	can_generate_complement = (
+		is_submitted
+		and facts["is_ppd"]
+		and facts["has_stamped_ffm"]
+		and facts["has_submitted_payment_entries"]
+		and not facts["has_active_complement"]
+	)
+
+	return {
+		"can_stamp": can_stamp,
+		"can_view_ffm": facts["has_ffm"],
+		"can_cancel_cfdi": can_cancel_cfdi,
+		"can_download_xml": facts["has_uuid"] and facts["has_xml"],
+		"can_download_pdf": facts["has_uuid"] and facts["has_pdf"],
+		"can_generate_payment_complement": can_generate_complement,
+		"can_refacturar": can_refacturar,
+		"can_substitute": can_substitute,
+	}
+
+
+# ── Messages ───────────────────────────────────────────────────────────────
+
+
+def _compute_messages(facts: dict) -> list:
+	"""Genera mensajes para la UI basados en facts."""
+	msgs = []
+	fiscal_status = facts["fiscal_status"]
+
+	if facts["is_draft"]:
+		msgs.append(
+			{
+				"code": "BLOCKED_DRAFT",
+				"level": "info",
+				"text": _("Borrador — envía primero la factura de venta."),
+			}
+		)
+		return msgs
+
+	if facts["is_cancelled"]:
+		msgs.append({"code": "BLOCKED_CANCELLED", "level": "info", "text": _("Factura de venta cancelada.")})
+		return msgs
+
+	# ── SI submitted ──────────────────────────────────────────────────────
+	# CFDI_CANCELLED tiene prioridad: el estado fiscal de la SI es la fuente de
+	# verdad cuando el CFDI fue cancelado, incluso si la FFM ya no tiene UUID.
+	if fiscal_status == _CANCELADO or facts["has_cancelled_ffm"]:
+		msgs.append({"code": "CFDI_CANCELLED", "level": "warning", "text": _("CFDI cancelado ante el SAT.")})
+		return msgs
+
+	# Solo mostrar CFDI_NOT_STAMPED cuando no hay cancelación y no hay UUID
+	if not facts["has_stamped_ffm"]:
+		msgs.append({"code": "CFDI_NOT_STAMPED", "level": "warning", "text": _("CFDI no timbrado.")})
+		return msgs
+
+	if fiscal_status == _TIMBRADO:
+		msgs.append({"code": "CFDI_STAMPED", "level": "success", "text": _("CFDI timbrado correctamente.")})
+		if facts["has_uuid"] and not (facts["has_xml"] or facts["has_pdf"]):
+			msgs.append(
+				{"code": "CFDI_FILES_MISSING", "level": "info", "text": _("XML/PDF pendientes de descargar.")}
+			)
+
+	elif fiscal_status == _CANCELADO:
+		msgs.append({"code": "CFDI_CANCELLED", "level": "warning", "text": _("CFDI cancelado ante el SAT.")})
+
+	elif fiscal_status == _PENDIENTE_CANCELACION:
+		msgs.append(
+			{
+				"code": "CFDI_PENDING_CANCELLATION",
+				"level": "warning",
+				"text": _("Cancelación pendiente de confirmación del SAT."),
+			}
+		)
+
+	# ── Estado de complemento ─────────────────────────────────────────────
+	if facts["requires_complement"]:
+		if facts["has_active_complement"]:
+			msgs.append(
+				{"code": "COMPLEMENT_EXISTS", "level": "success", "text": _("Complemento de pago vigente.")}
+			)
+		elif facts["has_complement"]:
+			msgs.append(
+				{
+					"code": "COMPLEMENT_PENDING",
+					"level": "warning",
+					"text": _("Complemento de pago pendiente de timbrar o cancelado."),
+				}
+			)
+		else:
+			msgs.append(
+				{
+					"code": "COMPLEMENT_REQUIRED",
+					"level": "warning",
+					"text": _("Esta factura PPD requiere un Complemento de Pago."),
+				}
+			)
+
+	return msgs

--- a/facturacion_mexico/fiscal_state/sales_invoice_state.py
+++ b/facturacion_mexico/fiscal_state/sales_invoice_state.py
@@ -215,6 +215,13 @@ def _compute_actions(facts: dict) -> dict:
 		and not facts["has_active_complement"]
 	)
 
+	# Registrar pagos está permitido solo cuando no hay FFM cancelada ante el SAT.
+	# Equivale a la lógica de sales_invoice_block_cancel.js que oculta Create/Payment
+	# cuando la SI tiene FFM CANCELADO — gap crítico identificado en auditoría.
+	can_register_payment = (
+		is_submitted and not facts["is_cancelled"] and (not facts["has_ffm"] or facts["has_active_ffm"])
+	)
+
 	return {
 		"can_stamp": can_stamp,
 		"can_view_ffm": facts["has_ffm"],
@@ -224,6 +231,7 @@ def _compute_actions(facts: dict) -> dict:
 		"can_generate_payment_complement": can_generate_complement,
 		"can_refacturar": can_refacturar,
 		"can_substitute": can_substitute,
+		"can_register_payment": can_register_payment,
 	}
 
 

--- a/facturacion_mexico/public/js/payment_entry.js
+++ b/facturacion_mexico/public/js/payment_entry.js
@@ -1,40 +1,101 @@
 /**
  * Payment Entry — Complemento de Pago MX
- *
- * Muestra botón "Crear Complemento de Pago" cuando el PE cumple las condiciones
- * para generar un complemento PPD: submitido, tipo Receive, con SIs PPD timbradas
- * referenciadas y sin complemento previo.
+ * Botones y guards controlados por fiscal_state centralizado.
  */
 
 frappe.ui.form.on("Payment Entry", {
 	refresh(frm) {
 		_hide_technical_checkboxes(frm);
-		_setup_complemento_btn(frm);
-		_setup_complemento_cancel_warning(frm);
-		_inject_complemento_summary(frm);
+		_inject_complemento_summary(frm); // widget HTML — display rico, conservado
+
+		if (frm.doc.docstatus !== 1) return;
+
+		// Estado fiscal centralizado — una sola llamada controla botones y cancel guard
+		frappe.call({
+			method: "facturacion_mexico.fiscal_state.api.get_fiscal_ui_state",
+			args: { doctype: "Payment Entry", name: frm.doc.name },
+			callback(r) {
+				if (!r.message) return;
+				const { actions, messages, facts } = r.message;
+				_apply_buttons(frm, actions);
+				_apply_cancel_guard(frm, facts);
+				_apply_messages(frm, messages);
+			},
+		});
 	},
 	fm_complemento_pago(frm) {
 		_inject_complemento_summary(frm);
 	},
 });
 
+// ── Aplicar botones desde fiscal_state ─────────────────────────────────────
+
+function _apply_buttons(frm, actions) {
+	if (actions.can_view_complement) {
+		frm.add_custom_button(__("Ver Complemento de Pago"), function () {
+			frappe.set_route("Form", "Complemento Pago MX", frm.doc.fm_complemento_pago);
+		}).addClass("btn-info");
+	}
+
+	if (actions.can_create_complement) {
+		frm.add_custom_button(__("Crear Complemento de Pago"), function () {
+			frappe.confirm(__("¿Crear Complemento de Pago para este Payment Entry?"), function () {
+				frappe.call({
+					method: "facturacion_mexico.complementos_pago.api.crear_complemento_pago_desde_pe",
+					args: { payment_entry_name: frm.doc.name },
+					callback: function (r) {
+						if (r.message && r.message.complemento_name) {
+							frappe.show_alert(
+								{
+									message: __("Complemento {0} creado correctamente.", [
+										r.message.complemento_name,
+									]),
+									indicator: "green",
+								},
+								5
+							);
+							frm.reload_doc();
+						}
+					},
+				});
+			});
+		}).addClass("btn-primary");
+	}
+}
+
+// ── Guard de cancelación desde fiscal_state ────────────────────────────────
+
+function _apply_cancel_guard(frm, facts) {
+	if (!facts.has_active_complement) return;
+	_hide_cancel_button(frm);
+	// prettier-ignore
+	frm.dashboard.set_headline_alert(__("Este Payment Entry tiene un Complemento de Pago fiscal activo ({0}). Cancele primero el complemento antes de cancelar el pago.", [frm.doc.fm_complemento_pago]), "orange");
+}
+
+// ── Aplicar mensajes desde fiscal_state ────────────────────────────────────
+
+function _apply_messages(frm, messages) {
+	if (!messages || !messages.length) return;
+	// Solo mostrar si no hay ya un headline del cancel guard
+	if (frm.doc.fm_complemento_pago) return; // el widget ya muestra el estado
+	frm.dashboard.clear_headline();
+	const level_color = { success: "green", warning: "orange", error: "red", info: "blue" };
+	const primary = messages[0];
+	frm.dashboard.set_headline_alert(primary.text, level_color[primary.level] || "grey");
+}
+
+// ── Funciones sin cambio ───────────────────────────────────────────────────
+
 function _hide_technical_checkboxes(frm) {
 	frm.set_df_property("fm_require_complement", "hidden", 1);
 	frm.set_df_property("fm_complement_generated", "hidden", 1);
 }
 
-function _setup_complemento_cancel_warning(frm) {
-	if (frm.doc.docstatus !== 1) return;
-	if (!frm.doc.fm_complemento_pago) return;
-
-	frappe.db.get_value("Complemento Pago MX", frm.doc.fm_complemento_pago, "status").then((r) => {
-		const st = r.message && r.message.status;
-		if (st && st !== "Cancelado") {
-			_hide_cancel_button(frm);
-			// prettier-ignore
-			frm.dashboard.set_headline_alert(__("Este Payment Entry tiene un Complemento de Pago fiscal activo ({0}) en estado '{1}'. Cancele primero el complemento antes de cancelar el pago.", [frm.doc.fm_complemento_pago, st]), "orange");
-		}
-	});
+function _hide_cancel_button(frm) {
+	if (frm.page && frm.page.btn_cancel) frm.page.btn_cancel.addClass("hidden");
+	frm.page.wrapper
+		.find('button.btn-danger, .btn[data-label="Cancel"], button:contains("Cancel")')
+		.addClass("hidden");
 }
 
 function _inject_complemento_summary(frm) {
@@ -160,74 +221,4 @@ function _complemento_status_color(status) {
 		default:
 			return "grey";
 	}
-}
-
-function _hide_cancel_button(frm) {
-	if (frm.page && frm.page.btn_cancel) frm.page.btn_cancel.addClass("hidden");
-	frm.page.wrapper
-		.find('button.btn-danger, .btn[data-label="Cancel"], button:contains("Cancel")')
-		.addClass("hidden");
-}
-
-function _setup_complemento_btn(frm) {
-	// Solo PE submitido
-	if (frm.doc.docstatus !== 1) return;
-
-	// Solo cobros (Receive)
-	if (frm.doc.payment_type !== "Receive") return;
-
-	// Ya tiene complemento — mostrar enlace de navegación en lugar de botón
-	if (frm.doc.fm_complemento_pago) {
-		frm.add_custom_button(__("Ver Complemento de Pago"), function () {
-			frappe.set_route("Form", "Complemento Pago MX", frm.doc.fm_complemento_pago);
-		}).addClass("btn-info");
-		return;
-	}
-
-	// Verificar si hay al menos una SI con fm_es_ppd=1 referenciada
-	const si_names = (frm.doc.references || [])
-		.filter(
-			(ref) => ref.reference_doctype === "Sales Invoice" && flt(ref.allocated_amount) > 0
-		)
-		.map((ref) => ref.reference_name);
-
-	if (!si_names.length) return;
-
-	frappe.db
-		.get_list("Sales Invoice", {
-			filters: [
-				["name", "in", si_names],
-				["fm_es_ppd", "=", 1],
-			],
-			fields: ["name"],
-			limit: 1,
-		})
-		.then((rows) => {
-			if (!rows.length) return;
-			frm.add_custom_button(__("Crear Complemento de Pago"), function () {
-				frappe.confirm(
-					__("¿Crear Complemento de Pago para este Payment Entry?"),
-					function () {
-						frappe.call({
-							method: "facturacion_mexico.complementos_pago.api.crear_complemento_pago_desde_pe",
-							args: { payment_entry_name: frm.doc.name },
-							callback: function (r) {
-								if (r.message && r.message.complemento_name) {
-									frappe.show_alert(
-										{
-											message: __("Complemento {0} creado correctamente.", [
-												r.message.complemento_name,
-											]),
-											indicator: "green",
-										},
-										5
-									);
-									frm.reload_doc();
-								}
-							},
-						});
-					}
-				);
-			}).addClass("btn-primary");
-		});
 }

--- a/facturacion_mexico/public/js/sales_invoice.js
+++ b/facturacion_mexico/public/js/sales_invoice.js
@@ -33,18 +33,23 @@ load_fiscal_states();
 
 frappe.ui.form.on("Sales Invoice", {
 	refresh: function (frm) {
-		// Limpiar botones previos
 		frm.remove_custom_button(__("Timbrar Factura"));
-		frm.remove_custom_button(__("Ver Factura Fiscal")); // evitar duplicados
+		frm.remove_custom_button(__("Ver Factura Fiscal"));
 
-		if (frm.doc.docstatus === 1) {
-			// Mostrar botón de navegación si existe vínculo, independiente del estado
-			if (frm.doc.fm_factura_fiscal_mx) {
-				add_view_fiscal_button(frm);
-			}
-			// RFC check + timbrar button lo maneja _check_rfc_and_show_timbrar,
-			// llamado desde sales_invoice_block_cancel.js después de resolver el estado de cancelación
-		}
+		if (frm.doc.docstatus !== 1) return;
+
+		// Estado fiscal centralizado — decide Timbrar y Ver Factura Fiscal
+		frappe.call({
+			method: "facturacion_mexico.fiscal_state.api.get_fiscal_ui_state",
+			args: { doctype: "Sales Invoice", name: frm.doc.name },
+			callback(r) {
+				if (!r.message) return;
+				const { actions } = r.message;
+				if (actions.can_view_ffm) add_view_fiscal_button(frm);
+				// can_stamp: condiciones técnicas OK — RFC check decide si mostrar o avisar
+				if (actions.can_stamp) _check_rfc_and_show_timbrar(frm);
+			},
+		});
 	},
 });
 

--- a/facturacion_mexico/public/js/si_post_fiscal_actions.js
+++ b/facturacion_mexico/public/js/si_post_fiscal_actions.js
@@ -44,16 +44,18 @@
 
 	function add_post_fiscal_actions(frm) {
 		if (frm.doc.docstatus !== 1) return;
-		const st = norm(frm.doc.fm_fiscal_status || "");
-		if (st !== S.CANCELADO && st !== "CANCELADO") return;
 
-		// Si hay PE activo, no mostrar acciones fiscales post-cancelación
+		// Estado fiscal centralizado — reemplaza chequeo de fm_fiscal_status + get_active_pe_for_si
 		frappe.call({
-			method: "facturacion_mexico.complementos_pago.api.get_active_pe_for_si",
-			args: { si_name: frm.doc.name },
+			method: "facturacion_mexico.fiscal_state.api.get_fiscal_ui_state",
+			args: { doctype: "Sales Invoice", name: frm.doc.name },
 			callback: function (r) {
-				if (r.message) return; // hay PE activo — no mostrar botones
-				_add_post_fiscal_action_buttons(frm);
+				if (!r.message) return;
+				const { actions, facts } = r.message;
+				// Opciones Fiscales solo cuando hay FFM cancelada y sin PE activo
+				if (facts.has_cancelled_ffm && !facts.has_submitted_payment_entries) {
+					_add_post_fiscal_action_buttons(frm);
+				}
 			},
 		});
 	}
@@ -175,40 +177,48 @@
 	}
 
 	function add_substitute_button_mx(frm) {
-		// [Milestone 3] Mostrar sólo si hay FFM timbrada vigente ligada al SI
-		const status = (frm.doc.fm_fiscal_status || "").toUpperCase();
-		if (frm.doc.docstatus === 1 && status === "TIMBRADO") {
-			frm.add_custom_button(
-				__("🔄 Sustituir CFDI (01)"),
-				() => {
-					frappe.confirm(
-						__(
-							"Se creará un Sales Invoice de reemplazo (borrador) para emitir el CFDI sustituto (TipoRelación 04). ¿Continuar?"
-						),
-						() => {
-							frappe
-								.call({
-									method: "facturacion_mexico.facturacion_fiscal.timbrado_api.create_substitution_si",
-									args: { si_name: frm.doc.name },
-									freeze: true,
-									freeze_message: __("Creando Sales Invoice de reemplazo..."),
-								})
-								.then((r) => {
-									const out = (r && r.message) || {};
-									if (!out || !out.new_si) return;
-									frappe.show_alert({
-										message: __("SI de reemplazo creado:") + " " + out.new_si,
-										indicator: "green",
+		if (frm.doc.docstatus !== 1) return;
+
+		// Estado fiscal centralizado — reemplaza chequeo local fm_fiscal_status=TIMBRADO
+		frappe.call({
+			method: "facturacion_mexico.fiscal_state.api.get_fiscal_ui_state",
+			args: { doctype: "Sales Invoice", name: frm.doc.name },
+			callback: function (r) {
+				if (!r.message || !r.message.actions.can_substitute) return;
+				frm.add_custom_button(
+					__("🔄 Sustituir CFDI (01)"),
+					() => {
+						frappe.confirm(
+							__(
+								"Se creará un Sales Invoice de reemplazo (borrador) para emitir el CFDI sustituto (TipoRelación 04). ¿Continuar?"
+							),
+							() => {
+								frappe
+									.call({
+										method: "facturacion_mexico.facturacion_fiscal.timbrado_api.create_substitution_si",
+										args: { si_name: frm.doc.name },
+										freeze: true,
+										freeze_message: __(
+											"Creando Sales Invoice de reemplazo..."
+										),
+									})
+									.then((r) => {
+										const out = (r && r.message) || {};
+										if (!out || !out.new_si) return;
+										frappe.show_alert({
+											message:
+												__("SI de reemplazo creado:") + " " + out.new_si,
+											indicator: "green",
+										});
+										frappe.set_route("Form", "Sales Invoice", out.new_si);
 									});
-									// Abrir el SI de reemplazo para que el usuario corrija datos antes de timbrar
-									frappe.set_route("Form", "Sales Invoice", out.new_si);
-								});
-						}
-					);
-				},
-				__("Opciones Fiscales")
-			);
-		}
+							}
+						);
+					},
+					__("Opciones Fiscales")
+				);
+			},
+		});
 	}
 
 	frappe.ui.form.on("Sales Invoice", {

--- a/facturacion_mexico/tests/test_check_ppd_requirement.py
+++ b/facturacion_mexico/tests/test_check_ppd_requirement.py
@@ -1,0 +1,296 @@
+"""
+Tests para check_ppd_requirement() en payment_entry_validate.py
+
+Casos cubiertos (unitarios):
+  1. PE Receive con SI PPD timbrada → fm_require_complement = 1
+  2. PE Receive con SI PUE timbrada → fm_require_complement = 0
+  3. PE Receive con SI PPD no timbrada → fm_require_complement = 0
+  4. PE no Receive (Payment) → fm_require_complement = 0
+  5. PE cancelado (docstatus=2) → fm_require_complement = 0
+
+Casos cubiertos (integración):
+  6. Hook corre al guardar PE real con SI PPD timbrada → fm_require_complement = 1
+  7. Hook corre al guardar PE real con SI PUE → fm_require_complement = 0
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.complementos_pago.hooks_handlers.payment_entry_validate import (
+	check_ppd_requirement,
+)
+
+
+def _make_pe(payment_type="Receive", docstatus=1, references=None):
+	"""Crea un doc mock de Payment Entry con los campos mínimos."""
+	doc = frappe._dict(
+		payment_type=payment_type,
+		docstatus=docstatus,
+		fm_require_complement=0,
+		references=references or [],
+	)
+	doc.get = lambda key, default=None: (
+		doc.get(key, default) if isinstance(doc, dict) else getattr(doc, key, default)
+	)
+	return doc
+
+
+def _si_ref(si_name, allocated=1000):
+	return frappe._dict(
+		reference_doctype="Sales Invoice",
+		reference_name=si_name,
+		allocated_amount=allocated,
+	)
+
+
+class TestCheckPPDRequirement(FrappeTestCase):
+	# ── Caso 1 ────────────────────────────────────────────────────────────
+	def test_receive_ppd_timbrada_requiere_complemento(self):
+		"""Receive + SI PPD timbrada → fm_require_complement = 1."""
+		doc = _make_pe(references=[_si_ref("SINV-PPD-001")])
+		with patch("frappe.get_all", return_value=[{"name": "SINV-PPD-001"}]):
+			check_ppd_requirement(doc)
+		self.assertEqual(doc.fm_require_complement, 1)
+
+	# ── Caso 2 ────────────────────────────────────────────────────────────
+	def test_receive_pue_no_requiere_complemento(self):
+		"""Receive + SI PUE → fm_require_complement = 0 (frappe.get_all retorna vacío)."""
+		doc = _make_pe(references=[_si_ref("SINV-PUE-001")])
+		with patch("frappe.get_all", return_value=[]):
+			check_ppd_requirement(doc)
+		self.assertEqual(doc.fm_require_complement, 0)
+
+	# ── Caso 3 ────────────────────────────────────────────────────────────
+	def test_receive_ppd_no_timbrada_no_requiere(self):
+		"""Receive + SI PPD pero NO timbrada → fm_require_complement = 0."""
+		doc = _make_pe(references=[_si_ref("SINV-PPD-DRAFT")])
+		with patch("frappe.get_all", return_value=[]):
+			check_ppd_requirement(doc)
+		self.assertEqual(doc.fm_require_complement, 0)
+
+	# ── Caso 4 ────────────────────────────────────────────────────────────
+	def test_payment_no_receive(self):
+		"""Payment type != Receive → fm_require_complement = 0 sin consultar BD."""
+		doc = _make_pe(payment_type="Pay", references=[_si_ref("SINV-001")])
+		with patch("frappe.get_all") as mock_get_all:
+			check_ppd_requirement(doc)
+			mock_get_all.assert_not_called()
+		self.assertEqual(doc.fm_require_complement, 0)
+
+	# ── Caso 5 ────────────────────────────────────────────────────────────
+	def test_pe_cancelado(self):
+		"""PE cancelado (docstatus=2) → fm_require_complement = 0."""
+		doc = _make_pe(docstatus=2, references=[_si_ref("SINV-PPD-001")])
+		with patch("frappe.get_all") as mock_get_all:
+			check_ppd_requirement(doc)
+			mock_get_all.assert_not_called()
+		self.assertEqual(doc.fm_require_complement, 0)
+
+	# ── Caso extra: sin referencias ───────────────────────────────────────
+	def test_sin_referencias(self):
+		"""Sin referencias → fm_require_complement = 0."""
+		doc = _make_pe(references=[])
+		with patch("frappe.get_all") as mock_get_all:
+			check_ppd_requirement(doc)
+			mock_get_all.assert_not_called()
+		self.assertEqual(doc.fm_require_complement, 0)
+
+	# ── Caso extra: allocated_amount = 0 ─────────────────────────────────
+	def test_allocated_amount_cero_ignorado(self):
+		"""Referencia con allocated_amount=0 se ignora."""
+		doc = _make_pe(references=[_si_ref("SINV-PPD-001", allocated=0)])
+		with patch("frappe.get_all") as mock_get_all:
+			check_ppd_requirement(doc)
+			mock_get_all.assert_not_called()
+		self.assertEqual(doc.fm_require_complement, 0)
+
+
+class TestCheckPPDRequirementIntegracion(FrappeTestCase):
+	"""Tests de integración: confirma que el hook corre al guardar PE real en BD."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		from frappe.utils import getdate
+
+		# --- Company (patrón documentado en test-guard) ---
+		default_co = frappe.defaults.get_global_default("company")
+		if default_co and frappe.db.exists("Company", default_co):
+			cls.company = default_co
+		else:
+			cls.company = frappe.db.get_value("Company", {}, "name")
+			if not cls.company:
+				company = frappe.new_doc("Company")
+				company.company_name = "_Test Company"
+				company.abbr = "_TC"
+				company.default_currency = "MXN"
+				company.country = "Mexico"
+				company.insert(ignore_permissions=True)
+				cls.company = company.name
+				frappe.db.set_default("company", cls.company)
+
+		cls.currency = frappe.db.get_value("Company", cls.company, "default_currency") or "MXN"
+
+		# --- UOM ---
+		if not frappe.db.exists("UOM", "Nos"):
+			frappe.get_doc({"doctype": "UOM", "uom_name": "Nos"}).insert(ignore_permissions=True)
+
+		# --- Customer Group + Territory ---
+		if not frappe.db.exists("Customer Group", "All Customer Groups"):
+			frappe.get_doc(
+				{"doctype": "Customer Group", "customer_group_name": "All Customer Groups", "is_group": 1}
+			).insert(ignore_permissions=True)
+		if not frappe.db.exists("Customer Group", "Individual"):
+			frappe.get_doc(
+				{
+					"doctype": "Customer Group",
+					"customer_group_name": "Individual",
+					"is_group": 0,
+					"parent_customer_group": "All Customer Groups",
+				}
+			).insert(ignore_permissions=True)
+		if not frappe.db.exists("Territory", "All Territories"):
+			frappe.get_doc(
+				{"doctype": "Territory", "territory_name": "All Territories", "is_group": 1}
+			).insert(ignore_permissions=True)
+		if not frappe.db.exists("Territory", "Rest Of The World"):
+			frappe.get_doc(
+				{
+					"doctype": "Territory",
+					"territory_name": "Rest Of The World",
+					"is_group": 0,
+					"parent_territory": "All Territories",
+				}
+			).insert(ignore_permissions=True)
+
+		# --- Customer ---
+		cls.customer = "_Test Customer"
+		if not frappe.db.exists("Customer", cls.customer):
+			customer = frappe.new_doc("Customer")
+			customer.customer_name = "_Test Customer"
+			customer.customer_type = "Individual"
+			customer.customer_group = "Individual"
+			customer.territory = "Rest Of The World"
+			customer.insert(ignore_permissions=True)
+
+		# --- SAT Producto Servicio (requerido por hook validate de SI) ---
+		sat_code = "84111506"
+		if not frappe.db.exists("SAT Producto Servicio", sat_code):
+			sat = frappe.new_doc("SAT Producto Servicio")
+			sat.codigo = sat_code
+			sat.descripcion = "Servicios de consultoria - Test"
+			sat.insert(ignore_permissions=True)
+
+		# --- Item ---
+		item_group = frappe.db.get_value("Item Group", {"is_group": 0}, "name") or "All Item Groups"
+		cls.item_code = "FM-TEST-PPD-ITEM"
+		if not frappe.db.exists("Item", cls.item_code):
+			item = frappe.new_doc("Item")
+			item.item_code = cls.item_code
+			item.item_name = "Item test PPD"
+			item.item_group = item_group
+			item.stock_uom = "Nos"
+			item.is_stock_item = 0
+			item.fm_producto_servicio_sat = sat_code
+			item.insert(ignore_permissions=True)
+		else:
+			frappe.db.set_value("Item", cls.item_code, "fm_producto_servicio_sat", sat_code)
+
+		# --- Cost Center ---
+		cls.cost_center = frappe.db.get_value("Cost Center", {"is_group": 0, "company": cls.company}, "name")
+		if not cls.cost_center:
+			parent_cc = frappe.db.get_value("Cost Center", {"company": cls.company}, "name")
+			if parent_cc:
+				cc = frappe.new_doc("Cost Center")
+				cc.cost_center_name = "FM Test PPD"
+				cc.company = cls.company
+				cc.parent_cost_center = parent_cc
+				cc.insert(ignore_permissions=True)
+				cls.cost_center = cc.name
+
+		# --- Fiscal Year ---
+		today = getdate()
+		fy_name = str(today.year)
+		if not frappe.db.exists("Fiscal Year", fy_name):
+			fy = frappe.new_doc("Fiscal Year")
+			fy.year = fy_name
+			fy.year_start_date = f"{today.year}-01-01"
+			fy.year_end_date = f"{today.year}-12-31"
+			fy.append("companies", {"company": cls.company})
+			fy.insert(ignore_permissions=True)
+		else:
+			fy = frappe.get_doc("Fiscal Year", fy_name)
+			if cls.company not in [c.company for c in fy.companies]:
+				fy.append("companies", {"company": cls.company})
+				fy.save(ignore_permissions=True)
+
+		# --- Cuentas para PE ---
+		cls.receivable_account = frappe.db.get_value(
+			"Account", {"account_type": "Receivable", "company": cls.company, "is_group": 0}, "name"
+		)
+		cls.bank_account = frappe.db.get_value(
+			"Account",
+			{"account_type": ["in", ["Bank", "Cash"]], "company": cls.company, "is_group": 0},
+			"name",
+		)
+
+		frappe.db.commit()
+
+	def _make_real_si(self, is_ppd=True, fiscal_status="TIMBRADO"):
+		"""Crea SI real submitted con campos fiscales seteados vía db_set."""
+		si = frappe.new_doc("Sales Invoice")
+		si.company = self.company
+		si.customer = self.customer
+		si.cost_center = self.cost_center
+		si.currency = self.currency
+		si.conversion_rate = 1.0
+		si.append("items", {"item_code": self.item_code, "qty": 1, "rate": 500})
+		si.insert(ignore_permissions=True)
+		si.submit()
+		frappe.db.set_value(
+			"Sales Invoice",
+			si.name,
+			{"fm_es_ppd": 1 if is_ppd else 0, "fm_fiscal_status": fiscal_status},
+		)
+		frappe.db.commit()
+		return si.name
+
+	def _make_real_pe(self, si_name, allocated=500):
+		"""Crea PE real tipo Receive con referencia a la SI."""
+		if not self.receivable_account or not self.bank_account:
+			self.skipTest("No hay cuentas contables disponibles para PE en este site")
+
+		pe = frappe.new_doc("Payment Entry")
+		pe.payment_type = "Receive"
+		pe.company = self.company
+		pe.party_type = "Customer"
+		pe.party = self.customer
+		pe.paid_from = self.receivable_account
+		pe.paid_to = self.bank_account
+		pe.paid_amount = allocated
+		pe.received_amount = allocated
+		pe.target_exchange_rate = 1.0
+		pe.source_exchange_rate = 1.0
+		pe.append(
+			"references",
+			{"reference_doctype": "Sales Invoice", "reference_name": si_name, "allocated_amount": allocated},
+		)
+		pe.insert(ignore_permissions=True)
+		return pe
+
+	# ── Caso 6: integración PPD timbrada ─────────────────────────────────
+	def test_integracion_ppd_timbrada_activa_campo(self):
+		"""Hook corre al guardar PE real: SI PPD timbrada → fm_require_complement = 1."""
+		si_name = self._make_real_si(is_ppd=True, fiscal_status="TIMBRADO")
+		pe = self._make_real_pe(si_name)
+		# El hook ya corrió en insert() → verificar el campo en el doc en memoria
+		self.assertEqual(pe.fm_require_complement, 1)
+
+	# ── Caso 7: integración PUE no activa campo ───────────────────────────
+	def test_integracion_pue_no_activa_campo(self):
+		"""Hook corre al guardar PE real: SI PUE → fm_require_complement = 0."""
+		si_name = self._make_real_si(is_ppd=False, fiscal_status="TIMBRADO")
+		pe = self._make_real_pe(si_name)
+		self.assertEqual(pe.fm_require_complement, 0)

--- a/facturacion_mexico/tests/test_fiscal_state_complemento.py
+++ b/facturacion_mexico/tests/test_fiscal_state_complemento.py
@@ -1,0 +1,242 @@
+"""
+Tests para fiscal_state/complemento_state.py
+
+Casos cubiertos:
+  1. Complemento Pendiente con documentos relacionados → PENDING_STAMP, can_stamp=True
+  2. Complemento Pendiente sin documentos relacionados → MISSING_RELATED_DOCS
+  3. Complemento Timbrado sin PE cancelado → CFDI_STAMPED, can_cancel=True
+  4. Complemento Timbrado sin XML/PDF → FILES_MISSING
+  5. Complemento Timbrado con PE cancelado → CFDI_STAMPED + PE_CANCELLED
+  6. Complemento Cancelado → CFDI_CANCELLED
+  7. Complemento Error → STAMP_ERROR, can_stamp=True
+  8. Complemento Pendiente Cancelación → CANCELLATION_PENDING, can_retry_cancel=True
+  9. Actions derivadas correctamente
+"""
+
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.fiscal_state.complemento_state import (
+	_compute_actions,
+	_compute_facts,
+	_compute_messages,
+)
+
+
+def _mock_comp(
+	docstatus=0,
+	status="Pendiente",
+	uuid_sat="",
+	facturapi_id="",
+	xml_file="",
+	pdf_file="",
+	payment_entry="",
+	monto_p=1000,
+	moneda_p="MXN",
+	forma_pago_p="03",
+	documentos_relacionados=None,
+):
+	comp = MagicMock()
+	comp.docstatus = docstatus
+	comp.name = "COMP-TEST"
+
+	attrs = {
+		"status": status,
+		"uuid_sat": uuid_sat,
+		"facturapi_id": facturapi_id,
+		"xml_file": xml_file,
+		"pdf_file": pdf_file,
+		"payment_entry": payment_entry,
+		"monto_p": monto_p,
+		"moneda_p": moneda_p,
+		"forma_pago_p": forma_pago_p,
+		"documentos_relacionados": documentos_relacionados or [],
+	}
+	comp.get = lambda key, default=None: attrs.get(key, default)
+	return comp
+
+
+class TestFiscalStateComplementoFacts(FrappeTestCase):
+	# ── Caso 1: Pendiente con docs ────────────────────────────────────────
+	def test_pendiente_con_docs(self):
+		comp = _mock_comp(documentos_relacionados=[{"si": "SI-001"}])
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(comp)
+		self.assertTrue(facts["is_pendiente"])
+		self.assertFalse(facts["has_uuid"])
+		self.assertTrue(facts["has_documentos_relacionados"])
+
+	# ── Caso 2: Timbrado con uuid ─────────────────────────────────────────
+	def test_timbrado(self):
+		comp = _mock_comp(
+			status="Timbrado",
+			uuid_sat="UUID-123",
+			facturapi_id="FAP-001",
+			xml_file="/files/comp.xml",
+			pdf_file="/files/comp.pdf",
+			payment_entry="PE-001",
+		)
+		with patch("frappe.get_all", return_value=[{"docstatus": 1}]):
+			facts = _compute_facts(comp)
+		self.assertTrue(facts["is_timbrado"])
+		self.assertTrue(facts["has_uuid"])
+		self.assertTrue(facts["has_xml"])
+		self.assertTrue(facts["has_pdf"])
+		self.assertTrue(facts["pe_submitted"])
+		self.assertFalse(facts["pe_cancelled"])
+
+	# ── Caso 3: Timbrado con PE cancelado ────────────────────────────────
+	def test_timbrado_pe_cancelado(self):
+		comp = _mock_comp(
+			status="Timbrado",
+			uuid_sat="UUID-123",
+			payment_entry="PE-001",
+		)
+		with patch("frappe.get_all", return_value=[{"docstatus": 2}]):
+			facts = _compute_facts(comp)
+		self.assertTrue(facts["is_timbrado"])
+		self.assertTrue(facts["pe_cancelled"])
+		self.assertFalse(facts["pe_submitted"])
+
+	# ── Caso 4: Cancelado ────────────────────────────────────────────────
+	def test_cancelado(self):
+		comp = _mock_comp(status="Cancelado", uuid_sat="UUID-123")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(comp)
+		self.assertTrue(facts["is_cancelado"])
+		self.assertFalse(facts["is_timbrado"])
+
+	# ── Caso 5: Error ────────────────────────────────────────────────────
+	def test_error(self):
+		comp = _mock_comp(status="Error")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(comp)
+		self.assertTrue(facts["is_error"])
+
+	# ── Caso 6: Pendiente Cancelación ────────────────────────────────────
+	def test_pendiente_cancelacion(self):
+		comp = _mock_comp(status="Pendiente Cancelación", uuid_sat="UUID-123")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(comp)
+		self.assertTrue(facts["is_pendiente_cancelacion"])
+
+
+class TestFiscalStateComplementoActions(FrappeTestCase):
+	def _base(self, **overrides):
+		facts = {
+			"is_draft": True,
+			"is_submitted": False,
+			"is_cancelled": False,
+			"status": "Timbrado",
+			"is_timbrado": True,
+			"is_cancelado": False,
+			"is_pendiente": False,
+			"is_error": False,
+			"is_pendiente_cancelacion": False,
+			"has_uuid": True,
+			"has_facturapi_id": True,
+			"has_xml": True,
+			"has_pdf": True,
+			"has_payment_entry": True,
+			"pe_submitted": True,
+			"pe_cancelled": False,
+			"has_documentos_relacionados": True,
+		}
+		facts.update(overrides)
+		return facts
+
+	def test_puede_timbrar_pendiente(self):
+		facts = self._base(status="Pendiente", is_timbrado=False, is_pendiente=True, has_uuid=False)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_stamp"])
+		self.assertFalse(actions["can_cancel"])
+
+	def test_puede_timbrar_error(self):
+		facts = self._base(status="Error", is_timbrado=False, is_error=True, has_uuid=False)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_stamp"])
+
+	def test_puede_cancelar_timbrado(self):
+		facts = self._base()
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_cancel"])
+		self.assertFalse(actions["can_stamp"])
+
+	def test_puede_reintentar_cancelacion(self):
+		facts = self._base(status="Pendiente Cancelación", is_timbrado=False, is_pendiente_cancelacion=True)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_retry_cancel"])
+		self.assertFalse(actions["can_cancel"])
+
+	def test_puede_descargar(self):
+		facts = self._base()
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_download_xml"])
+		self.assertTrue(actions["can_download_pdf"])
+
+	def test_no_puede_descargar_sin_uuid(self):
+		facts = self._base(has_uuid=False, has_xml=False, has_pdf=False)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_download_xml"])
+		self.assertFalse(actions["can_download_pdf"])
+
+
+class TestFiscalStateComplementoMessages(FrappeTestCase):
+	def _base(self, **overrides):
+		facts = {
+			"is_timbrado": True,
+			"is_cancelado": False,
+			"is_pendiente": False,
+			"is_error": False,
+			"is_pendiente_cancelacion": False,
+			"has_uuid": True,
+			"has_xml": True,
+			"has_pdf": True,
+			"has_documentos_relacionados": True,
+			"pe_submitted": True,
+			"pe_cancelled": False,
+		}
+		facts.update(overrides)
+		return facts
+
+	def test_pendiente_con_docs(self):
+		codes = [m["code"] for m in _compute_messages(self._base(is_timbrado=False, is_pendiente=True))]
+		self.assertIn("PENDING_STAMP", codes)
+
+	def test_pendiente_sin_docs(self):
+		codes = [
+			m["code"]
+			for m in _compute_messages(
+				self._base(is_timbrado=False, is_pendiente=True, has_documentos_relacionados=False)
+			)
+		]
+		self.assertIn("MISSING_RELATED_DOCS", codes)
+		self.assertNotIn("PENDING_STAMP", codes)
+
+	def test_timbrado(self):
+		codes = [m["code"] for m in _compute_messages(self._base())]
+		self.assertIn("CFDI_STAMPED", codes)
+
+	def test_timbrado_sin_archivos(self):
+		codes = [m["code"] for m in _compute_messages(self._base(has_xml=False, has_pdf=False))]
+		self.assertIn("FILES_MISSING", codes)
+
+	def test_timbrado_pe_cancelado(self):
+		codes = [m["code"] for m in _compute_messages(self._base(pe_cancelled=True))]
+		self.assertIn("CFDI_STAMPED", codes)
+		self.assertIn("PE_CANCELLED", codes)
+
+	def test_cancelado(self):
+		codes = [m["code"] for m in _compute_messages(self._base(is_timbrado=False, is_cancelado=True))]
+		self.assertIn("CFDI_CANCELLED", codes)
+
+	def test_error(self):
+		codes = [m["code"] for m in _compute_messages(self._base(is_timbrado=False, is_error=True))]
+		self.assertIn("STAMP_ERROR", codes)
+
+	def test_pendiente_cancelacion(self):
+		codes = [
+			m["code"] for m in _compute_messages(self._base(is_timbrado=False, is_pendiente_cancelacion=True))
+		]
+		self.assertIn("CANCELLATION_PENDING", codes)

--- a/facturacion_mexico/tests/test_fiscal_state_complemento.py
+++ b/facturacion_mexico/tests/test_fiscal_state_complemento.py
@@ -125,8 +125,8 @@ class TestFiscalStateComplementoFacts(FrappeTestCase):
 class TestFiscalStateComplementoActions(FrappeTestCase):
 	def _base(self, **overrides):
 		facts = {
-			"is_draft": True,
-			"is_submitted": False,
+			"is_draft": False,
+			"is_submitted": True,
 			"is_cancelled": False,
 			"status": "Timbrado",
 			"is_timbrado": True,
@@ -147,13 +147,29 @@ class TestFiscalStateComplementoActions(FrappeTestCase):
 		return facts
 
 	def test_puede_timbrar_pendiente(self):
-		facts = self._base(status="Pendiente", is_timbrado=False, is_pendiente=True, has_uuid=False)
+		"""Timbrar requiere docstatus=0 (draft) con status Pendiente."""
+		facts = self._base(
+			is_draft=True,
+			is_submitted=False,
+			status="Pendiente",
+			is_timbrado=False,
+			is_pendiente=True,
+			has_uuid=False,
+		)
 		actions = _compute_actions(facts)
 		self.assertTrue(actions["can_stamp"])
 		self.assertFalse(actions["can_cancel"])
 
 	def test_puede_timbrar_error(self):
-		facts = self._base(status="Error", is_timbrado=False, is_error=True, has_uuid=False)
+		"""Timbrar requiere docstatus=0 (draft) con status Error."""
+		facts = self._base(
+			is_draft=True,
+			is_submitted=False,
+			status="Error",
+			is_timbrado=False,
+			is_error=True,
+			has_uuid=False,
+		)
 		actions = _compute_actions(facts)
 		self.assertTrue(actions["can_stamp"])
 

--- a/facturacion_mexico/tests/test_fiscal_state_ffm.py
+++ b/facturacion_mexico/tests/test_fiscal_state_ffm.py
@@ -1,0 +1,291 @@
+"""
+Tests para fiscal_state/ffm_state.py
+
+Casos cubiertos:
+  1. FFM borrador → sin mensajes
+  2. FFM submitted BORRADOR con tax_system válido → PENDING_STAMP, can_stamp=True
+  3. FFM submitted BORRADOR sin tax_system → TAX_SYSTEM_INVALID, can_stamp=False
+  4. FFM submitted TIMBRADO sin PE activo → CFDI_STAMPED, can_cancel=True
+  5. FFM submitted TIMBRADO con PE activo → CANCEL_BLOCKED_ACTIVE_PE, can_cancel=False
+  6. FFM submitted CANCELADO → CFDI_CANCELLED, can_cancel=False
+  7. FFM submitted PENDIENTE_CANCELACION → CANCELLATION_PENDING, can_retry_cancel=True
+  8. FFM submitted ERROR → STAMP_ERROR
+  9. sync_pending bloquea acciones
+  10. Actions derivadas correctamente
+"""
+
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.fiscal_state.ffm_state import (
+	_compute_actions,
+	_compute_facts,
+	_compute_messages,
+)
+
+
+def _mock_ffm(
+	docstatus=1,
+	status="BORRADOR",
+	fm_uuid="",
+	facturapi_id="",
+	fm_tipo_comprobante="I - Ingreso",
+	fm_payment_method_sat="PUE",
+	fm_xml_url="",
+	fm_pdf_url="",
+	fm_motivo_cancelacion="",
+	cancellation_reason="",
+	fm_sync_status="idle",
+	fm_tax_system="601 - General de Ley",
+	sales_invoice="",
+):
+	ffm = MagicMock()
+	ffm.docstatus = docstatus
+	ffm.name = "FFMX-TEST"
+
+	attrs = {
+		"status": status,
+		"fm_uuid": fm_uuid,
+		"facturapi_id": facturapi_id,
+		"fm_tipo_comprobante": fm_tipo_comprobante,
+		"fm_payment_method_sat": fm_payment_method_sat,
+		"fm_xml_url": fm_xml_url,
+		"fm_pdf_url": fm_pdf_url,
+		"fm_motivo_cancelacion": fm_motivo_cancelacion,
+		"cancellation_reason": cancellation_reason,
+		"fm_sync_status": fm_sync_status,
+		"fm_tax_system": fm_tax_system,
+		"sales_invoice": sales_invoice,
+	}
+	ffm.get = lambda key, default=None: attrs.get(key, default)
+	return ffm
+
+
+class TestFiscalStateFFMFacts(FrappeTestCase):
+	# ── Caso 1: borrador ──────────────────────────────────────────────────
+	def test_borrador_docstatus(self):
+		ffm = _mock_ffm(docstatus=0)
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(ffm)
+		self.assertTrue(facts["is_draft"])
+		self.assertFalse(facts["is_submitted"])
+
+	# ── Caso 2: TIMBRADO con uuid ─────────────────────────────────────────
+	def test_timbrado_con_uuid(self):
+		ffm = _mock_ffm(status="TIMBRADO", fm_uuid="UUID-123", facturapi_id="FAP-001")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(ffm)
+		self.assertTrue(facts["is_timbrado"])
+		self.assertTrue(facts["has_uuid"])
+		self.assertTrue(facts["has_facturapi_id"])
+		self.assertFalse(facts["has_active_payment_entry"])
+
+	# ── Caso 3: TIMBRADO con PE activo ───────────────────────────────────
+	def test_timbrado_con_pe_activo(self):
+		ffm = _mock_ffm(status="TIMBRADO", fm_uuid="UUID-123", sales_invoice="SI-001")
+		pe_refs = [{"parent": "PE-001"}]
+		submitted_pe = [{"name": "PE-001"}]
+		with patch("frappe.get_all", side_effect=[pe_refs, submitted_pe]):
+			facts = _compute_facts(ffm)
+		self.assertTrue(facts["has_active_payment_entry"])
+		self.assertTrue(facts["has_sales_invoice"])
+
+	# ── Caso 4: CANCELADO ────────────────────────────────────────────────
+	def test_cancelado(self):
+		ffm = _mock_ffm(status="CANCELADO", fm_uuid="UUID-123", fm_motivo_cancelacion="02")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(ffm)
+		self.assertTrue(facts["is_cancelado"])
+		self.assertEqual(facts["motivo_cancelacion"], "02")
+
+	# ── Caso 5: sync_pending ─────────────────────────────────────────────
+	def test_sync_pending(self):
+		ffm = _mock_ffm(fm_sync_status="pending")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(ffm)
+		self.assertTrue(facts["sync_pending"])
+
+	# ── Caso 6: tax_system inválido ───────────────────────────────────────
+	def test_tax_system_invalido(self):
+		ffm = _mock_ffm(fm_tax_system="⚠️ Sin configurar")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(ffm)
+		self.assertFalse(facts["tax_system_valid"])
+
+	def test_tax_system_valido(self):
+		ffm = _mock_ffm(fm_tax_system="601 - General de Ley")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(ffm)
+		self.assertTrue(facts["tax_system_valid"])
+
+	# ── Caso 7: PPD vs PUE ───────────────────────────────────────────────
+	def test_ppd(self):
+		ffm = _mock_ffm(fm_payment_method_sat="PPD")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(ffm)
+		self.assertTrue(facts["is_ppd"])
+		self.assertFalse(facts["is_pue"])
+
+	def test_pue(self):
+		ffm = _mock_ffm(fm_payment_method_sat="PUE")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(ffm)
+		self.assertFalse(facts["is_ppd"])
+		self.assertTrue(facts["is_pue"])
+
+
+class TestFiscalStateFFMActions(FrappeTestCase):
+	def _base(self, **overrides):
+		facts = {
+			"is_draft": False,
+			"is_submitted": True,
+			"is_cancelled": False,
+			"status": "TIMBRADO",
+			"is_timbrado": True,
+			"is_cancelado": False,
+			"is_pendiente_cancelacion": False,
+			"is_borrador": False,
+			"is_error": False,
+			"sync_pending": False,
+			"has_uuid": True,
+			"has_facturapi_id": True,
+			"has_xml": True,
+			"has_pdf": True,
+			"tax_system_valid": True,
+			"has_active_payment_entry": False,
+			"has_sales_invoice": True,
+		}
+		facts.update(overrides)
+		return facts
+
+	def test_can_stamp_borrador(self):
+		facts = self._base(status="BORRADOR", is_timbrado=False, is_borrador=True, has_uuid=False)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_stamp"])
+		self.assertFalse(actions["can_cancel"])
+
+	def test_no_puede_timbrar_sin_tax_system(self):
+		facts = self._base(
+			status="BORRADOR", is_timbrado=False, is_borrador=True, has_uuid=False, tax_system_valid=False
+		)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_stamp"])
+
+	def test_puede_cancelar_timbrado_sin_pe(self):
+		facts = self._base()
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_cancel"])
+		self.assertFalse(actions["can_stamp"])
+
+	def test_no_puede_cancelar_con_pe_activo(self):
+		facts = self._base(has_active_payment_entry=True)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_cancel"])
+
+	def test_no_puede_cancelar_con_sync_pending(self):
+		facts = self._base(sync_pending=True)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_cancel"])
+		self.assertFalse(actions["can_stamp"])
+
+	def test_puede_reintentar_cancelacion(self):
+		facts = self._base(status="PENDIENTE_CANCELACION", is_timbrado=False, is_pendiente_cancelacion=True)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_retry_cancel"])
+		self.assertFalse(actions["can_cancel"])
+
+	def test_puede_descargar_archivos(self):
+		facts = self._base()
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_download_xml"])
+		self.assertTrue(actions["can_download_pdf"])
+		self.assertTrue(actions["can_send_email"])
+
+	def test_no_puede_descargar_sin_uuid(self):
+		facts = self._base(has_uuid=False, has_xml=False, has_pdf=False)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_download_xml"])
+		self.assertFalse(actions["can_download_pdf"])
+
+
+class TestFiscalStateFFMMessages(FrappeTestCase):
+	def _base(self, **overrides):
+		facts = {
+			"is_submitted": True,
+			"status": "TIMBRADO",
+			"is_timbrado": True,
+			"is_cancelado": False,
+			"is_pendiente_cancelacion": False,
+			"is_borrador": False,
+			"is_error": False,
+			"sync_pending": False,
+			"has_uuid": True,
+			"has_facturapi_id": True,
+			"has_xml": True,
+			"has_pdf": True,
+			"tax_system_valid": True,
+			"has_active_payment_entry": False,
+		}
+		facts.update(overrides)
+		return facts
+
+	def test_sin_mensajes_borrador(self):
+		msgs = _compute_messages(self._base(is_submitted=False))
+		self.assertEqual(msgs, [])
+
+	def test_sync_pending(self):
+		codes = [m["code"] for m in _compute_messages(self._base(sync_pending=True))]
+		self.assertIn("SYNC_PENDING", codes)
+
+	def test_pending_stamp(self):
+		codes = [
+			m["code"]
+			for m in _compute_messages(self._base(status="BORRADOR", is_timbrado=False, is_borrador=True))
+		]
+		self.assertIn("PENDING_STAMP", codes)
+
+	def test_tax_system_invalid(self):
+		codes = [
+			m["code"]
+			for m in _compute_messages(
+				self._base(status="BORRADOR", is_timbrado=False, is_borrador=True, tax_system_valid=False)
+			)
+		]
+		self.assertIn("TAX_SYSTEM_INVALID", codes)
+		self.assertNotIn("PENDING_STAMP", codes)
+
+	def test_cfdi_stamped(self):
+		codes = [m["code"] for m in _compute_messages(self._base())]
+		self.assertIn("CFDI_STAMPED", codes)
+
+	def test_files_missing(self):
+		codes = [m["code"] for m in _compute_messages(self._base(has_xml=False, has_pdf=False))]
+		self.assertIn("FILES_MISSING", codes)
+
+	def test_cancel_blocked_active_pe(self):
+		codes = [m["code"] for m in _compute_messages(self._base(has_active_payment_entry=True))]
+		self.assertIn("CANCEL_BLOCKED_ACTIVE_PE", codes)
+		self.assertIn("CFDI_STAMPED", codes)
+
+	def test_cfdi_cancelled(self):
+		codes = [
+			m["code"]
+			for m in _compute_messages(self._base(status="CANCELADO", is_timbrado=False, is_cancelado=True))
+		]
+		self.assertIn("CFDI_CANCELLED", codes)
+
+	def test_cancellation_pending(self):
+		codes = [
+			m["code"]
+			for m in _compute_messages(
+				self._base(status="PENDIENTE_CANCELACION", is_timbrado=False, is_pendiente_cancelacion=True)
+			)
+		]
+		self.assertIn("CANCELLATION_PENDING", codes)
+
+	def test_stamp_error(self):
+		codes = [
+			m["code"] for m in _compute_messages(self._base(status="ERROR", is_timbrado=False, is_error=True))
+		]
+		self.assertIn("STAMP_ERROR", codes)

--- a/facturacion_mexico/tests/test_fiscal_state_payment_entry.py
+++ b/facturacion_mexico/tests/test_fiscal_state_payment_entry.py
@@ -1,0 +1,276 @@
+"""
+Tests para fiscal_state/payment_entry_state.py y el endpoint get_fiscal_ui_state.
+
+Casos cubiertos (unitarios con mocks):
+  1. PE Receive PPD timbrado sin complemento → COMPLEMENT_REQUIRED
+  2. PE Receive PPD timbrado con complemento activo (Timbrado) → COMPLEMENT_EXISTS
+  3. PE Receive PPD timbrado con complemento cancelado → COMPLEMENT_CANCELLED
+  4. PE Receive PPD timbrado con complemento en error → COMPLEMENT_ERROR
+  5. PE Receive PPD sin SI timbrada → COMPLEMENT_BLOCKED_NO_STAMPED_SI
+  6. PE Receive PUE → COMPLEMENT_NOT_REQUIRED
+  7. PE cancelado → sin mensajes
+  8. Actions derivadas correctamente por estado
+
+Ejecutar:
+  bench --site test-facturacion.localhost execute facturacion_mexico.tests.ci_pre_tests.run
+  bench --site test-facturacion.localhost run-tests --app facturacion_mexico \
+    --module facturacion_mexico.tests.test_fiscal_state_payment_entry --lightmode
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.fiscal_state.payment_entry_state import (
+	_compute_actions,
+	_compute_facts,
+	_compute_messages,
+	get_payment_entry_fiscal_state,
+)
+
+
+def _mock_pe(
+	docstatus=1,
+	payment_type="Receive",
+	party_type="Customer",
+	references=None,
+	fm_require_complement=0,
+	fm_complemento_pago=None,
+):
+	"""Crea un mock de Payment Entry para tests unitarios."""
+	pe = MagicMock()
+	pe.docstatus = docstatus
+	pe.payment_type = payment_type
+	pe.party_type = party_type
+	pe.fm_require_complement = fm_require_complement
+	pe.fm_complemento_pago = fm_complemento_pago
+
+	ref_list = references or []
+	pe.get = lambda key, default=None: ref_list if key == "references" else getattr(pe, key, default)
+
+	return pe
+
+
+def _si_ref(name, is_ppd=True, fiscal_status="TIMBRADO", allocated=1000):
+	ref = MagicMock()
+	ref.reference_doctype = "Sales Invoice"
+	ref.reference_name = name
+	ref.allocated_amount = allocated
+	return ref
+
+
+class TestFiscalStatePaymentEntryFacts(FrappeTestCase):
+	"""Tests unitarios para _compute_facts()."""
+
+	def _facts(self, pe, si_data=None, comp_data=None):
+		"""Helper: computa facts con datos controlados vía mocks."""
+		si_return = si_data if si_data is not None else []
+		comp_return = comp_data if comp_data is not None else []
+
+		with patch(
+			"frappe.get_all", side_effect=[si_return, comp_return] if comp_data is not None else [si_return]
+		):
+			return _compute_facts(pe)
+
+	# ── Caso 1: PPD timbrada, sin complemento ─────────────────────────────
+	def test_ppd_timbrada_sin_complemento(self):
+		pe = _mock_pe(fm_require_complement=1, references=[_si_ref("SI-001")])
+		with patch(
+			"frappe.get_all",
+			return_value=[{"name": "SI-001", "fm_es_ppd": 1, "fm_fiscal_status": "TIMBRADO"}],
+		):
+			facts = _compute_facts(pe)
+		self.assertTrue(facts["has_ppd_invoice"])
+		self.assertTrue(facts["has_ppd_stamped_invoice"])
+		self.assertTrue(facts["requires_complement"])
+		self.assertFalse(facts["has_complement"])
+		self.assertFalse(facts["has_active_complement"])
+
+	# ── Caso 2: PPD timbrada, complemento activo ──────────────────────────
+	def test_ppd_con_complemento_timbrado(self):
+		pe = _mock_pe(fm_require_complement=1, fm_complemento_pago="COMP-001", references=[_si_ref("SI-001")])
+		si_data = [{"name": "SI-001", "fm_es_ppd": 1, "fm_fiscal_status": "TIMBRADO"}]
+		comp_data = [
+			{"name": "COMP-001", "status": "Timbrado", "uuid_sat": "UUID-123", "facturapi_id": "FAP-001"}
+		]
+		with patch("frappe.get_all", side_effect=[si_data, comp_data]):
+			facts = _compute_facts(pe)
+		self.assertTrue(facts["has_active_complement"])
+		self.assertFalse(facts["has_cancelled_complement"])
+		self.assertEqual(facts["complement_status"], "Timbrado")
+		self.assertTrue(facts["complement_has_uuid"])
+		self.assertTrue(facts["complement_has_file"])
+
+	# ── Caso 3: complemento cancelado ────────────────────────────────────
+	def test_complemento_cancelado(self):
+		pe = _mock_pe(fm_require_complement=1, fm_complemento_pago="COMP-001", references=[_si_ref("SI-001")])
+		si_data = [{"name": "SI-001", "fm_es_ppd": 1, "fm_fiscal_status": "TIMBRADO"}]
+		comp_data = [
+			{"name": "COMP-001", "status": "Cancelado", "uuid_sat": "UUID-123", "facturapi_id": "FAP-001"}
+		]
+		with patch("frappe.get_all", side_effect=[si_data, comp_data]):
+			facts = _compute_facts(pe)
+		self.assertFalse(facts["has_active_complement"])
+		self.assertTrue(facts["has_cancelled_complement"])
+		self.assertFalse(facts["has_complement_error"])
+
+	# ── Caso 4: complemento con error ────────────────────────────────────
+	def test_complemento_error(self):
+		pe = _mock_pe(fm_require_complement=1, fm_complemento_pago="COMP-001", references=[_si_ref("SI-001")])
+		si_data = [{"name": "SI-001", "fm_es_ppd": 1, "fm_fiscal_status": "TIMBRADO"}]
+		comp_data = [{"name": "COMP-001", "status": "Error", "uuid_sat": None, "facturapi_id": None}]
+		with patch("frappe.get_all", side_effect=[si_data, comp_data]):
+			facts = _compute_facts(pe)
+		self.assertTrue(facts["has_complement_error"])
+		self.assertFalse(facts["has_active_complement"])
+
+	# ── Caso 5: PPD sin SI timbrada ───────────────────────────────────────
+	def test_ppd_sin_si_timbrada(self):
+		pe = _mock_pe(fm_require_complement=0, references=[_si_ref("SI-001")])
+		si_data = [{"name": "SI-001", "fm_es_ppd": 1, "fm_fiscal_status": "BORRADOR"}]
+		with patch("frappe.get_all", return_value=si_data):
+			facts = _compute_facts(pe)
+		self.assertTrue(facts["has_ppd_invoice"])
+		self.assertFalse(facts["has_ppd_stamped_invoice"])
+		self.assertFalse(facts["requires_complement"])
+
+	# ── Caso 6: PUE ───────────────────────────────────────────────────────
+	def test_pue_no_requiere_complemento(self):
+		pe = _mock_pe(fm_require_complement=0, references=[_si_ref("SI-001")])
+		si_data = [{"name": "SI-001", "fm_es_ppd": 0, "fm_fiscal_status": "TIMBRADO"}]
+		with patch("frappe.get_all", return_value=si_data):
+			facts = _compute_facts(pe)
+		self.assertFalse(facts["has_ppd_invoice"])
+		self.assertFalse(facts["requires_complement"])
+
+	# ── Caso 7: PE cancelado ──────────────────────────────────────────────
+	def test_pe_cancelado_estado_documental(self):
+		pe = _mock_pe(docstatus=2)
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(pe)
+		self.assertFalse(facts["is_submitted"])
+		self.assertTrue(facts["is_cancelled"])
+
+
+class TestFiscalStatePaymentEntryActions(FrappeTestCase):
+	"""Tests unitarios para _compute_actions() — solo lógica derivada, sin BD."""
+
+	def test_can_create_complement_cuando_requiere_y_no_tiene(self):
+		facts = {
+			"is_submitted": True,
+			"payment_type": "Receive",
+			"requires_complement": True,
+			"has_active_complement": False,
+			"has_cancelled_complement": False,
+			"has_complement": False,
+			"has_complement_error": False,
+			"complement_status": None,
+			"complement_has_file": False,
+		}
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_create_complement"])
+		self.assertFalse(actions["can_view_complement"])
+
+	def test_no_puede_crear_si_ya_tiene_activo(self):
+		facts = {
+			"is_submitted": True,
+			"payment_type": "Receive",
+			"requires_complement": True,
+			"has_active_complement": True,
+			"has_cancelled_complement": False,
+			"has_complement": True,
+			"has_complement_error": False,
+			"complement_status": "Timbrado",
+			"complement_has_file": True,
+		}
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_create_complement"])
+		self.assertTrue(actions["can_view_complement"])
+		self.assertTrue(actions["can_cancel_complement"])
+		self.assertTrue(actions["can_download_complement_xml"])
+
+	def test_puede_reintentar_si_error(self):
+		facts = {
+			"is_submitted": True,
+			"payment_type": "Receive",
+			"requires_complement": True,
+			"has_active_complement": False,
+			"has_cancelled_complement": False,
+			"has_complement": True,
+			"has_complement_error": True,
+			"complement_status": "Error",
+			"complement_has_file": False,
+		}
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_retry_complement"])
+		self.assertFalse(actions["can_cancel_complement"])
+
+
+class TestFiscalStatePaymentEntryMessages(FrappeTestCase):
+	"""Tests unitarios para _compute_messages() — solo lógica de mensajes."""
+
+	def _base_facts(self, **overrides):
+		facts = {
+			"is_submitted": True,
+			"is_cancelled": False,
+			"is_draft": False,
+			"payment_type": "Receive",
+			"party_type": "Customer",
+			"has_ppd_invoice": True,
+			"has_ppd_stamped_invoice": True,
+			"requires_complement": True,
+			"has_complement": False,
+			"has_active_complement": False,
+			"has_cancelled_complement": False,
+			"has_complement_error": False,
+			"complement_status": None,
+			"complement_has_uuid": False,
+			"complement_has_file": False,
+			"has_sales_invoice_references": True,
+			"has_allocated_sales_invoice_references": True,
+		}
+		facts.update(overrides)
+		return facts
+
+	def test_mensaje_complement_required(self):
+		msgs = _compute_messages(self._base_facts())
+		codes = [m["code"] for m in msgs]
+		self.assertIn("COMPLEMENT_REQUIRED", codes)
+
+	def test_mensaje_complement_exists(self):
+		msgs = _compute_messages(self._base_facts(has_active_complement=True, complement_status="Timbrado"))
+		codes = [m["code"] for m in msgs]
+		self.assertIn("COMPLEMENT_EXISTS", codes)
+
+	def test_mensaje_complement_cancelled(self):
+		msgs = _compute_messages(self._base_facts(has_cancelled_complement=True))
+		codes = [m["code"] for m in msgs]
+		self.assertIn("COMPLEMENT_CANCELLED", codes)
+
+	def test_mensaje_complement_error(self):
+		msgs = _compute_messages(self._base_facts(has_complement_error=True))
+		codes = [m["code"] for m in msgs]
+		self.assertIn("COMPLEMENT_ERROR", codes)
+
+	def test_mensaje_not_required_cuando_pue(self):
+		msgs = _compute_messages(
+			self._base_facts(has_ppd_invoice=False, has_ppd_stamped_invoice=False, requires_complement=False)
+		)
+		codes = [m["code"] for m in msgs]
+		self.assertIn("COMPLEMENT_NOT_REQUIRED", codes)
+
+	def test_mensaje_blocked_ppd_sin_timbrar(self):
+		msgs = _compute_messages(
+			self._base_facts(has_ppd_invoice=True, has_ppd_stamped_invoice=False, requires_complement=False)
+		)
+		codes = [m["code"] for m in msgs]
+		self.assertIn("COMPLEMENT_BLOCKED_NO_STAMPED_SI", codes)
+
+	def test_sin_mensajes_pe_cancelado(self):
+		msgs = _compute_messages(self._base_facts(is_submitted=False, is_cancelled=True))
+		self.assertEqual(msgs, [])
+
+	def test_sin_mensajes_pe_no_receive(self):
+		msgs = _compute_messages(self._base_facts(payment_type="Pay"))
+		self.assertEqual(msgs, [])

--- a/facturacion_mexico/tests/test_fiscal_state_sales_invoice.py
+++ b/facturacion_mexico/tests/test_fiscal_state_sales_invoice.py
@@ -1,0 +1,350 @@
+"""
+Tests para fiscal_state/sales_invoice_state.py
+
+Casos cubiertos:
+  1. SI borrador → BLOCKED_DRAFT, sin acciones
+  2. SI submitted sin FFM → CFDI_NOT_STAMPED, can_stamp=True
+  3. SI submitted con FFM timbrada (PUE) → CFDI_STAMPED, can_cancel=True
+  4. SI submitted con FFM timbrada (PPD) + PE + sin complemento → COMPLEMENT_REQUIRED
+  5. SI submitted con FFM timbrada (PPD) + PE + complemento activo → COMPLEMENT_EXISTS
+  6. SI submitted con FFM cancelada motivo 02 → CFDI_CANCELLED, can_refacturar=True
+  7. SI submitted con FFM cancelada motivo 01 → can_substitute=False (motivo 01 no es refacturar)
+  8. SI cancelada → BLOCKED_CANCELLED
+  9. Actions derivadas correctamente
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.fiscal_state.sales_invoice_state import (
+	_compute_actions,
+	_compute_facts,
+	_compute_messages,
+)
+
+
+def _mock_si(
+	docstatus=1,
+	fm_fiscal_status="",
+	fm_factura_fiscal_mx="",
+	fm_es_ppd=0,
+	is_return=0,
+	outstanding_amount=1000,
+	grand_total=1000,
+):
+	si = MagicMock()
+	si.docstatus = docstatus
+	si.name = "ACC-SINV-TEST"
+	si.fm_fiscal_status = fm_fiscal_status
+	si.fm_factura_fiscal_mx = fm_factura_fiscal_mx
+	si.fm_es_ppd = fm_es_ppd
+	si.is_return = is_return
+	si.outstanding_amount = outstanding_amount
+	si.grand_total = grand_total
+
+	def _get(key, default=None):
+		return getattr(si, key, default)
+
+	si.get = _get
+	return si
+
+
+def _ffm(status="TIMBRADO", fm_uuid="UUID-123", motivo=None, docstatus=1):
+	return [
+		{
+			"name": "FFMX-TEST",
+			"status": status,
+			"fm_uuid": fm_uuid,
+			"fm_motivo_cancelacion": motivo,
+			"docstatus": docstatus,
+		}
+	]
+
+
+class TestFiscalStateSIFacts(FrappeTestCase):
+	# ── Caso 1: borrador ──────────────────────────────────────────────────
+	def test_borrador(self):
+		si = _mock_si(docstatus=0, fm_fiscal_status="")
+		with patch("frappe.get_all", return_value=[]), patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(si)
+		self.assertTrue(facts["is_draft"])
+		self.assertFalse(facts["is_submitted"])
+
+	# ── Caso 2: submitted sin FFM ─────────────────────────────────────────
+	def test_submitted_sin_ffm(self):
+		si = _mock_si(fm_fiscal_status="BORRADOR")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(si)
+		self.assertTrue(facts["is_submitted"])
+		self.assertFalse(facts["has_ffm"])
+		self.assertFalse(facts["has_stamped_ffm"])
+		self.assertEqual(facts["fiscal_status"], "BORRADOR")
+
+	# ── Caso 3: FFM timbrada PUE ─────────────────────────────────────────
+	def test_ffm_timbrada_pue(self):
+		si = _mock_si(fm_fiscal_status="TIMBRADO", fm_factura_fiscal_mx="FFMX-001", fm_es_ppd=0)
+		with patch("frappe.get_all", side_effect=[_ffm(), [], [], []]):
+			facts = _compute_facts(si)
+		self.assertTrue(facts["has_ffm"])
+		self.assertTrue(facts["has_stamped_ffm"])
+		self.assertTrue(facts["has_active_ffm"])
+		self.assertFalse(facts["has_cancelled_ffm"])
+		self.assertFalse(facts["is_ppd"])
+		self.assertFalse(facts["requires_complement"])
+
+	# ── Caso 4: FFM timbrada PPD + PE submitted + sin complemento ─────────
+	def test_ppd_con_pe_sin_complemento(self):
+		si = _mock_si(fm_fiscal_status="TIMBRADO", fm_factura_fiscal_mx="FFMX-001", fm_es_ppd=1)
+		ffm_data = _ffm()
+		pe_refs = [{"parent": "PE-001"}]
+		submitted_pe = [{"name": "PE-001"}]
+		comps = []
+
+		with patch("frappe.get_all", side_effect=[ffm_data, [], pe_refs, submitted_pe, submitted_pe, comps]):
+			facts = _compute_facts(si)
+
+		self.assertTrue(facts["is_ppd"])
+		self.assertTrue(facts["has_submitted_payment_entries"])
+		self.assertTrue(facts["requires_complement"])
+		self.assertFalse(facts["has_active_complement"])
+
+	# ── Caso 5: PPD con complemento activo ───────────────────────────────
+	def test_ppd_con_complemento_activo(self):
+		si = _mock_si(fm_fiscal_status="TIMBRADO", fm_factura_fiscal_mx="FFMX-001", fm_es_ppd=1)
+		ffm_data = _ffm()
+		pe_refs = [{"parent": "PE-001"}]
+		submitted_pe = [{"name": "PE-001"}]
+		comps = [{"name": "COMP-001", "status": "Timbrado"}]
+
+		with patch("frappe.get_all", side_effect=[ffm_data, [], pe_refs, submitted_pe, submitted_pe, comps]):
+			facts = _compute_facts(si)
+
+		self.assertTrue(facts["has_complement"])
+		self.assertTrue(facts["has_active_complement"])
+
+	# ── Caso 6: FFM cancelada motivo 02 ──────────────────────────────────
+	def test_ffm_cancelada_motivo_02(self):
+		si = _mock_si(fm_fiscal_status="CANCELADO", fm_factura_fiscal_mx="FFMX-001")
+		ffm_data = _ffm(status="CANCELADO", motivo="02")
+
+		with patch("frappe.get_all", side_effect=[ffm_data, [], [], []]):
+			facts = _compute_facts(si)
+
+		self.assertTrue(facts["has_cancelled_ffm"])
+		self.assertFalse(facts["has_active_ffm"])
+		self.assertEqual(facts["ffm_motivo_cancelacion"], "02")
+
+	# ── Caso 7: cancelada ────────────────────────────────────────────────
+	def test_si_cancelada(self):
+		si = _mock_si(docstatus=2, fm_fiscal_status="CANCELADO")
+		with patch("frappe.get_all", return_value=[]):
+			facts = _compute_facts(si)
+		self.assertTrue(facts["is_cancelled"])
+		self.assertFalse(facts["is_submitted"])
+
+
+class TestFiscalStateSIActions(FrappeTestCase):
+	def _base_facts(self, **overrides):
+		facts = {
+			"is_draft": False,
+			"is_submitted": True,
+			"is_cancelled": False,
+			"is_ppd": False,
+			"is_pue": True,
+			"fiscal_status": "TIMBRADO",
+			"has_ffm": True,
+			"has_active_ffm": True,
+			"has_cancelled_ffm": False,
+			"has_stamped_ffm": True,
+			"has_uuid": True,
+			"has_xml": True,
+			"has_pdf": True,
+			"outstanding_amount": 0,
+			"is_paid": True,
+			"is_partially_paid": False,
+			"has_payment_entries": False,
+			"has_submitted_payment_entries": False,
+			"requires_complement": False,
+			"has_complement": False,
+			"has_active_complement": False,
+			"ffm_motivo_cancelacion": None,
+		}
+		facts.update(overrides)
+		return facts
+
+	def test_can_stamp_cuando_sin_ffm(self):
+		facts = self._base_facts(
+			fiscal_status="BORRADOR",
+			has_ffm=False,
+			has_active_ffm=False,
+			has_stamped_ffm=False,
+			has_uuid=False,
+			has_xml=False,
+			has_pdf=False,
+		)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_stamp"])
+		self.assertFalse(actions["can_view_ffm"])
+
+	def test_no_puede_timbrar_si_tiene_ffm_activa(self):
+		facts = self._base_facts()
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_stamp"])
+		self.assertTrue(actions["can_view_ffm"])
+		self.assertTrue(actions["can_cancel_cfdi"])
+
+	def test_puede_refacturar_motivo_02(self):
+		facts = self._base_facts(
+			fiscal_status="CANCELADO",
+			has_active_ffm=False,
+			has_cancelled_ffm=True,
+			ffm_motivo_cancelacion="02",
+		)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_refacturar"])
+		self.assertFalse(actions["can_cancel_cfdi"])
+
+	def test_no_puede_refacturar_motivo_01(self):
+		facts = self._base_facts(
+			fiscal_status="CANCELADO",
+			has_active_ffm=False,
+			has_cancelled_ffm=True,
+			ffm_motivo_cancelacion="01",
+		)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_refacturar"])
+
+	def test_puede_sustituir_cuando_timbrado(self):
+		facts = self._base_facts(fiscal_status="TIMBRADO")
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_substitute"])
+
+	def test_puede_generar_complemento_ppd(self):
+		facts = self._base_facts(
+			is_ppd=True,
+			is_pue=False,
+			has_submitted_payment_entries=True,
+			requires_complement=True,
+			has_active_complement=False,
+		)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_generate_payment_complement"])
+
+	def test_no_puede_cancelar_si_tiene_complemento_activo(self):
+		facts = self._base_facts(has_active_complement=True)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_cancel_cfdi"])
+
+
+class TestFiscalStateSIMessages(FrappeTestCase):
+	def _base(self, **overrides):
+		facts = {
+			"is_draft": False,
+			"is_submitted": True,
+			"is_cancelled": False,
+			"fiscal_status": "TIMBRADO",
+			"has_stamped_ffm": True,
+			"has_cancelled_ffm": False,
+			"has_uuid": True,
+			"has_xml": True,
+			"has_pdf": True,
+			"requires_complement": False,
+			"has_complement": False,
+			"has_active_complement": False,
+			"ffm_motivo_cancelacion": None,
+		}
+		facts.update(overrides)
+		return facts
+
+	def test_borrador(self):
+		codes = [m["code"] for m in _compute_messages(self._base(is_draft=True, is_submitted=False))]
+		self.assertIn("BLOCKED_DRAFT", codes)
+
+	def test_cancelado(self):
+		codes = [m["code"] for m in _compute_messages(self._base(is_cancelled=True, is_submitted=False))]
+		self.assertIn("BLOCKED_CANCELLED", codes)
+
+	def test_cfdi_not_stamped(self):
+		"""CFDI_NOT_STAMPED solo cuando no hay cancelación y no hay UUID."""
+		codes = [
+			m["code"]
+			for m in _compute_messages(
+				self._base(
+					has_stamped_ffm=False,
+					has_uuid=False,
+					fiscal_status="BORRADOR",
+					has_cancelled_ffm=False,
+				)
+			)
+		]
+		self.assertIn("CFDI_NOT_STAMPED", codes)
+		self.assertNotIn("CFDI_CANCELLED", codes)
+
+	def test_cfdi_cancelled_con_uuid(self):
+		"""CFDI_CANCELLED cuando fiscal_status=CANCELADO con UUID."""
+		codes = [m["code"] for m in _compute_messages(self._base(fiscal_status="CANCELADO"))]
+		self.assertIn("CFDI_CANCELLED", codes)
+		self.assertNotIn("CFDI_NOT_STAMPED", codes)
+
+	def test_cfdi_cancelled_sin_uuid(self):
+		"""CFDI_CANCELLED tiene prioridad sobre CFDI_NOT_STAMPED cuando fiscal_status=CANCELADO."""
+		codes = [
+			m["code"]
+			for m in _compute_messages(
+				self._base(
+					fiscal_status="CANCELADO",
+					has_stamped_ffm=False,
+					has_uuid=False,
+					has_cancelled_ffm=False,
+				)
+			)
+		]
+		self.assertIn("CFDI_CANCELLED", codes)
+		self.assertNotIn("CFDI_NOT_STAMPED", codes)
+
+	def test_cfdi_cancelled_por_ffm_cancelada(self):
+		"""CFDI_CANCELLED también cuando has_cancelled_ffm=True aunque fiscal_status no sea CANCELADO."""
+		codes = [
+			m["code"]
+			for m in _compute_messages(
+				self._base(
+					fiscal_status="",
+					has_stamped_ffm=False,
+					has_uuid=False,
+					has_cancelled_ffm=True,
+				)
+			)
+		]
+		self.assertIn("CFDI_CANCELLED", codes)
+		self.assertNotIn("CFDI_NOT_STAMPED", codes)
+
+	def test_cfdi_stamped(self):
+		codes = [m["code"] for m in _compute_messages(self._base())]
+		self.assertIn("CFDI_STAMPED", codes)
+
+	def test_cfdi_files_missing(self):
+		codes = [m["code"] for m in _compute_messages(self._base(has_xml=False, has_pdf=False))]
+		self.assertIn("CFDI_FILES_MISSING", codes)
+
+	def test_cfdi_cancelled(self):
+		codes = [m["code"] for m in _compute_messages(self._base(fiscal_status="CANCELADO"))]
+		self.assertIn("CFDI_CANCELLED", codes)
+
+	def test_complement_required(self):
+		codes = [m["code"] for m in _compute_messages(self._base(requires_complement=True))]
+		self.assertIn("COMPLEMENT_REQUIRED", codes)
+
+	def test_complement_exists(self):
+		codes = [
+			m["code"]
+			for m in _compute_messages(self._base(requires_complement=True, has_active_complement=True))
+		]
+		self.assertIn("COMPLEMENT_EXISTS", codes)
+
+	def test_complement_pending(self):
+		codes = [
+			m["code"] for m in _compute_messages(self._base(requires_complement=True, has_complement=True))
+		]
+		self.assertIn("COMPLEMENT_PENDING", codes)

--- a/facturacion_mexico/tests/test_fiscal_state_sales_invoice.py
+++ b/facturacion_mexico/tests/test_fiscal_state_sales_invoice.py
@@ -237,6 +237,47 @@ class TestFiscalStateSIActions(FrappeTestCase):
 		actions = _compute_actions(facts)
 		self.assertFalse(actions["can_cancel_cfdi"])
 
+	# ── can_register_payment ─────────────────────────────────────────────
+	def test_puede_registrar_pago_sin_ffm(self):
+		"""SI submitted sin FFM → can_register_payment = True."""
+		facts = self._base_facts(
+			has_ffm=False,
+			has_active_ffm=False,
+			has_stamped_ffm=False,
+			has_uuid=False,
+			has_xml=False,
+			has_pdf=False,
+			fiscal_status="BORRADOR",
+		)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_register_payment"])
+
+	def test_puede_registrar_pago_con_ffm_activa(self):
+		"""SI submitted con FFM activa (TIMBRADO) → can_register_payment = True."""
+		facts = self._base_facts(fiscal_status="TIMBRADO", has_active_ffm=True)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_register_payment"])
+
+	def test_no_puede_registrar_pago_con_ffm_cancelada(self):
+		"""SI submitted con FFM CANCELADA → can_register_payment = False."""
+		facts = self._base_facts(
+			fiscal_status="CANCELADO",
+			has_ffm=True,
+			has_active_ffm=False,
+			has_cancelled_ffm=True,
+		)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_register_payment"])
+
+	def test_no_puede_registrar_pago_si_cancelada(self):
+		"""SI cancelada (docstatus=2) → can_register_payment = False."""
+		facts = self._base_facts(
+			is_submitted=False,
+			is_cancelled=True,
+		)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_register_payment"])
+
 
 class TestFiscalStateSIMessages(FrappeTestCase):
 	def _base(self, **overrides):


### PR DESCRIPTION
## Objetivo

Crear una fuente única de verdad para decisiones de UI fiscal (botones, mensajes, guards)
en Sales Invoice, Factura Fiscal Mexico, Payment Entry y Complemento Pago MX,
eliminando lógica duplicada y queries async dispersos en múltiples archivos JS.

## Cambios principales

### fiscal_state/ — nuevo módulo Python (read-only)
- `api.py`: endpoint whitelisted `get_fiscal_ui_state(doctype, name)`
- `payment_entry_state.py`: facts, actions, messages para PE
- `sales_invoice_state.py`: facts, actions, messages para SI + can_register_payment
- `ffm_state.py`: facts, actions, messages para FFM
- `complemento_state.py`: facts, actions, messages para Complemento

### Hooks Python
- `check_ppd_requirement()`: implementado (era no-op). Actualiza fm_require_complement
  al guardar PE — fuente única de verdad para estado PPD. Cierra issue #114.

### Migración UI (4 doctypes)
- `complemento_pago_mx.js`: refresh() → get_fiscal_ui_state. Clear headline previene duplicados.
- `payment_entry.js`: refresh() → get_fiscal_ui_state. Cancel guard usa facts.has_active_complement.
- `factura_fiscal_mexico.js`: applyFFMUi() → get_fiscal_ui_state. Elimina load_fiscal_states + _check_active_pe.
- `sales_invoice.js` + `si_post_fiscal_actions.js`: refresh() → get_fiscal_ui_state.

### Roles por DocPerm
- Botón Cancelar en FFM y Complemento usa `frappe.model.can_cancel()` en lugar de
  lista hardcodeada de roles — configurable por cliente sin tocar código.

## Validaciones realizadas

- 91 tests unitarios PASS: PE (18), SI (30), FFM (27), Complemento (20), check_ppd (9)
- Smoke test real en test-fm-v010.localhost: 4 doctypes con documentos reales
- Validación visual en browser para todos los estados fiscales:
  BORRADOR, TIMBRADO, CANCELADO, PENDIENTE_CANCELACION, ERROR
- `sales_invoice_block_cancel.js` sin cambios (realtime events preservados)

## Fuera de alcance

- Migración UI de Factura Global, E-Receipts, Addendas
- fiscal_state es read-only — no modifica comportamiento existente del app

## Riesgos / pendientes

- Requiere `bench build --app facturacion_mexico`
- No requiere `bench migrate` (sin cambios de schema)
- Roles de cancelación dependen de DocPerm configurado correctamente
- Bug conocido: refresh sin reload en FFM cuando PE se cancela externamente (documentado)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized fiscal UI state API to drive form buttons and dashboard messages across invoices, payments and complements.

* **Improvements**
  * Forms now render buttons/alerts consistently from the centralized state; cancel/download/email button visibility and guards updated.
  * Payment Entry now computes and stores complement requirement based on referenced invoices.

* **Tests**
  * Extensive unit/integration tests covering fiscal-state facts, actions and messages for all affected doc types.

* **Documentation**
  * Added ADR and an audit document describing the centralized fiscal UI state design and migration plan.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luisrms69/facturacion_mexico/pull/122)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->