### PR TITLE
fix(tipo-e): notas de crédito CFDI tipo E — flujo completo (#116)

### DIFF
--- a/docs/adr/0024-addendas-pre-timbrado-issue129.md
+++ b/docs/adr/0024-addendas-pre-timbrado-issue129.md
@@ -153,3 +153,48 @@ a toda FFM nueva hasta que el scheduler `bulk_sync_invoices` corría (hasta 5 mi
 
 **Refactor completo pendiente:** Issue #133 — limpieza de `fm_sync_status`,
 `bulk_sync_invoices`, `try/except` silencioso en `update_sales_invoice_fiscal_info`.
+
+---
+
+## Nota adicional — 2026-05-12/13 (PR #134 — hardening CodeRabbit)
+
+### Hardening post-merge aplicado
+
+Tras la revisión de CodeRabbit en PR #134, se aplicaron 7 fixes en commit `f529654`:
+
+| Fix | Descripción |
+|---|---|
+| M1 | `validate_required_data` — rechazaba `0`/`False` válidos como "faltante" |
+| M2 | `_derive_prefix` — prefix XML puede empezar con dígito (inválido en XSD 1.0) |
+| N1 | `timbrado_api` — `.get()` seguro + guard contra `addenda_xml` vacío |
+| O1 | `_update_venta_mostrador_visibility` — no reseteaba cache en error de red |
+| N2-N5 | Comentarios técnicos traducidos a inglés en 4 archivos |
+
+Diferidos: M3 (refactor test helper), T1 (nitpick MagicMock sin bug real), D1 (markdown lint en docs internos).
+
+### Estado del "BUG MAYOR" documentado arriba
+
+La sección "BUG MAYOR — Pendiente de diagnóstico" describía tres problemas. Estado actualizado:
+
+| Problema | Estado |
+|---|---|
+| Botón Timbrar bloqueado en FFMs nuevas (`fm_sync_status`) | ✅ Resuelto — Issue #133, PR #134 |
+| Botón Timbrar desaparece intermitentemente en navegación SI↔FFM | ⏳ Pendiente — Issue #135 (refactor JS) |
+| Error "Field not permitted in query: fm_fiscal_status" | ⏳ Pendiente diagnóstico |
+| FFM queda en "Operación en Progreso" | ⏳ Relacionado con el bug JS — Issue #135 |
+
+### Issue #135 — Refactor completo de factura_fiscal_mexico.js
+
+El archivo `factura_fiscal_mexico.js` tiene 2709 líneas y múltiples problemas estructurales
+detectados durante esta implementación. Se creó Issue #135 para rastrear el rediseño completo.
+El bug del botón Timbrar que desaparece es consecuencia directa de la arquitectura actual del archivo.
+
+### Estado final del ADR
+
+**Estado:** Implementado parcialmente — Fases 1-4 en PR #134.
+**Pendientes de esta decisión:**
+- Fase 5: smoke test de attachments/descarga con addenda (post-merge, sin código nuevo)
+- Fase 6: post-timbrado manual (Issue separado, futuro)
+- Issue #132: campos legacy `fm_addenda_status/xml/errors/date`
+- Issue #133: refactor `fm_sync_status`
+- Issue #135: rediseño `factura_fiscal_mexico.js`

--- a/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
+++ b/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
@@ -1,0 +1,155 @@
+# ADR 0025 — Notas de Crédito CFDI tipo E (Issue #116)
+
+**Fecha:** 2026-05-13
+**Estado:** Implementado — pendientes normativos documentados (#136, #137)
+**Autor:** Luis Montanaro / Claude Sonnet 4.6
+
+---
+
+## Contexto
+
+Issue #116 requería implementar el flujo completo de emisión de Notas de Crédito
+(CFDI tipo E — Egreso) desde ERPNext. El único camino actualmente soportado es desde
+una Sales Invoice de devolución (`is_return=True`), que representa devolución física
+de mercancía.
+
+---
+
+## Decisión
+
+Implementar el flujo mínimo necesario para que las notas de crédito timbren
+correctamente como CFDI tipo E, partiendo de la infraestructura existente en
+`Factura Fiscal Mexico` (mismo DocType que tipo I).
+
+**Nota:** El uso del mismo DocType introduce complejidad. Se ha documentado como
+deuda técnica (Issue #135 — refactor FFM JS) y la complejidad creció durante esta
+implementación. Se recomienda evaluar DocType separado para tipo E en versiones futuras.
+
+---
+
+## Cambios implementados
+
+### 1. UUID relacionado obligatorio
+
+Guard bloqueante en `_prepare_facturapi_data()` antes de enviar a FacturAPI:
+
+```python
+if invoice_data.get("type") == "E" and not uuid_relacionado:
+    frappe.throw("No se puede timbrar la Nota de Crédito: falta el UUID del CFDI origen relacionado.")
+```
+
+`related_documents` se garantiza siempre — no se omite silenciosamente.
+
+### 2. Resolución automática de UUID origen — `_find_uuid_cfdi_origen()`
+
+Dos rutas:
+1. `Sales Invoice.fm_factura_fiscal_mx` → `Factura Fiscal Mexico.fm_uuid` (ruta rápida)
+2. Query directa en `Factura Fiscal Mexico` por `sales_invoice=return_against` y `status=TIMBRADO` (fallback)
+
+### 3. TipoRelación 03 para devoluciones físicas
+
+Toda nota de crédito generada desde Sales Invoice `is_return=True` usa `TipoRelación = 03`
+(Devolución de mercancía sobre facturas o traslados previos).
+
+TipoRelación 01 (descuentos, bonificaciones) es un flujo distinto — Issue #137.
+
+### 4. FormaPago automática — `_auto_populate_forma_pago_tipo_e()` *(provisional)*
+
+Fuente única de verdad para FormaPago en tipo E, basada en `outstanding_amount` de la SI origen:
+
+```python
+if nota_total <= outstanding_origen:   # factura no pagada
+    forma_pago = "15 - Condonación"
+elif outstanding_origen == 0:          # factura pagada
+    forma_pago = hereda de FFM origen  # proxy; pendiente Issue #136
+else:                                  # caso mixto
+    forma_pago = "15 - Condonación"   # safe default
+```
+
+**Provisional:** el caso `outstanding=0` puede representar "saldo a favor" (sin reembolso real)
+o reembolso efectivo. La distinción requiere validación con despacho contable. Ver Issue #136.
+
+### 5. Herencia de campos fiscales desde FFM origen — `_get_origin_ffm()`
+
+- `fm_facturar_venta_mostrador` heredado del origen — sin override manual
+- `fm_payment_method_sat` del origen usado para determinar FormaPago
+
+### 6. Campos fiscales read-only en tipo E — `_lock_egreso_fields()`
+
+JS bloquea en cada refresh:
+`sales_invoice`, `company`, `fm_payment_method_sat`, `fm_forma_pago_timbrado`,
+`fm_facturar_venta_mostrador`, `fm_tipo_relacion_sat`, `fm_uuid_relacionado`.
+
+El operador no puede customizar datos fiscales en una nota de crédito.
+
+### 7. Sin addenda en tipo E
+
+`AddendaService.render()` se salta para CFDI tipo E. La propagación de addenda
+también se excluye para Sales Invoice `is_return=True`.
+
+### 8. Montos absolutos en validación de discrepancias
+
+`_validate_amount_discrepancies()` usa `abs()` en totales ERPNext para manejar
+las cantidades negativas propias de las SIs de devolución.
+
+---
+
+## Validación realizada
+
+| Caso | Origen | outstanding | FormaPago resultante | TipoRelación |
+|---|---|---|---|---|
+| FFMX-2026-00025 | PPD / no pagada | > 0 | 15 - Condonación | 03 |
+| FFMX-2026-00027 | PPD / no pagada | > 0 | 15 - Condonación | 03 |
+| FFMX-2026-00028 | PPD / no pagada | > 0 | 15 - Condonación | 03 |
+
+Todos timbrados exitosamente en sandbox FacturAPI.
+
+---
+
+## Pendientes normativos — NO declarar el flujo como cerrado
+
+### Issue #136 — Validación normativa completa tipo E
+
+- **FormaPago cuando outstanding=0:** ¿"saldo a favor" usa 15 o la forma real del reembolso?
+  Pendiente validación con despacho contable.
+- **Pagos parciales mezclados:** nota que excede outstanding parcialmente — requiere
+  política de negocio explícita.
+- **Addenda en tipo E por cliente:** actualmente excluida globalmente. ¿Algunos clientes
+  (Liverpool, Walmart) la requieren?
+
+### Issue #137 — Flujo TipoRelación 01
+
+Descuentos, bonificaciones y ajustes comerciales sin devolución física → TipoRelación 01.
+No existe flujo en ERPNext para este caso actualmente.
+
+---
+
+## Deuda técnica
+
+- El FFM fue diseñado para tipo I. Tipo E se implementó como excepción en múltiples
+  puntos del código (guards dispersos en JS, Python y validaciones). Un DocType
+  separado para notas de crédito sería más limpio. Issue #135.
+- `_auto_populate_forma_pago_tipo_e()` es provisional hasta resolver Issue #136.
+- Los guards JS en `_lock_egreso_fields()` son necesarios porque otras funciones
+  del refresh sobreescriben los `read_only`. Síntoma del diseño acumulativo del FFM.
+
+---
+
+## Consecuencias
+
+- Notas de crédito por devolución física timbran correctamente como CFDI tipo E
+- UUID relacionado y `related_documents` garantizados normativamente
+- FormaPago determinada automáticamente (regla provisional)
+- Campos fiscales inmutables en tipo E desde UI
+- Issue #116 cerrado funcionalmente — pendientes normativos en #136 y #137
+
+---
+
+## Referencias
+
+- Issue #116 — feat(tipo-e): Notas de crédito CFDI tipo E
+- Issue #136 — validación normativa SAT pendiente para CFDI tipo E
+- Issue #137 — flujo nota de crédito TipoRelación 01
+- Issue #135 — refactor FFM JS
+- ADR 0024 — addendas pre-timbrado (contexto del FFM)
+- `docs/development/REPORTE_NORMATIVA_NOTA_CREDITO_PENDIENTES.md`

--- a/facturacion_mexico/addendas/hooks_handlers/sales_invoice_addenda_propagate.py
+++ b/facturacion_mexico/addendas/hooks_handlers/sales_invoice_addenda_propagate.py
@@ -16,8 +16,16 @@ from frappe.utils import cint
 
 
 def propagate_addenda_from_customer(doc, method=None):
-	"""Hook Sales Invoice.validate — propaga flags de addenda desde Customer."""
+	"""Hook Sales Invoice.validate — propaga flags de addenda desde Customer.
+
+	Credit notes (is_return=1) are excluded: addenda on return invoices is not
+	standard practice and requires explicit configuration if needed.
+	"""
 	if not doc.customer:
+		return
+
+	# Return invoices (notas de crédito) do not inherit addenda from customer
+	if cint(doc.get("is_return")):
 		return
 
 	customer_requires = cint(frappe.db.get_value("Customer", doc.customer, "fm_requires_addenda") or 0)

--- a/facturacion_mexico/addendas/hooks_handlers/sales_invoice_addenda_propagate.py
+++ b/facturacion_mexico/addendas/hooks_handlers/sales_invoice_addenda_propagate.py
@@ -18,8 +18,8 @@ from frappe.utils import cint
 def propagate_addenda_from_customer(doc, method=None):
 	"""Hook Sales Invoice.validate — propaga flags de addenda desde Customer.
 
-	Credit notes (is_return=1) are excluded: addenda on return invoices is not
-	standard practice and requires explicit configuration if needed.
+	Las notas de crédito (is_return=1) se excluyen: la addenda en facturas de
+	devolución no es práctica estándar y requiere configuración explícita.
 	"""
 	if not doc.customer:
 		return

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -794,8 +794,8 @@
 		// Validaciones específicas de datos fiscales
 
 		// Tipo E: payment form is inherited from origin — skip client validation
-		const is_egreso_save = (frm.doc.fm_tipo_comprobante || "").startsWith("E");
-		if (!is_egreso_save && frm.doc.fm_payment_method_sat === "PUE") {
+		const is_egreso = (frm.doc.fm_tipo_comprobante || "").startsWith("E");
+		if (!is_egreso && frm.doc.fm_payment_method_sat === "PUE") {
 			if (
 				!frm.doc.fm_forma_pago_timbrado ||
 				frm.doc.fm_forma_pago_timbrado.startsWith("99 -")
@@ -1249,7 +1249,9 @@
 		// For tipo E (credit notes), lock all fields that must not be customized.
 		// Called last in refresh + after async settlement to survive any override.
 		if (!(frm.doc.fm_tipo_comprobante || "").startsWith("E")) return;
-		const lock = (f) => frm.set_df_property(f, "read_only", 1);
+		const lock = (f) => {
+			if (frm.get_field(f)) frm.set_df_property(f, "read_only", 1);
+		};
 		lock("sales_invoice");
 		lock("company");
 		lock("fm_payment_method_sat");

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -500,6 +500,11 @@
 			if (is_egreso) {
 				frm.set_df_property("fm_tipo_relacion_sat", "read_only", 1);
 				frm.set_df_property("fm_uuid_relacionado", "read_only", 1);
+				// Credit notes: fiscal fields inherited from origin — no manual override
+				frm.set_df_property("fm_facturar_venta_mostrador", "read_only", 1);
+				frm.set_df_property("fm_forma_pago_timbrado", "read_only", 1);
+				// SAT mandates PUE for tipo E — payment method is not selectable
+				frm.set_df_property("fm_payment_method_sat", "read_only", 1);
 			}
 
 			// PROTECCIÓN: Bloquear campos fiscales post-submit
@@ -518,6 +523,11 @@
 				check_and_show_billing_data_status(frm);
 				check_customer_fiscal_warning(frm);
 			}, 1500);
+
+			// Lock tipo E fields LAST — overrides any function that may have reset them
+			_lock_egreso_fields(frm);
+			// Re-apply after async calls settle (applyFFMUi, setup_fiscal_interface)
+			setTimeout(() => _lock_egreso_fields(frm), 600);
 		},
 
 		// NUEVO: después de save/reload
@@ -783,8 +793,9 @@
 
 		// Validaciones específicas de datos fiscales
 
-		// Validar que PUE tenga forma de pago específica (solo si ya seleccionó PUE)
-		if (frm.doc.fm_payment_method_sat === "PUE") {
+		// Tipo E: payment form is inherited from origin — skip client validation
+		const is_egreso_save = (frm.doc.fm_tipo_comprobante || "").startsWith("E");
+		if (!is_egreso_save && frm.doc.fm_payment_method_sat === "PUE") {
 			if (
 				!frm.doc.fm_forma_pago_timbrado ||
 				frm.doc.fm_forma_pago_timbrado.startsWith("99 -")
@@ -1234,7 +1245,23 @@
 	// IMPLEMENTACIÓN RADIO BUTTONS - Punto 5
 	// ========================================
 
+	function _lock_egreso_fields(frm) {
+		// For tipo E (credit notes), lock all fields that must not be customized.
+		// Called last in refresh + after async settlement to survive any override.
+		if (!(frm.doc.fm_tipo_comprobante || "").startsWith("E")) return;
+		const lock = (f) => frm.set_df_property(f, "read_only", 1);
+		lock("sales_invoice");
+		lock("company");
+		lock("fm_payment_method_sat");
+		lock("fm_forma_pago_timbrado");
+		lock("fm_facturar_venta_mostrador");
+		lock("fm_tipo_relacion_sat");
+		lock("fm_uuid_relacionado");
+	}
+
 	function setup_payment_method_radio_buttons(frm) {
+		// Tipo E: SAT mandates PUE — radio buttons not rendered, field stays read_only
+		if ((frm.doc.fm_tipo_comprobante || "").startsWith("E")) return;
 		// Solo aplicar en formulario cargado y campo presente
 		if (!frm.doc || !frm.fields_dict.fm_payment_method_sat) {
 			return;
@@ -1439,6 +1466,14 @@
 
 		if (!frm.fields_dict.fm_forma_pago_timbrado) {
 			return; // Campo no existe
+		}
+
+		// Credit notes (tipo E) inherit payment form from origin — no manual edit allowed
+		const is_egreso = (frm.doc.fm_tipo_comprobante || "").startsWith("E");
+		if (is_egreso) {
+			frm.set_df_property("fm_forma_pago_timbrado", "hidden", 0);
+			frm.set_df_property("fm_forma_pago_timbrado", "read_only", 1);
+			return;
 		}
 
 		if (payment_method === "PPD") {

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -87,7 +87,8 @@
    "label": "Factura de Venta",
    "options": "Sales Invoice",
    "reqd": 1,
-   "search_index": 1
+   "search_index": 1,
+   "read_only": 1
   },
   {
    "fieldname": "company",

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -294,7 +294,7 @@ class FacturaFiscalMexico(Document):
 			self.fm_uuid_relacionado = None
 
 	def _get_origin_ffm(self) -> dict | None:
-		"""Return key fields from the original FFM for this credit note."""
+		"""Devolver campos clave de la FFM original para esta nota de crédito."""
 		if not self.sales_invoice:
 			return None
 		return_against = frappe.db.get_value("Sales Invoice", self.sales_invoice, "return_against")
@@ -325,13 +325,13 @@ class FacturaFiscalMexico(Document):
 		}
 
 	def _auto_populate_forma_pago_tipo_e(self) -> None:
-		"""Determine FormaPago for CFDI tipo E based on origin SI outstanding_amount.
+		"""Determinar FormaPago para CFDI tipo E con base en el outstanding_amount de la SI origen.
 
-		Single source of truth — normative rule (Issue #116):
-		  nota_total <= outstanding_origen → 15 Condonación (reduces pending debt)
-		  outstanding_origen == 0          → inherit origin FFM payment form (paid invoice)
-		  mixed case                       → 15 Condonación as safe default pending
-		                                     clarification on saldo-a-favor vs real refund
+		Única fuente de verdad — regla normativa (Issue #116):
+		  nota_total <= outstanding_origen → 15 Condonación (reduce deuda pendiente)
+		  outstanding_origen == 0          → hereda forma de pago de la FFM origen (factura pagada)
+		  caso mixto                       → 15 Condonación como default seguro mientras se
+		                                     clarifica saldo-a-favor vs devolución real (Issue #136).
 		"""
 		if not self.sales_invoice:
 			return
@@ -351,24 +351,22 @@ class FacturaFiscalMexico(Document):
 		elif origin_outstanding == 0:
 			# Origin fully paid — inherit origin payment form as best available proxy.
 			# Pending ChatGPT clarification: saldo-a-favor vs real refund (Issue #136).
-			origin_ffm_name = frappe.db.get_value("Sales Invoice", return_against, "fm_factura_fiscal_mx")
-			if origin_ffm_name:
-				self.fm_forma_pago_timbrado = (
-					frappe.db.get_value("Factura Fiscal Mexico", origin_ffm_name, "fm_forma_pago_timbrado")
-					or ""
-				)
+			# Reuse _get_origin_ffm() for consistent two-step fallback lookup.
+			origin_ffm = self._get_origin_ffm()
+			if origin_ffm:
+				self.fm_forma_pago_timbrado = origin_ffm.get("fm_forma_pago_timbrado") or ""
 		else:
 			# Mixed case: nota exceeds pending debt partially.
 			# Use 15 as safe default pending business policy definition.
 			self.fm_forma_pago_timbrado = "15 - Condonación"
 
 	def _find_uuid_cfdi_origen(self) -> str | None:
-		"""Find UUID of the original CFDI for this credit note.
+		"""Buscar el UUID del CFDI original para esta nota de crédito.
 
-		Two-step lookup:
-		  1. Via Sales Invoice.fm_factura_fiscal_mx (fast, field-based)
-		  2. Fallback: query Factura Fiscal Mexico where sales_invoice = return_against
-		     and status is TIMBRADO (robust when the link field is not populated)
+		Búsqueda en dos pasos:
+		  1. Vía Sales Invoice.fm_factura_fiscal_mx (rápida, basada en campo)
+		  2. Fallback: consulta Factura Fiscal Mexico donde sales_invoice = return_against
+		     y status es TIMBRADO (robusto cuando el campo link no está poblado).
 		"""
 		if not self.sales_invoice:
 			return None

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -2,7 +2,7 @@ import frappe
 from frappe import _
 from frappe.contacts.doctype.address.address import get_address_display
 from frappe.model.document import Document
-from frappe.utils import flt, now_datetime
+from frappe.utils import cint, flt, now_datetime
 
 from facturacion_mexico.sat.constants import TIPO_COMPROBANTE, TIPO_RELACION, parse_select_code
 
@@ -275,21 +275,123 @@ class FacturaFiscalMexico(Document):
 		"""Establecer tipo automáticamente según contexto."""
 		if self._is_sales_invoice_return():
 			self.fm_tipo_comprobante = "E - Egreso"
-			# autollenar relación
-			self.fm_tipo_relacion_sat = self.fm_tipo_relacion_sat or "01 - " + TIPO_RELACION["01"]
+			self.fm_payment_method_sat = "PUE"  # SAT: PPD not allowed on credit notes
 			self.fm_uuid_relacionado = self.fm_uuid_relacionado or self._find_uuid_cfdi_origen()
-			self.fm_payment_method_sat = "PUE"  # SAT no permite PPD en notas de crédito
+
+			# Physical merchandise return → TipoRelación 03 (normative, Issue #116).
+			# TipoRelación 01 (discounts/bonifications) is a separate flow — Issue #137.
+			self.fm_tipo_relacion_sat = self.fm_tipo_relacion_sat or "03 - " + TIPO_RELACION["03"]
+
+			# Inherit venta-mostrador flag from origin — no customization allowed.
+			# FormaPago for tipo E is determined in auto_load_payment_method_from_sales_invoice()
+			# based on outstanding_amount of origin SI (single source of truth).
+			origin_ffm = self._get_origin_ffm()
+			if origin_ffm:
+				self.fm_facturar_venta_mostrador = cint(origin_ffm.get("fm_facturar_venta_mostrador", 0))
 		else:
 			self.fm_tipo_comprobante = "I - Ingreso"
 			self.fm_tipo_relacion_sat = None
 			self.fm_uuid_relacionado = None
 
+	def _get_origin_ffm(self) -> dict | None:
+		"""Return key fields from the original FFM for this credit note."""
+		if not self.sales_invoice:
+			return None
+		return_against = frappe.db.get_value("Sales Invoice", self.sales_invoice, "return_against")
+		if not return_against:
+			return None
+		ffm_name = frappe.db.get_value("Sales Invoice", return_against, "fm_factura_fiscal_mx")
+		if not ffm_name:
+			ffm_name = frappe.db.get_value(
+				"Factura Fiscal Mexico",
+				{"sales_invoice": return_against, "status": "TIMBRADO"},
+				"name",
+				order_by="creation desc",
+			)
+		if not ffm_name:
+			return None
+		# Use separate calls to avoid potential as_dict+list-field issues in Frappe v16
+		forma_pago = frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "fm_forma_pago_timbrado") or ""
+		venta_mostrador = cint(
+			frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "fm_facturar_venta_mostrador") or 0
+		)
+		payment_method = (
+			frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "fm_payment_method_sat") or "PUE"
+		)
+		return {
+			"fm_forma_pago_timbrado": forma_pago,
+			"fm_facturar_venta_mostrador": venta_mostrador,
+			"fm_payment_method_sat": payment_method,
+		}
+
+	def _auto_populate_forma_pago_tipo_e(self) -> None:
+		"""Determine FormaPago for CFDI tipo E based on origin SI outstanding_amount.
+
+		Single source of truth — normative rule (Issue #116):
+		  nota_total <= outstanding_origen → 15 Condonación (reduces pending debt)
+		  outstanding_origen == 0          → inherit origin FFM payment form (paid invoice)
+		  mixed case                       → 15 Condonación as safe default pending
+		                                     clarification on saldo-a-favor vs real refund
+		"""
+		if not self.sales_invoice:
+			return
+		si = frappe.get_doc("Sales Invoice", self.sales_invoice)
+		return_against = si.get("return_against")
+		if not return_against:
+			return
+
+		origin_si = frappe.get_doc("Sales Invoice", return_against)
+		origin_outstanding = flt(origin_si.outstanding_amount)
+		nota_total = abs(flt(si.grand_total))
+
+		if nota_total <= origin_outstanding:
+			# Credit fully absorbed by pending debt — no real refund
+			self.fm_forma_pago_timbrado = "15 - Condonación"
+
+		elif origin_outstanding == 0:
+			# Origin fully paid — inherit origin payment form as best available proxy.
+			# Pending ChatGPT clarification: saldo-a-favor vs real refund (Issue #136).
+			origin_ffm_name = frappe.db.get_value("Sales Invoice", return_against, "fm_factura_fiscal_mx")
+			if origin_ffm_name:
+				self.fm_forma_pago_timbrado = (
+					frappe.db.get_value("Factura Fiscal Mexico", origin_ffm_name, "fm_forma_pago_timbrado")
+					or ""
+				)
+		else:
+			# Mixed case: nota exceeds pending debt partially.
+			# Use 15 as safe default pending business policy definition.
+			self.fm_forma_pago_timbrado = "15 - Condonación"
+
 	def _find_uuid_cfdi_origen(self) -> str | None:
-		"""Buscar UUID del CFDI original."""
-		# TODO: Implementar lógica que busque el UUID del CFDI original
-		# 1) FFM relacionado a la SI origen, o
-		# 2) Campo en la Sales Invoice original.
-		return getattr(self, "uuid_origen", None)
+		"""Find UUID of the original CFDI for this credit note.
+
+		Two-step lookup:
+		  1. Via Sales Invoice.fm_factura_fiscal_mx (fast, field-based)
+		  2. Fallback: query Factura Fiscal Mexico where sales_invoice = return_against
+		     and status is TIMBRADO (robust when the link field is not populated)
+		"""
+		if not self.sales_invoice:
+			return None
+
+		return_against = frappe.db.get_value("Sales Invoice", self.sales_invoice, "return_against")
+		if not return_against:
+			return None
+
+		# Route 1: via fm_factura_fiscal_mx field on origin SI
+		ffm_name = frappe.db.get_value("Sales Invoice", return_against, "fm_factura_fiscal_mx")
+		if ffm_name:
+			uuid = frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "fm_uuid")
+			if uuid:
+				return uuid
+
+		# Route 2: fallback — query FFM linked to origin SI with valid fiscal status
+		ffm_row = frappe.db.get_value(
+			"Factura Fiscal Mexico",
+			{"sales_invoice": return_against, "status": "TIMBRADO", "fm_uuid": ["!=", ""]},
+			"fm_uuid",
+			order_by="creation desc",
+		)
+		return ffm_row or None
 
 	def _validate_uuid_origen(self):
 		"""Validar UUID relacionado."""
@@ -661,6 +763,13 @@ class FacturaFiscalMexico(Document):
 		- Siempre asignar "99 - Por definir"
 		"""
 		if not self.sales_invoice or not self.fm_payment_method_sat:
+			return
+
+		# Tipo E: FormaPago based on outstanding_amount of origin SI.
+		# This is the single source of truth — Issue #116 normative rule.
+		if (self.fm_tipo_comprobante or "").startswith("E"):
+			if not self.fm_forma_pago_timbrado:
+				self._auto_populate_forma_pago_tipo_e()
 			return
 
 		# Para PPD: Siempre asignar "99 - Por definir"

--- a/facturacion_mexico/facturacion_fiscal/tests/test_tipo_e_nota_credito.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_tipo_e_nota_credito.py
@@ -1,0 +1,197 @@
+"""
+Tests Issue #116 — Notas de Crédito CFDI tipo E.
+
+Cubre:
+  1. Tipo E sin UUID relacionado → bloquea timbrado (frappe.throw)
+  2. Tipo E con UUID válido → related_documents incluido en payload
+  3. _find_uuid_cfdi_origen resuelve UUID desde return_against vía fm_factura_fiscal_mx
+  4. _find_uuid_cfdi_origen resuelve UUID desde return_against vía query FFM (fallback)
+  5. _find_uuid_cfdi_origen retorna None cuando no hay FFM timbrada en SI origen
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe import _
+from frappe.tests.utils import FrappeTestCase
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _mock_ffm(fm_tipo_comprobante="E - Egreso", fm_uuid_relacionado="", fm_tipo_relacion_sat="01"):
+	ffm = MagicMock()
+	_data = {
+		"fm_tipo_comprobante": fm_tipo_comprobante,
+		"fm_uuid_relacionado": fm_uuid_relacionado,
+		"fm_tipo_relacion_sat": fm_tipo_relacion_sat,
+		"fm_payment_method_sat": "PUE",
+		"fm_cfdi_use": "G03",
+		"fm_tax_system": "601",
+		"sales_invoice": "SINV-TEST-001",
+	}
+	ffm.get = lambda key, default=None: _data.get(key, default)
+	ffm.name = "FFMX-TEST-001"
+	return ffm
+
+
+def _mock_si(is_return=0, return_against=None):
+	si = MagicMock()
+	si.name = "SINV-TEST-001"
+	si.customer = "Test Customer"
+	si.is_return = is_return
+	si.return_against = return_against
+	si.items = []
+	_data = {
+		"is_return": is_return,
+		"return_against": return_against,
+		"branch": None,
+		"ffm_substitution_source_uuid": "",
+	}
+	si.get = lambda key, default=None: _data.get(key, default)
+	return si
+
+
+# ── Tests guard bloqueante ────────────────────────────────────────────────────
+
+
+class TestTipoEGuard(FrappeTestCase):
+	"""Guard en _prepare_facturapi_data: tipo E sin UUID bloquea timbrado."""
+
+	def _run_tipo_e_block(self, uuid_relacionado: str):
+		"""Ejecutar solo el bloque Tipo E de _prepare_facturapi_data."""
+		invoice_data = {"type": "E"}
+		ffm = _mock_ffm(fm_uuid_relacionado=uuid_relacionado)
+
+		tipo_relacion = ffm.get("fm_tipo_relacion_sat", "").strip()
+		uuid = ffm.get("fm_uuid_relacionado", "").strip()
+
+		if not uuid:
+			frappe.throw(
+				_(
+					"No se puede timbrar la Nota de Crédito: "
+					"falta el UUID del CFDI origen relacionado. "
+					"Verifique que la factura original esté timbrada."
+				),
+				title=_("UUID Relacionado Requerido"),
+			)
+
+		relacion_code = tipo_relacion.split(" - ")[0].strip() if " - " in tipo_relacion else tipo_relacion
+		invoice_data["related_documents"] = [{"relationship": relacion_code, "documents": [uuid]}]
+		return invoice_data
+
+	def test_tipo_e_sin_uuid_bloquea_timbrado(self):
+		"""CFDI tipo E sin fm_uuid_relacionado → frappe.throw bloqueante."""
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			self._run_tipo_e_block(uuid_relacionado="")
+		self.assertIn("UUID", str(ctx.exception))
+
+	def test_tipo_e_con_uuid_incluye_related_documents(self):
+		"""CFDI tipo E con UUID válido → related_documents en payload con relación 01."""
+		test_uuid = "550E8400-E29B-41D4-A716-446655440000"
+		result = self._run_tipo_e_block(uuid_relacionado=test_uuid)
+
+		self.assertIn("related_documents", result)
+		docs = result["related_documents"]
+		self.assertEqual(len(docs), 1)
+		self.assertEqual(docs[0]["relationship"], "01")
+		self.assertIn(test_uuid, docs[0]["documents"])
+
+
+# ── Tests _find_uuid_cfdi_origen ─────────────────────────────────────────────
+
+
+class TestFindUuidCfdiOrigen(FrappeTestCase):
+	"""Tests para _find_uuid_cfdi_origen en Factura Fiscal Mexico."""
+
+	def _call(self, ffm_doc):
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
+
+		instance = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		instance.sales_invoice = ffm_doc.get("sales_invoice")
+		return instance._find_uuid_cfdi_origen()
+
+	def test_sin_sales_invoice_retorna_none(self):
+		ffm = MagicMock()
+		ffm.get = lambda k, d=None: None
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
+
+		instance = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		instance.sales_invoice = None
+		self.assertIsNone(instance._find_uuid_cfdi_origen())
+
+	def test_resuelve_uuid_via_fm_factura_fiscal_mx(self):
+		"""Ruta 1: SI origen tiene fm_factura_fiscal_mx → retorna fm_uuid de esa FFM."""
+		expected_uuid = "UUID-ORIGEN-001"
+
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
+
+		instance = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		instance.sales_invoice = "SINV-DEVOLUCION"
+
+		def mock_get_value(doctype, name, field, **kwargs):
+			if doctype == "Sales Invoice" and name == "SINV-DEVOLUCION" and field == "return_against":
+				return "SINV-ORIGINAL"
+			if doctype == "Sales Invoice" and name == "SINV-ORIGINAL" and field == "fm_factura_fiscal_mx":
+				return "FFM-ORIGINAL"
+			if doctype == "Factura Fiscal Mexico" and name == "FFM-ORIGINAL" and field == "fm_uuid":
+				return expected_uuid
+			return None
+
+		with patch("frappe.db.get_value", side_effect=mock_get_value):
+			result = instance._find_uuid_cfdi_origen()
+
+		self.assertEqual(result, expected_uuid)
+
+	def test_resuelve_uuid_via_query_fallback(self):
+		"""Ruta 2 (fallback): fm_factura_fiscal_mx vacío → query FFM por sales_invoice."""
+		expected_uuid = "UUID-FALLBACK-002"
+
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
+
+		instance = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		instance.sales_invoice = "SINV-DEVOLUCION"
+
+		def mock_get_value(doctype, name_or_filters, field=None, **kwargs):
+			# return_against lookup
+			if doctype == "Sales Invoice" and name_or_filters == "SINV-DEVOLUCION":
+				return "SINV-ORIGINAL"
+			# fm_factura_fiscal_mx → vacío (fuerza fallback)
+			if doctype == "Sales Invoice" and name_or_filters == "SINV-ORIGINAL":
+				return None
+			# Fallback query: FFM con sales_invoice = SINV-ORIGINAL y status TIMBRADO
+			if doctype == "Factura Fiscal Mexico" and isinstance(name_or_filters, dict):
+				return expected_uuid
+			return None
+
+		with patch("frappe.db.get_value", side_effect=mock_get_value):
+			result = instance._find_uuid_cfdi_origen()
+
+		self.assertEqual(result, expected_uuid)
+
+	def test_retorna_none_cuando_no_hay_ffm_timbrada(self):
+		"""Sin FFM timbrada en SI origen → retorna None (guard bloqueará el timbrado)."""
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
+
+		instance = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		instance.sales_invoice = "SINV-DEVOLUCION"
+
+		def mock_get_value(doctype, name_or_filters, field=None, **kwargs):
+			if doctype == "Sales Invoice" and name_or_filters == "SINV-DEVOLUCION":
+				return "SINV-ORIGINAL"
+			return None  # Sin FFM, sin UUID en ninguna ruta
+
+		with patch("frappe.db.get_value", side_effect=mock_get_value):
+			result = instance._find_uuid_cfdi_origen()
+
+		self.assertIsNone(result)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_tipo_e_nota_credito.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_tipo_e_nota_credito.py
@@ -15,11 +15,10 @@ import frappe
 from frappe import _
 from frappe.tests.utils import FrappeTestCase
 
-
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
-def _mock_ffm(fm_tipo_comprobante="E - Egreso", fm_uuid_relacionado="", fm_tipo_relacion_sat="01"):
+def _mock_ffm(fm_tipo_comprobante="E - Egreso", fm_uuid_relacionado="", fm_tipo_relacion_sat="03"):
 	ffm = MagicMock()
 	_data = {
 		"fm_tipo_comprobante": fm_tipo_comprobante,
@@ -87,14 +86,14 @@ class TestTipoEGuard(FrappeTestCase):
 		self.assertIn("UUID", str(ctx.exception))
 
 	def test_tipo_e_con_uuid_incluye_related_documents(self):
-		"""CFDI tipo E con UUID válido → related_documents en payload con relación 01."""
+		"""CFDI tipo E con UUID válido → related_documents en payload con relación 03 (devolución física)."""
 		test_uuid = "550E8400-E29B-41D4-A716-446655440000"
 		result = self._run_tipo_e_block(uuid_relacionado=test_uuid)
 
 		self.assertIn("related_documents", result)
 		docs = result["related_documents"]
 		self.assertEqual(len(docs), 1)
-		self.assertEqual(docs[0]["relationship"], "01")
+		self.assertEqual(docs[0]["relationship"], "03")
 		self.assertIn(test_uuid, docs[0]["documents"])
 
 

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -700,18 +700,27 @@ class TimbradoAPI:
 			tipo_relacion = factura_fiscal.get("fm_tipo_relacion_sat", "").strip()
 			uuid_relacionado = factura_fiscal.get("fm_uuid_relacionado", "").strip()
 
-			if tipo_relacion and uuid_relacionado:
-				# Extraer código de relación (formato "01 - Descripción" -> "01")
-				relacion_code = (
-					tipo_relacion.split(" - ")[0].strip() if " - " in tipo_relacion else tipo_relacion
+			# REGLA FISCAL: CFDI tipo E sin UUID relacionado es inválido ante el SAT.
+			# related_documents es obligatorio — no se omite silenciosamente.
+			if not uuid_relacionado:
+				frappe.throw(
+					_(
+						"No se puede timbrar la Nota de Crédito: "
+						"falta el UUID del CFDI origen relacionado. "
+						"Verifique que la factura original esté timbrada."
+					),
+					title=_("UUID Relacionado Requerido"),
 				)
 
-				invoice_data["related_documents"] = [
-					{
-						"relationship": relacion_code,
-						"documents": [uuid_relacionado],
-					}
-				]
+			# Extraer código de relación (formato "01 - Descripción" -> "01")
+			relacion_code = tipo_relacion.split(" - ")[0].strip() if " - " in tipo_relacion else tipo_relacion
+
+			invoice_data["related_documents"] = [
+				{
+					"relationship": relacion_code,
+					"documents": [uuid_relacionado],
+				}
+			]
 
 		# [Milestone 3] Inyectar relación 04 si el SI trae 'ffm_substitution_source_uuid'
 		src_uuid = (sales_invoice.get("ffm_substitution_source_uuid") or "").strip()
@@ -741,11 +750,13 @@ class TimbradoAPI:
 		self._validate_payload_completeness_ro(invoice_data, sales_invoice)
 
 		# Fase 4 Issue #129: Addenda pre-timbrado
+		# Tipo E (credit notes) never include addenda — skip entirely.
 		# render() returns None when SI does not require addenda — payload unchanged
 		# render() raises frappe.throw on config/data error — blocks timbrado
 		from facturacion_mexico.addendas.addenda_service import AddendaService
 
-		addenda_result = AddendaService().render(sales_invoice)
+		tipo_code = (invoice_data.get("type") or "I").upper()
+		addenda_result = None if tipo_code == "E" else AddendaService().render(sales_invoice)
 		if addenda_result is not None:
 			addenda_xml = (addenda_result.get("addenda_xml") or "").strip()
 			if not addenda_xml:
@@ -987,9 +998,10 @@ class TimbradoAPI:
 		# Obtener total fiscal del PAC
 		total_pac = flt(response.get("total", 0))
 
-		# Obtener totales del Sales Invoice guardados en Factura Fiscal
-		si_total_sin_iva = flt(factura_fiscal.si_total_antes_iva)
-		si_total_con_iva = flt(factura_fiscal.si_total_neto)
+		# Obtener totales del Sales Invoice guardados en Factura Fiscal.
+		# abs() handles return SIs (negative amounts) — PAC always returns positive.
+		si_total_sin_iva = abs(flt(factura_fiscal.si_total_antes_iva))
+		si_total_con_iva = abs(flt(factura_fiscal.si_total_neto))
 
 		# Calcular diferencias
 		diff_sin_iva = abs(total_pac - si_total_sin_iva)

--- a/facturacion_mexico/public/js/sales_invoice.js
+++ b/facturacion_mexico/public/js/sales_invoice.js
@@ -147,7 +147,10 @@ function redirect_to_fiscal_document(frm) {
 			if (uuid) {
 				_do_create_ffm(frm, {
 					fm_uuid_relacionado: uuid,
-					fm_tipo_relacion_sat: "01 - Nota de crédito de los documentos relacionados",
+					// Physical merchandise return → TipoRelación 03 (Issue #116)
+					// TipoRelación 01 (discounts/bonifications) handled in Issue #137
+					fm_tipo_relacion_sat:
+						"03 - Devolución de mercancía sobre facturas o traslados previos",
 				});
 			}
 		});


### PR DESCRIPTION
## Objetivo

Implementar el flujo mínimo necesario para que las notas de crédito (CFDI tipo E —
Egreso) timbren correctamente desde una Sales Invoice de devolución en ERPNext.
Issue #116 — funcionalmente cerrado; pendientes normativos en #136 y #137.

## Cambios principales

### Flujo CFDI tipo E
- UUID relacionado obligatorio: guard bloqueante en `_prepare_facturapi_data()` antes
  de enviar a FacturAPI — sin UUID, el timbrado no procede
- `_find_uuid_cfdi_origen()`: fallback server-side con doble ruta (via
  `fm_factura_fiscal_mx` + query directa en FFM por `sales_invoice=return_against`)
- `related_documents` siempre incluido en payload — nunca se omite silenciosamente
- TipoRelación **03** (Devolución de mercancía) para devoluciones físicas desde
  Sales Invoice return — tanto en JS como en Python
- FormaPago centralizada en `_auto_populate_forma_pago_tipo_e()`:
  `outstanding <= nota → 15 Condonación` / `outstanding == 0 → hereda forma origen`
  *(regla provisional — pendiente Issue #136)*

### Campos fiscales tipo E
- `_lock_egreso_fields()` en JS bloquea read-only: `sales_invoice`, `company`,
  `fm_payment_method_sat`, `fm_forma_pago_timbrado`, `fm_facturar_venta_mostrador`,
  `fm_tipo_relacion_sat`, `fm_uuid_relacionado`
- `sales_invoice` read-only en DocType JSON
- `setup_payment_method_radio_buttons` excluido para tipo E

### Otros fixes
- Addenda excluida en CFDI tipo E (sin propagación a SIs de devolución)
- `_validate_amount_discrepancies()` usa `abs()` para manejar montos negativos
  de SIs de devolución
- `_get_origin_ffm()`: hereda `fm_facturar_venta_mostrador` y `fm_payment_method_sat`
  del origen para derivar FormaPago

### Documentación
- ADR 0025 — decisiones de diseño, pendientes normativos y deuda técnica
- ADR 0024 — actualizado con estado final del flujo tipo E

## Validaciones realizadas

- FFMX-2026-00025 (PPD origen, outstanding > 0): TipoRelación=03, FormaPago=15 ✓
- FFMX-2026-00027 (PPD origen, outstanding > 0): TipoRelación=03, FormaPago=15 ✓
- FFMX-2026-00028 (PPD origen, outstanding > 0): TipoRelación=03, FormaPago=15 ✓
- test_tipo_e_nota_credito: 6/6 ✔

## Fuera de alcance

- TipoRelación 01 (descuentos/bonificaciones sin devolución física) — Issue #137
- FormaPago caso saldo-a-favor (outstanding=0, sin reembolso real) — Issue #136
- DocType separado para notas de crédito — Issue #135
- Addenda en tipo E por cliente — Issue #136

## Riesgos / pendientes

- **FormaPago provisional**: la regla basada en `outstanding_amount` es correcta para
  los casos probados, pero el caso `outstanding=0` con "saldo a favor" (sin reembolso
  real) requiere validación con despacho contable antes de producción
- **Deuda técnica FFM**: el FFM acumuló guards dispersos para tipo E; se recomienda
  refactor antes de agregar más funcionalidad tipo E — Issue #135
- Requiere `bench migrate` en sites existentes (cambio DocType `sales_invoice.read_only`)
- Requiere `bench build --app facturacion_mexico` (cambios JS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for issuing Credit Notes (Nota de Crédito) with proper fiscal configuration inherited from the original invoice.
  * Automatic origin invoice UUID resolution for credit notes with fallback lookup.
  * Credit note payment method now inherits from the original invoice and is read-only in the form.

* **Bug Fixes**
  * Corrected SAT relationship code for merchandise returns (TipoRelación 03).
  * Fixed amount validation for negative values in return invoices.
  * Credit notes excluded from addenda propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luisrms69/facturacion_mexico/pull/138)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->