### PR TITLE
feat(catalogos-sat): agregar fixture Metodo Pago SAT (PUE y PPD)

### DIFF
--- a/facturacion_mexico/fixtures/sat_metodo_pago.json
+++ b/facturacion_mexico/fixtures/sat_metodo_pago.json
@@ -1,0 +1,18 @@
+[
+ {
+  "doctype": "Metodo Pago SAT",
+  "name": "PUE",
+  "code": "PUE",
+  "description": "Pago en una sola exhibición",
+  "vigencia_desde": "2017-07-01",
+  "vigencia_hasta": null
+ },
+ {
+  "doctype": "Metodo Pago SAT",
+  "name": "PPD",
+  "code": "PPD",
+  "description": "Pago en parcialidades o diferido",
+  "vigencia_desde": "2017-07-01",
+  "vigencia_hasta": null
+ }
+]


### PR DESCRIPTION
## Objetivo

Poblar el catálogo `Metodo Pago SAT` que existía como DocType vacío.
Sin estos datos el workspace mostraba el catálogo vacío y `sync_sat_catalogs()`
reportaba el catálogo como faltante.

## Cambios principales

- Nuevo archivo `fixtures/sat_metodo_pago.json` con 2 registros SAT:
  - `PUE` — Pago en una sola exhibición
  - `PPD` — Pago en parcialidades o diferido
- Frappe auto-importa todos los JSON de `fixtures/` durante `bench migrate`
  vía `frappe.utils.fixtures.sync_fixtures()` — no requiere cambios en hooks.py

## Validaciones realizadas

- Cargado correctamente en facturacion-v16.dev via bench migrate
- Estructura consistente con otros catálogos SAT del app (Forma Pago, Uso CFDI, etc.)

## Fuera de alcance

- Otros catálogos SAT (ya tienen fixtures)

## Riesgos / pendientes

- Requiere bench migrate en cada site para cargar los datos