### PR TITLE
fix(reclasificacion): avisar al usuario cuando falta mapeo en Payment Entry (#112 Fase 0)

### DIFF
--- a/docs/development/REPORTE_ISSUE112_RECLASIFICACION_FISCAL_PE.md
+++ b/docs/development/REPORTE_ISSUE112_RECLASIFICACION_FISCAL_PE.md
@@ -53,12 +53,12 @@ CRFM [NUEVO] (rector: qué cuentas se reclasifican y a dónde)
   ↓ genera idempotente
 MRFPE (tabla operativa — sin cambios en schema Fase 1)
   ↓ consume (sin cambios)
-payment_entry_reclasificacion.py (solo se agrega log_error)
+payment_entry_reclasificacion.py (solo se agrega msgprint)
 ```
 
 ### Criterios de diseño aprobados
 
-1. No mover la lógica actual de Payment Entry — solo agregar `log_error`
+1. No mover la lógica actual de Payment Entry — solo agregar aviso al usuario
 2. No eliminar MRFPE — sigue siendo tabla operativa final
 3. No modificar CFM — solo lectura para detección
 4. CFM no absorbe egresos/pagos — no es fuente universal
@@ -241,29 +241,33 @@ frappe.msgprint(f"Creados: {len(creados)} | Ya existían: {len(ya_existian)} | P
 
 ---
 
-## Fase 0 — Fix inmediato (PR independiente)
+## Fase 0 — Fix inmediato (PR #126)
 
-Antes de implementar CRFM, este cambio elimina el silencio contable:
+Implementado. Elimina el silencio contable mostrando aviso visible al usuario:
 
 ```python
-# payment_entry_reclasificacion.py
+# payment_entry_reclasificacion.py — implementación real
 if not cuenta_destino:
-    frappe.log_error(
-        f"Sin mapeo de reclasificación: {company} / {tipo_operacion} / "
-        f"{tax.account_head} en PE {doc.name}. Impuesto no reclasificado.",
-        "Reclasificación Fiscal Incompleta"
+    frappe.msgprint(
+        f"⚠️ Las siguientes cuentas de impuesto no tienen mapeo de reclasificación "
+        f"y no serán reclasificadas en este cobro:<br><br><b>{cuentas}</b><br><br>"
+        f"Configure el mapeo en <b>Mapeo Reclasificacion Fiscal Payment Entry</b>.",
+        title="Reclasificación Fiscal Incompleta",
+        indicator="orange",
     )
     continue
 ```
 
+El aviso es naranja, no bloqueante — el PE se guarda correctamente.
+Sin `frappe.log_error` — el mensaje al usuario es suficiente.
 Riesgo: mínimo. No cambia comportamiento del GL.
 
 ---
 
 ## Alcance por fases
 
-### Fase 0 — log_error (PR pequeño, inmediato)
-- `payment_entry_reclasificacion.py`: `continue` → `log_error + continue`
+### Fase 0 — msgprint naranja (PR #126 — implementado)
+- `payment_entry_reclasificacion.py`: `continue` → `msgprint` naranja + `continue`
 
 ### Fase 1 — CRFM para Cobros
 - DocType `Configuracion Reclasificacion Fiscal Mexico` + child `Regla Reclasificacion Fiscal`
@@ -292,7 +296,7 @@ Riesgo: mínimo. No cambia comportamiento del GL.
 | Migración de datos | ✅ Ninguno | DocType nuevo — sin datos históricos |
 | MRFPE existente | ✅ Ninguno | No se toca. Instalaciones con MRFPE manual siguen funcionando |
 | CFM | ✅ Ninguno | Solo lectura |
-| payment_entry_reclasificacion.py | ✅ Mínimo | Solo agrega log_error |
+| payment_entry_reclasificacion.py | ✅ Mínimo | Solo agrega msgprint naranja |
 | Fixtures | ⚠️ Bajo | 2 DocTypes nuevos: JSON + hooks.py |
 | Permisos | ⚠️ Bajo | System Manager + Accounts Manager (igual que MRFPE) |
 | Idempotencia generación | ⚠️ Medio | `frappe.db.exists()` antes de `insert()` — cubierto en pseudocódigo |

--- a/docs/development/REPORTE_ISSUE112_RECLASIFICACION_FISCAL_PE.md
+++ b/docs/development/REPORTE_ISSUE112_RECLASIFICACION_FISCAL_PE.md
@@ -1,0 +1,345 @@
+# Issue #112 — Reclasificación Fiscal en Payment Entry
+# Análisis de Arquitectura y Diseño para Resolución
+# Fecha: 2026-05-10
+# Estado: DISEÑO APROBADO — pendiente implementación
+
+---
+
+## Contexto del problema
+
+Issue #112 es la **prioridad 1 del cierre de roadmap**. No es un bug menor —
+es una deficiencia arquitectónica en el flujo de reclasificación fiscal que ocurre
+cada vez que se registra un cobro PPD (y eventualmente pagos).
+
+El problema tiene dos niveles:
+1. **Inmediato:** el sistema falla silenciosamente cuando no hay mapeo — no avisa
+2. **Arquitectónico:** hay un diseño deficiente entre dos doctypes que deben trabajar
+   juntos pero están completamente desconectados
+
+---
+
+## El flujo de reclasificación fiscal — qué debe pasar
+
+Cuando una empresa mexicana emite una factura PPD (pago en parcialidades o diferido):
+
+```
+MOMENTO 1 — Timbrado de la factura (Sales Invoice):
+  IVA 16% = $160 → queda en "IVA por Cobrar" (cuenta temporal/transitoria)
+  No se reconoce como ingreso fiscal todavía
+
+MOMENTO 2 — Registro del cobro (Payment Entry):
+  El IVA pendiente SE RECLASIFICA:
+  Dr  "IVA por Cobrar"  $160   ← cuenta_origen (transitoria)
+  Cr  "IVA Cobrado"     $160   ← cuenta_destino (definitiva)
+
+  Este GL extra es el que genera payment_entry_reclasificacion.py
+```
+
+⚠️ **Nota sobre IVA 0% y Exento:** Aunque estos impuestos no generan monto
+reclasificable en Payment Entry, pueden requerir visibilidad para reportes
+fiscales. Por tanto, **ningún rol fiscal se excluye automáticamente**
+— todos se muestran para revisión y el usuario decide si los configura
+o los marca como Omitido. No implica que todos requieran movimiento
+contable en el cobro.
+
+---
+
+## Arquitectura aprobada
+
+```
+CFM (declaración de alcance fiscal — ingresos)
+  ↓ lectura (solo detección, sin modificar)
+CRFM [NUEVO] (rector: qué cuentas se reclasifican y a dónde)
+  ↓ genera idempotente
+MRFPE (tabla operativa — sin cambios en schema Fase 1)
+  ↓ consume (sin cambios)
+payment_entry_reclasificacion.py (solo se agrega log_error)
+```
+
+### Criterios de diseño aprobados
+
+1. No mover la lógica actual de Payment Entry — solo agregar `log_error`
+2. No eliminar MRFPE — sigue siendo tabla operativa final
+3. No modificar CFM — solo lectura para detección
+4. CFM no absorbe egresos/pagos — no es fuente universal
+5. CRFM es flexible para fuentes futuras (`source_type` por regla, no por header)
+6. Generación de MRFPE idempotente: no duplicar, no borrar registros manuales
+7. Permitir revisar faltantes antes de generar
+8. Retenciones: detectar pero no auto-generar en Fase 1
+9. MRFPE existentes: detectar como "Ya existe externo", no migrar
+10. Modo Manual funciona sin CFM
+11. **Sin exclusiones automáticas de roles** — incluso IVA 0% y Exento se muestran para revisión fiscal/reportes; el usuario decide si se omiten
+12. Issue #112 se cierra con: Fase 0 + CRFM Cobros + detección/generación idempotente
+
+---
+
+## Diseño final del nuevo DocType: Configuracion Reclasificacion Fiscal Mexico (CRFM)
+
+### Header (uno por empresa, naming `CRFM-{company}`)
+
+```
+company           (Link → Company, reqd, unique)
+enabled           (Check, default 1)
+ultima_deteccion  (Datetime, read_only)
+ultima_generacion (Datetime, read_only)
+```
+
+**Nota:** `source_type` NO va en el header — va en cada regla de la child table.
+Esto permite que el mismo CRFM maneje reglas de distintas fuentes en el futuro.
+
+### Child table: Regla Reclasificacion Fiscal
+
+```
+source_type     (Select: "Ingresos / CFM" | "Manual", reqd)
+tipo_operacion  (Select: Cobro | Pago, reqd)
+rol_fiscal      (Data, read_only — contexto semántico de CFM)
+cuenta_origen   (Link → Account, reqd, read_only si source_type = Ingresos/CFM)
+cuenta_destino  (Link → Account — el usuario confirma antes de generar)
+activo          (Check, default 1)
+estado_mrfpe    (Select: ver tabla de estados, read_only)
+mrfpe_ref       (Link → MRFPE, read_only — apunta al MRFPE relacionado, generado o externo)
+nota            (Small Text — mensaje contextual auto-llenado por el sistema o editable por usuario)
+```
+
+**Semántica de `mrfpe_ref`:** apunta al MRFPE relacionado independientemente de su
+origen. `estado_mrfpe` es quien indica si fue generado por este CRFM ("Generado")
+o si existía previamente ("Ya existe externo"). No se usan dos campos separados
+en Fase 1 — `estado_mrfpe` da el contexto suficiente.
+
+**Uso del campo `nota`:** el sistema lo auto-llena en la detección para guiar al
+usuario. Ejemplos:
+- Retención detectada — revisar mecánica contable antes de generar MRFPE.
+- IVA 0% / Exento — normalmente puede marcarse como Omitido si no hay cuenta destino.
+- MRFPE externo detectado — funciona correctamente sin intervención.
+
+### Tabla de estados de `estado_mrfpe`
+
+| Estado | Significado | Acción del usuario |
+|---|---|---|
+| `Pendiente cuenta destino` | Detectado desde CFM, falta cuenta_destino | Debe llenar cuenta_destino |
+| `Listo para generar` | cuenta_destino definida, aún no se ha creado MRFPE — **transición automática** | Clic en "Generar MRFPE" |
+| `Generado` | MRFPE creado por este CRFM; mrfpe_ref apunta al registro generado | Ninguna |
+| `Ya existe externo` | Ya hay MRFPE activo para esta cuenta_origen, no generado por CRFM; mrfpe_ref apunta a él | Puede "adoptar" en Fase 2 |
+| `Omitido` | El usuario decidió no reclasificar este impuesto | Ninguna |
+
+**Transición automática a "Listo para generar":** cuando el usuario llena
+`cuenta_destino` en una regla con estado "Pendiente cuenta destino", el estado
+debe cambiar automáticamente. Se implementa en `validate()` del CRFM (Python)
+o como evento `cuenta_destino` en el JS del form. Se prefiere `validate()` para
+que funcione también en imports y bench execute.
+
+---
+
+## Flujo de uso — dos botones separados
+
+### Botón 1: "Detectar Faltantes" (solo source_type = Ingresos/CFM)
+
+```python
+cfm = frappe.get_doc("Configuracion Fiscal Mexico", f"CFM-{company}")
+
+for row in cfm.mapeo_cuentas:
+    # Solo filas con cuenta mapeada y validada
+    if row.estado_validacion != "Válido" or not row.cuenta_impuesto:
+        continue
+
+    # TODOS los roles — sin exclusiones automáticas; el usuario decide qué omitir
+    # El usuario decide qué reclasificar mediante cuenta_destino y estado
+
+    # ¿Ya existe en MRFPE externo?
+    mrfpe_externo = frappe.db.get_value(
+        "Mapeo Reclasificacion Fiscal Payment Entry",
+        {"company": company, "tipo_operacion": "Cobro",
+         "cuenta_origen": row.cuenta_impuesto, "activo": 1},
+        "name"
+    )
+
+    # ¿Ya existe regla en este CRFM?
+    regla_existente = _buscar_regla_existente(crfm, row.cuenta_impuesto, "Cobro")
+
+    if regla_existente:
+        continue  # ya procesada
+
+    estado = "Ya existe externo" if mrfpe_externo else "Pendiente cuenta destino"
+    mrfpe_ref = mrfpe_externo if mrfpe_externo else None
+
+    # Nota contextual automática
+    nota = ""
+    if mrfpe_externo:
+        nota = "MRFPE externo detectado — funciona correctamente sin intervención."
+    elif row.es_retencion:
+        nota = "Retención detectada — revisar mecánica contable antes de generar MRFPE."
+    elif row.rol_fiscal in ("IVA Exento", "IVA por Pagar (0% exportación)"):
+        nota = "IVA 0% / Exento — puede marcarse como Omitido si no hay cuenta destino."
+
+    crfm.append("reglas", {
+        "source_type": "Ingresos / CFM",
+        "tipo_operacion": "Cobro",
+        "rol_fiscal": row.rol_fiscal,
+        "cuenta_origen": row.cuenta_impuesto,
+        "estado_mrfpe": estado,
+        "mrfpe_ref": mrfpe_ref,
+        "nota": nota,
+    })
+```
+
+**Resultado visible para el usuario:**
+
+```
+| Rol Fiscal        | Cuenta Origen           | Cuenta Destino   | Estado                    |
+| IVA Nacional      | 2101-IVA Cobrable       | [editable]       | Pendiente cuenta destino  |
+| IVA Frontera      | 2102-IVA Cobr.Frontera  | [editable]       | Pendiente cuenta destino  |
+| IVA 0% Exportac.  | 2103-IVA Export         | [editable]       | Pendiente cuenta destino  |
+| IVA Exento        | 2104-IVA Exento         | [editable]       | Pendiente cuenta destino  |
+| Ret. IVA Honor.   | 2201-IVA Ret.Hon        | [editable]       | Pendiente cuenta destino  |
+| IVA Nacional      | 2101-IVA Cobrable       | 2105-IVA Cobrado | Ya existe externo         |
+```
+
+El usuario llena `cuenta_destino` en las filas que corresponde.
+Para retenciones, puede marcar `Omitido` si decide no reclasificar en Fase 1.
+
+### Botón 2: "Generar MRFPE"
+
+```python
+creados = []
+ya_existian = []
+pendientes = []
+
+for regla in crfm.reglas:
+    if regla.estado_mrfpe in ("Ya existe externo", "Generado", "Omitido"):
+        continue
+
+    if not regla.cuenta_destino:
+        pendientes.append(regla.cuenta_origen)
+        continue
+
+    # Idempotencia
+    if frappe.db.exists("Mapeo Reclasificacion Fiscal Payment Entry", {
+        "company": company,
+        "tipo_operacion": regla.tipo_operacion,
+        "cuenta_origen": regla.cuenta_origen,
+        "activo": 1,
+    }):
+        regla.estado_mrfpe = "Ya existe externo"
+        ya_existian.append(regla.cuenta_origen)
+        continue
+
+    mrfpe = frappe.new_doc("Mapeo Reclasificacion Fiscal Payment Entry")
+    mrfpe.company = company
+    mrfpe.tipo_operacion = regla.tipo_operacion
+    mrfpe.cuenta_origen = regla.cuenta_origen
+    mrfpe.cuenta_destino = regla.cuenta_destino
+    mrfpe.activo = 1
+    mrfpe.insert(ignore_permissions=True)
+
+    regla.mrfpe_ref = mrfpe.name
+    regla.estado_mrfpe = "Generado"
+    creados.append(mrfpe.name)
+
+# Reporte final al usuario
+frappe.msgprint(f"Creados: {len(creados)} | Ya existían: {len(ya_existian)} | Pendientes: {len(pendientes)}")
+```
+
+---
+
+## Fase 0 — Fix inmediato (PR independiente)
+
+Antes de implementar CRFM, este cambio elimina el silencio contable:
+
+```python
+# payment_entry_reclasificacion.py
+if not cuenta_destino:
+    frappe.log_error(
+        f"Sin mapeo de reclasificación: {company} / {tipo_operacion} / "
+        f"{tax.account_head} en PE {doc.name}. Impuesto no reclasificado.",
+        "Reclasificación Fiscal Incompleta"
+    )
+    continue
+```
+
+Riesgo: mínimo. No cambia comportamiento del GL.
+
+---
+
+## Alcance por fases
+
+### Fase 0 — log_error (PR pequeño, inmediato)
+- `payment_entry_reclasificacion.py`: `continue` → `log_error + continue`
+
+### Fase 1 — CRFM para Cobros
+- DocType `Configuracion Reclasificacion Fiscal Mexico` + child `Regla Reclasificacion Fiscal`
+- Botón "Detectar Faltantes" (solo Cobros, source_type = Ingresos/CFM)
+- Botón "Generar MRFPE" (idempotente)
+- Modo Manual (sin CFM) funcional
+- Retenciones: detectadas, usuario decide (no auto-generación)
+- MRFPE existentes: detectados como "Ya existe externo"
+- **Cierra issue #112**
+
+### Fase 2 — Adopción de MRFPE manuales (futuro)
+- Botón "Adoptar MRFPE existente" — vincula registros externos a CRFM
+- Referencia inversa en MRFPE (`crfm_ref`, `managed_by_crfm`) — toca schema MRFPE
+
+### Fase 3 — Pagos/Egresos (futuro, issue separado)
+- `source_type = "Egresos / futuro"` se activa
+- Nueva fuente de detección para compras/pagos
+- Abre issue separado: "Configuración fiscal de egresos/pagos"
+
+---
+
+## Análisis de riesgos
+
+| Riesgo | Nivel | Detalle |
+|---|---|---|
+| Migración de datos | ✅ Ninguno | DocType nuevo — sin datos históricos |
+| MRFPE existente | ✅ Ninguno | No se toca. Instalaciones con MRFPE manual siguen funcionando |
+| CFM | ✅ Ninguno | Solo lectura |
+| payment_entry_reclasificacion.py | ✅ Mínimo | Solo agrega log_error |
+| Fixtures | ⚠️ Bajo | 2 DocTypes nuevos: JSON + hooks.py |
+| Permisos | ⚠️ Bajo | System Manager + Accounts Manager (igual que MRFPE) |
+| Idempotencia generación | ⚠️ Medio | `frappe.db.exists()` antes de `insert()` — cubierto en pseudocódigo |
+| Exclusiones incorrectas de roles | ⚠️ Cubierto | Sin exclusiones automáticas — todos los roles visibles para el usuario |
+
+---
+
+## Archivos a crear (Fase 0 + Fase 1)
+
+### Fase 0 (1 archivo modificado)
+```
+facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py
+```
+
+### Fase 1 (nuevos)
+```
+facturacion_mexico/facturacion_fiscal/doctype/
+  configuracion_reclasificacion_fiscal_mexico/
+    configuracion_reclasificacion_fiscal_mexico.json
+    configuracion_reclasificacion_fiscal_mexico.py
+    configuracion_reclasificacion_fiscal_mexico.js
+    test_configuracion_reclasificacion_fiscal_mexico.py
+
+  regla_reclasificacion_fiscal/
+    regla_reclasificacion_fiscal.json
+    regla_reclasificacion_fiscal.py
+```
+
+### Fase 1 (modificados)
+```
+facturacion_mexico/hooks.py  — agregar fixtures para los 2 nuevos doctypes
+```
+
+### NO se modifican
+```
+mapeo_reclasificacion_fiscal_payment_entry.py / .json / .js
+configuracion_fiscal_mexico.py / .json / .js
+mapeo_cuenta_fiscal_mexico.json
+payment_entry_reclasificacion.py (solo Fase 0)
+```
+
+---
+
+## Referencias
+
+- Issue #112: https://github.com/luisrms69/facturacion_mexico/issues/112
+- `facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py`
+- `facturacion_mexico/facturacion_fiscal/doctype/mapeo_reclasificacion_fiscal_payment_entry/`
+- `facturacion_mexico/facturacion_fiscal/doctype/configuracion_fiscal_mexico/`
+- `facturacion_mexico/utils/roles_fiscales.py`

--- a/facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py
+++ b/facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py
@@ -51,7 +51,16 @@ def cargar_impuestos_en_payment_entry(doc, method=None):
 	if paid_amount <= 0:
 		return
 
-	grupos = _calcular_grupos_desde_doc(doc)
+	grupos, sin_mapeo = _calcular_grupos_desde_doc(doc)
+	if sin_mapeo:
+		cuentas = ", ".join(sin_mapeo)
+		frappe.msgprint(
+			f"⚠️ Las siguientes cuentas de impuesto no tienen mapeo de reclasificación "
+			f"y no serán reclasificadas en este cobro:<br><br><b>{cuentas}</b><br><br>"
+			f"Configure el mapeo en <b>Mapeo Reclasificacion Fiscal Payment Entry</b>.",
+			title="Reclasificación Fiscal Incompleta",
+			indicator="orange",
+		)
 	if not grupos:
 		return
 
@@ -119,12 +128,13 @@ def _limpiar_filas_reclas(doc):
 	doc.taxes = [t for t in doc.get("taxes", []) if _RECLAS_MARKER not in (t.description or "")]
 
 
-def _calcular_grupos_desde_doc(doc) -> dict:
+def _calcular_grupos_desde_doc(doc) -> tuple[dict, list]:
 	"""
-	Devuelve {(cuenta_origen, cuenta_destino, tipo_op): monto_total}
-	con los montos proporcionales reales a reclasificar.
+	Devuelve ({(cuenta_origen, cuenta_destino, tipo_op): monto_total}, [sin_mapeo])
+	con los montos proporcionales reales a reclasificar y las cuentas sin mapeo.
 	"""
 	grupos: dict = {}
+	sin_mapeo: list = []
 	company = doc.company
 
 	for ref in doc.get("references", []):
@@ -162,18 +172,15 @@ def _calcular_grupos_desde_doc(doc) -> dict:
 				"cuenta_destino",
 			)
 			if not cuenta_destino:
-				frappe.log_error(
-					f"Sin mapeo de reclasificación: {company} / {tipo_operacion} / "
-					f"{tax.account_head}. Impuesto no reclasificado en PE {doc.name}.",
-					"Reclasificación Fiscal Incompleta",
-				)
+				if tax.account_head not in sin_mapeo:
+					sin_mapeo.append(tax.account_head)
 				continue
 
 			key = (tax.account_head, cuenta_destino, tipo_operacion)
 			monto = round(tax_amount * proporcion, 6)
 			grupos[key] = grupos.get(key, 0.0) + monto
 
-	return grupos
+	return grupos, sin_mapeo
 
 
 # ---------------------------------------------------------------------------
@@ -186,11 +193,12 @@ def analizar_payment_entry_whitelisted(payment_entry_name: str) -> dict:
 	"""Diagnóstico desde bench console — no modifica nada."""
 	pe = frappe.get_doc("Payment Entry", payment_entry_name)
 	paid_amount = flt(pe.paid_amount)
-	grupos = _calcular_grupos_desde_doc(pe)
+	grupos, sin_mapeo = _calcular_grupos_desde_doc(pe)
 
 	resultado = {
 		"payment_entry": pe.name,
 		"paid_amount": paid_amount,
+		"sin_mapeo": sin_mapeo,
 		"grupos": [],
 	}
 	for (origen, destino, tipo), monto in grupos.items():

--- a/facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py
+++ b/facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py
@@ -134,7 +134,7 @@ def _calcular_grupos_desde_doc(doc) -> tuple[dict, list]:
 	con los montos proporcionales reales a reclasificar y las cuentas sin mapeo.
 	"""
 	grupos: dict = {}
-	sin_mapeo: list = []
+	sin_mapeo: set = set()
 	company = doc.company
 
 	for ref in doc.get("references", []):
@@ -172,15 +172,14 @@ def _calcular_grupos_desde_doc(doc) -> tuple[dict, list]:
 				"cuenta_destino",
 			)
 			if not cuenta_destino:
-				if tax.account_head not in sin_mapeo:
-					sin_mapeo.append(tax.account_head)
+				sin_mapeo.add(tax.account_head)
 				continue
 
 			key = (tax.account_head, cuenta_destino, tipo_operacion)
 			monto = round(tax_amount * proporcion, 6)
 			grupos[key] = grupos.get(key, 0.0) + monto
 
-	return grupos, sin_mapeo
+	return grupos, sorted(sin_mapeo)
 
 
 # ---------------------------------------------------------------------------

--- a/facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py
+++ b/facturacion_mexico/facturacion_fiscal/services/payment_entry_reclasificacion.py
@@ -162,6 +162,11 @@ def _calcular_grupos_desde_doc(doc) -> dict:
 				"cuenta_destino",
 			)
 			if not cuenta_destino:
+				frappe.log_error(
+					f"Sin mapeo de reclasificación: {company} / {tipo_operacion} / "
+					f"{tax.account_head}. Impuesto no reclasificado en PE {doc.name}.",
+					"Reclasificación Fiscal Incompleta",
+				)
 				continue
 
 			key = (tax.account_head, cuenta_destino, tipo_operacion)

--- a/facturacion_mexico/facturacion_fiscal/services/test_payment_entry_reclasificacion.py
+++ b/facturacion_mexico/facturacion_fiscal/services/test_payment_entry_reclasificacion.py
@@ -322,9 +322,11 @@ class TestPaymentEntryReclasificacion(unittest.TestCase):
 	def test_sin_mapeo_muestra_aviso_al_usuario(self):
 		"""Cuentas sin mapeo → msgprint naranja; PE se guarda sin bloquear."""
 		pe = _make_pe_mock(1160.0, grand_total=1160.0)
-		with mock.patch(f"{_MODULE}._calcular_grupos_desde_doc", return_value=({}, [self.otro])):
-			with mock.patch.object(payment_entry_reclasificacion.frappe, "msgprint") as mock_msg:
-				cargar_impuestos_en_payment_entry(pe)
+		with (
+			mock.patch(f"{_MODULE}._calcular_grupos_desde_doc", return_value=({}, [self.otro])),
+			mock.patch.object(payment_entry_reclasificacion.frappe, "msgprint") as mock_msg,
+		):
+			cargar_impuestos_en_payment_entry(pe)
 
 		mock_msg.assert_called_once()
 		call_kwargs = mock_msg.call_args[1]

--- a/facturacion_mexico/facturacion_fiscal/services/test_payment_entry_reclasificacion.py
+++ b/facturacion_mexico/facturacion_fiscal/services/test_payment_entry_reclasificacion.py
@@ -169,11 +169,12 @@ class TestPaymentEntryReclasificacion(unittest.TestCase):
 		pe = _make_pe_mock(allocated, grand_total=grand_total)
 
 		with mock.patch.object(payment_entry_reclasificacion.frappe, "get_doc", return_value=si_mock):
-			grupos = _calcular_grupos_desde_doc(pe)
+			grupos, sin_mapeo = _calcular_grupos_desde_doc(pe)
 
 		key = (self.origen, self.destino, "Cobro")
 		self.assertIn(key, grupos)
 		self.assertAlmostEqual(grupos[key], tax_amount, places=2)
+		self.assertEqual(sin_mapeo, [])
 
 	def test_calcular_grupos_proporcion_parcial(self):
 		"""_calcular_grupos_desde_doc calcula monto proporcional para pago parcial."""
@@ -182,38 +183,43 @@ class TestPaymentEntryReclasificacion(unittest.TestCase):
 		pe = _make_pe_mock(allocated, allocated=allocated, grand_total=grand_total)
 
 		with mock.patch.object(payment_entry_reclasificacion.frappe, "get_doc", return_value=si_mock):
-			grupos = _calcular_grupos_desde_doc(pe)
+			grupos, sin_mapeo = _calcular_grupos_desde_doc(pe)
 
 		key = (self.origen, self.destino, "Cobro")
 		expected = round(tax_amount * (allocated / grand_total), 6)
 		self.assertAlmostEqual(grupos[key], expected, places=4)
+		self.assertEqual(sin_mapeo, [])
 
 	def test_calcular_grupos_sin_mapeo_retorna_vacio(self):
-		"""SI con account_head sin mapeo activo retorna grupos vacíos."""
+		"""SI con account_head sin mapeo activo retorna grupos vacíos y cuenta en sin_mapeo."""
 		si_mock = _make_si_mock(1160.0, 160.0, origen=self.otro)
 		pe = _make_pe_mock(1160.0, grand_total=1160.0)
 
 		with mock.patch.object(payment_entry_reclasificacion.frappe, "get_doc", return_value=si_mock):
-			grupos = _calcular_grupos_desde_doc(pe)
+			grupos, sin_mapeo = _calcular_grupos_desde_doc(pe)
 
 		self.assertEqual(len(grupos), 0)
+		self.assertIn(self.otro, sin_mapeo)
 
 	def test_calcular_grupos_impuesto_cero_ignorado(self):
-		"""tax_amount=0 no genera grupo."""
+		"""tax_amount=0 no genera grupo ni sin_mapeo."""
 		si_mock = _make_si_mock(1000.0, 0.0, origen=self.origen)
 		pe = _make_pe_mock(1000.0, grand_total=1000.0)
 
 		with mock.patch.object(payment_entry_reclasificacion.frappe, "get_doc", return_value=si_mock):
-			grupos = _calcular_grupos_desde_doc(pe)
+			grupos, sin_mapeo = _calcular_grupos_desde_doc(pe)
 
 		self.assertEqual(len(grupos), 0)
+		self.assertEqual(sin_mapeo, [])
 
 	# -----------------------------------------------------------------------
 	# Tests de cargar_impuestos_en_payment_entry
 	# Mockean _calcular_grupos_desde_doc para aislar la lógica de filas
 	# -----------------------------------------------------------------------
 
-	def _run_cargar(self, grand_total=1160.0, tax_amount=160.0, allocated=None, grupos_override=None):
+	def _run_cargar(
+		self, grand_total=1160.0, tax_amount=160.0, allocated=None, grupos_override=None, sin_mapeo=None
+	):
 		"""Helper: corre cargar_impuestos con grupos mockeados."""
 		if allocated is None:
 			allocated = grand_total
@@ -222,7 +228,7 @@ class TestPaymentEntryReclasificacion(unittest.TestCase):
 		grupos = (
 			grupos_override if grupos_override is not None else {(self.origen, self.destino, "Cobro"): monto}
 		)
-		with mock.patch(f"{_MODULE}._calcular_grupos_desde_doc", return_value=grupos):
+		with mock.patch(f"{_MODULE}._calcular_grupos_desde_doc", return_value=(grupos, sin_mapeo or [])):
 			cargar_impuestos_en_payment_entry(pe)
 		return pe
 
@@ -271,7 +277,7 @@ class TestPaymentEntryReclasificacion(unittest.TestCase):
 
 		monto = 160.0
 		grupos = {(self.origen, self.destino, "Cobro"): monto}
-		with mock.patch(f"{_MODULE}._calcular_grupos_desde_doc", return_value=grupos):
+		with mock.patch(f"{_MODULE}._calcular_grupos_desde_doc", return_value=(grupos, [])):
 			cargar_impuestos_en_payment_entry(pe)
 
 		count_despues = len([t for t in pe["taxes"] if _RECLAS_MARKER in (t.get("description") or "")])
@@ -310,5 +316,20 @@ class TestPaymentEntryReclasificacion(unittest.TestCase):
 	def test_impuesto_cero_ignorado(self):
 		"""Grupos vacíos por tax_amount=0 → no hay filas."""
 		pe = self._run_cargar(tax_amount=0.0, grupos_override={})
+		reclas = [t for t in pe["taxes"] if _RECLAS_MARKER in (t.get("description") or "")]
+		self.assertEqual(len(reclas), 0)
+
+	def test_sin_mapeo_muestra_aviso_al_usuario(self):
+		"""Cuentas sin mapeo → msgprint naranja; PE se guarda sin bloquear."""
+		pe = _make_pe_mock(1160.0, grand_total=1160.0)
+		with mock.patch(f"{_MODULE}._calcular_grupos_desde_doc", return_value=({}, [self.otro])):
+			with mock.patch.object(payment_entry_reclasificacion.frappe, "msgprint") as mock_msg:
+				cargar_impuestos_en_payment_entry(pe)
+
+		mock_msg.assert_called_once()
+		call_kwargs = mock_msg.call_args[1]
+		self.assertEqual(call_kwargs.get("indicator"), "orange")
+		self.assertIn(self.otro, mock_msg.call_args[0][0])
+		# PE no tiene filas de reclasificación — no bloqueó el guardado
 		reclas = [t for t in pe["taxes"] if _RECLAS_MARKER in (t.get("description") or "")]
 		self.assertEqual(len(reclas), 0)


### PR DESCRIPTION
## Objetivo

Eliminar el silencio contable cuando Payment Entry tiene impuestos sin mapeo
en Mapeo Reclasificacion Fiscal Payment Entry (MRFPE). Antes, la reclasificación
fallaba silenciosamente — el IVA no se reclasificaba y nadie se enteraba.

Cierra parcialmente issue #112 (Fase 0). El rediseño arquitectónico completo
(CRFM) va en Fase 1 — diseño aprobado en docs/development/REPORTE_ISSUE112.

## Cambios principales

- `_calcular_grupos_desde_doc` ahora retorna `(grupos, sin_mapeo)` — tupla
  con el dict de grupos a reclasificar y lista deduplicada de cuentas sin mapeo

- `cargar_impuestos_en_payment_entry` muestra `frappe.msgprint` naranja al
  usuario con las cuentas específicas faltantes y link al doctype de configuración.
  El PE se guarda sin bloquear — el aviso es informativo, no un error.

- `analizar_payment_entry_whitelisted` actualizado para nueva firma — incluye
  `sin_mapeo` en el resultado del diagnóstico.

## Validaciones realizadas

- `TestPaymentEntryReclasificacion` — 14/14 ✅ en `test-facturacion.localhost`
  - 4 tests existentes actualizados para nueva firma `tuple[dict, list]`
  - 1 test nuevo: `test_sin_mapeo_muestra_aviso_al_usuario` — verifica que
    `msgprint` se llama con `indicator="orange"` y que el PE no se bloquea

## Fuera de alcance

- Fase 1 — DocType CRFM (Configuracion Reclasificacion Fiscal Mexico): diseño
  aprobado en `docs/development/REPORTE_ISSUE112_RECLASIFICACION_FISCAL_PE.md`
- No modifica el GL ni el comportamiento de Payment Entry
- No toca CFM ni MRFPE schema

## Riesgos / pendientes

- Sin cambios de schema — no requiere `bench migrate`
- Sin cambios de fixtures
- El commit `39689e5` en la rama es un commit de trabajo previo superado por
  `cb7fa0b` — el diff neto vs main es el correcto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fiscal reclassification for payment entries now displays clear warning messages when tax account mappings are missing, preventing silent failures and potential data inconsistencies.
  * Unmapped tax accounts are now clearly identified and reported to users, enabling faster resolution of reclassification configuration issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luisrms69/facturacion_mexico/pull/126)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->