### PR TITLE
feat(cfdi-recibidos): Fase 2 — SupplierResolver, ConceptClassifier y CFDI Concepto Mapping (#151)

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,0 +1,85 @@
+# CONTINUITY.md — facturacion_mexico
+
+**Fecha:** 2026-05-23
+**Último PR:** #157 — feat(cfdi-recibidos): Fase 2 — SupplierResolver, ConceptClassifier y CFDI Concepto Mapping
+**Branch:** feature/issue151-cfdi-recibidos-fase2 → main (PR abierto)
+
+---
+
+## Cómo ponerse al tanto — leer en este orden
+
+```
+1. /home/erpnext/frappe-bench-v16/.claude/CLAUDE.md     ← reglas globales del bench
+2. CLAUDE.md (raíz de este repo)                         ← contexto del app
+3. Este archivo: CONTINUITY.md                           ← estado actual
+4. gh pr view 157                                        ← último PR
+```
+
+---
+
+## Estado del módulo cfdi_recibidos
+
+### Fase 1 — ✅ Mergeada (PR #156, 2026-05-23)
+
+| Componente | Estado |
+|---|---|
+| DocType `CFDI Recibido` | ✅ Funcional |
+| DocType `CFDI Recibido Concepto` (child) | ✅ Funcional |
+| Parser XML CFDI 4.0 | ✅ Funcional |
+| Ingesta multi-archivo via API | ✅ Funcional |
+| Deduplicación por UUID + hash | ✅ Funcional |
+| Endpoint `upload_xml` | ✅ Funcional |
+
+### Fase 2 — ⏳ PR #157 abierto
+
+| Componente | Estado |
+|---|---|
+| DocType `CFDI Concepto Mapping` | ✅ Implementado, 18/18 tests |
+| Servicio `SupplierResolver` | ✅ Implementado, tests OK |
+| Servicio `ConceptClassifier` (3 niveles fallback) | ✅ Implementado, tests OK |
+| Endpoints `resolve_supplier`, `classify_concepts`, `save_mapping_rule` | ✅ Implementados |
+| UI inline en bandeja | ❌ Diferida a Fase 2.5 o Fase 3 |
+
+### Restricciones de diseño confirmadas (no modificar sin PR)
+
+- Child `CFDI Recibido Concepto` no almacena resultado de clasificación — estado derivado en servidor
+- No autocreación de Suppliers
+- Sin regex, sin priority, sin GroupedItem en mapping MVP
+- Sin Custom Fields en Purchase Invoice
+
+---
+
+## PRs recientes
+
+| PR | Descripción | Estado |
+|---|---|---|
+| #155 | docs: arquitectura CFDI Recibidos aprobada | Mergeado |
+| #156 | feat: Fase 1 — ingesta, parser y DocTypes | Mergeado 2026-05-23 |
+| #157 | feat: Fase 2 — SupplierResolver, ConceptClassifier, CFDI Concepto Mapping | Abierto |
+
+---
+
+## Próxima tarea
+
+**Issue:** #152 — [CFDI Recibidos][Fase 3] PurchaseInvoiceBuilder, impuestos nativos y batch best-effort
+**Épica:** #149 — [EPIC] CFDI Recibidos / Compras — MVP
+**Dependencia:** PR #157 mergeado
+**Rama a crear:** `feature/issue152-cfdi-recibidos-fase3`
+
+**Pendientes de Fase 2 a resolver en Fase 2.5 o Fase 3:**
+- UI inline en bandeja para resolver proveedor y clasificar conceptos
+- Prueba manual explícita: fallback `supplier_rfc + any clave SAT`
+- Prueba manual explícita: `save_mapping_rule` actualización de regla existente
+- Advertencia en UI al vincular proveedor con RFC diferente al del CFDI
+
+---
+
+## Configuración de desarrollo
+
+| Ítem | Valor |
+|---|---|
+| Bench | `/home/erpnext/frappe-bench-v16` |
+| Site desarrollo | `facturacion-v16.dev` |
+| Site tests | `test-facturacion.localhost` |
+| Comando tests | `bench --site test-facturacion.localhost run-tests --app facturacion_mexico` |
+| Fixtures | `bench --site facturacion-v16.dev export-fixtures --app facturacion_mexico` |

--- a/facturacion_mexico/cfdi_recibidos/api.py
+++ b/facturacion_mexico/cfdi_recibidos/api.py
@@ -1,8 +1,13 @@
 """
-API pública de CFDI Recibidos — Fase 1.
+API pública de CFDI Recibidos.
 
-Endpoints:
-    upload_xml — carga uno o varios XMLs CFDI y los persiste como CFDI Recibido.
+Endpoints Fase 1:
+    upload_xml       — carga uno o varios XMLs CFDI y los persiste como CFDI Recibido.
+
+Endpoints Fase 2:
+    resolve_supplier  — asigna proveedor por RFC o vinculación manual.
+    classify_concepts — aplica CFDI Concepto Mapping sobre conceptos del CFDI.
+    save_mapping_rule — crea o actualiza una regla de clasificación.
 """
 
 import frappe
@@ -60,3 +65,89 @@ def upload_xml(company: str) -> list[dict]:
 		results.append({"file_name": file_name, **result})
 
 	return results
+
+
+@frappe.whitelist()
+def resolve_supplier(cfdi_recibido: str, supplier: str | None = None) -> dict:
+	"""
+	Asigna el proveedor al CFDI Recibido.
+
+	Sin `supplier`: busca automáticamente por Supplier.tax_id == supplier_rfc.
+	Con `supplier`: vinculación manual (aunque el RFC no coincida).
+	No autocrea Suppliers.
+	"""
+	from facturacion_mexico.cfdi_recibidos.services.supplier_resolver import (
+		resolve_supplier as _resolve,
+	)
+
+	if not cfdi_recibido:
+		frappe.throw(_("El campo 'cfdi_recibido' es obligatorio"), frappe.MandatoryError)
+
+	return _resolve(cfdi_recibido, supplier_override=supplier or None)
+
+
+@frappe.whitelist()
+def classify_concepts(cfdi_recibido: str) -> dict:
+	"""
+	Aplica reglas de CFDI Concepto Mapping sobre todos los conceptos.
+
+	Actualiza status del CFDI Recibido:
+	  - Listo: todos los conceptos tienen regla aplicable
+	  - Falta clasif.: al menos uno sin regla
+	"""
+	from facturacion_mexico.cfdi_recibidos.services.concept_classifier import (
+		classify_concepts as _classify,
+	)
+
+	if not cfdi_recibido:
+		frappe.throw(_("El campo 'cfdi_recibido' es obligatorio"), frappe.MandatoryError)
+
+	return _classify(cfdi_recibido)
+
+
+@frappe.whitelist()
+def save_mapping_rule(
+	target_type: str,
+	supplier_rfc: str = "",
+	sat_product_key: str = "",
+	target_item: str = "",
+	target_account: str = "",
+	target_cost_center: str = "",
+	company: str = "",
+) -> dict:
+	"""
+	Crea o actualiza una regla de CFDI Concepto Mapping.
+
+	Si ya existe una regla con la misma combinación company+supplier_rfc+sat_product_key,
+	la actualiza. Si no, crea una nueva.
+
+	Retorna: {status, mapping, message}
+	"""
+	if target_type not in ("Item", "ExpenseAccount"):
+		frappe.throw(_("target_type debe ser 'Item' o 'ExpenseAccount'"), frappe.ValidationError)
+
+	# Check for existing rule with same key combination
+	filters = {"supplier_rfc": supplier_rfc, "sat_product_key": sat_product_key}
+	if company:
+		filters["company"] = company
+
+	existing = frappe.db.get_value("CFDI Concepto Mapping", filters, "name")
+
+	if existing:
+		doc = frappe.get_doc("CFDI Concepto Mapping", existing)
+	else:
+		doc = frappe.new_doc("CFDI Concepto Mapping")
+		doc.company = company or None
+		doc.supplier_rfc = supplier_rfc
+		doc.sat_product_key = sat_product_key
+
+	doc.target_type = target_type
+	doc.target_item = target_item or None
+	doc.target_account = target_account or None
+	doc.target_cost_center = target_cost_center or None
+	doc.is_active = 1
+
+	doc.save(ignore_permissions=True)
+
+	action = "actualizada" if existing else "creada"
+	return {"status": "ok", "mapping": doc.name, "message": f"Regla {action}: {doc.name}"}

--- a/facturacion_mexico/cfdi_recibidos/api.py
+++ b/facturacion_mexico/cfdi_recibidos/api.py
@@ -126,10 +126,12 @@ def save_mapping_rule(
 	if target_type not in ("Item", "ExpenseAccount"):
 		frappe.throw(_("target_type debe ser 'Item' o 'ExpenseAccount'"), frappe.ValidationError)
 
-	# Check for existing rule with same key combination
-	filters = {"supplier_rfc": supplier_rfc, "sat_product_key": sat_product_key}
-	if company:
-		filters["company"] = company
+	# Check for existing rule with same key combination — company siempre incluido en la clave
+	filters = {
+		"supplier_rfc": supplier_rfc,
+		"sat_product_key": sat_product_key,
+		"company": company if company else ["in", ["", None]],
+	}
 
 	existing = frappe.db.get_value("CFDI Concepto Mapping", filters, "name")
 

--- a/facturacion_mexico/cfdi_recibidos/doctype/cfdi_concepto_mapping/cfdi_concepto_mapping.json
+++ b/facturacion_mexico/cfdi_recibidos/doctype/cfdi_concepto_mapping/cfdi_concepto_mapping.json
@@ -1,0 +1,107 @@
+{
+ "doctype": "DocType",
+ "name": "CFDI Concepto Mapping",
+ "module": "CFDI Recibidos",
+ "custom": 0,
+ "is_submittable": 0,
+ "track_changes": 1,
+ "engine": "InnoDB",
+ "naming_rule": "Autoincrement",
+ "fields": [
+  {
+   "fieldname": "section_origen",
+   "label": "Origen",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "company",
+   "label": "Empresa",
+   "fieldtype": "Link",
+   "options": "Company",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "supplier",
+   "label": "Proveedor",
+   "fieldtype": "Link",
+   "options": "Supplier",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "supplier_rfc",
+   "label": "RFC Proveedor",
+   "fieldtype": "Data",
+   "description": "Alternativa a Proveedor si no existe como Supplier en ERPNext"
+  },
+  {
+   "fieldname": "sat_product_key",
+   "label": "Clave Producto/Servicio SAT",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "description": "Vacío = aplica a cualquier clave SAT del proveedor"
+  },
+  {
+   "fieldname": "section_destino",
+   "label": "Destino en ERPNext",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "target_type",
+   "label": "Tipo de Destino",
+   "fieldtype": "Select",
+   "options": "Item\nExpenseAccount",
+   "reqd": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "target_item",
+   "label": "Item",
+   "fieldtype": "Link",
+   "options": "Item",
+   "depends_on": "eval:doc.target_type == 'Item'"
+  },
+  {
+   "fieldname": "target_account",
+   "label": "Cuenta de Gasto",
+   "fieldtype": "Link",
+   "options": "Account",
+   "depends_on": "eval:doc.target_type == 'ExpenseAccount'"
+  },
+  {
+   "fieldname": "target_cost_center",
+   "label": "Centro de Costo",
+   "fieldtype": "Link",
+   "options": "Cost Center"
+  },
+  {
+   "fieldname": "is_active",
+   "label": "Activo",
+   "fieldtype": "Check",
+   "default": "1",
+   "in_list_view": 1
+  }
+ ],
+ "permissions": [
+  {
+   "role": "Facturacion Mexico Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1
+  },
+  {
+   "role": "Facturacion Mexico User",
+   "read": 1,
+   "write": 1,
+   "create": 1
+  },
+  {
+   "role": "System Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1
+  }
+ ],
+ "title_field": "supplier_rfc"
+}

--- a/facturacion_mexico/cfdi_recibidos/doctype/cfdi_concepto_mapping/cfdi_concepto_mapping.py
+++ b/facturacion_mexico/cfdi_recibidos/doctype/cfdi_concepto_mapping/cfdi_concepto_mapping.py
@@ -1,16 +1,32 @@
+import frappe
 from frappe import _
 from frappe.model.document import Document
 
 
 class CFDIConceptoMapping(Document):
 	def validate(self):
+		self._validate_no_duplicado()
+		self._validate_target()
+
+	def _validate_no_duplicado(self):
+		company_filter = self.company or ["in", ["", None]]
+		duplicate = frappe.db.get_value(
+			"CFDI Concepto Mapping",
+			{
+				"name": ["!=", self.name or ""],
+				"company": company_filter,
+				"supplier_rfc": self.supplier_rfc or "",
+				"sat_product_key": self.sat_product_key or "",
+			},
+			"name",
+		)
+		if duplicate:
+			frappe.throw(_("Ya existe una regla con la misma combinación empresa + RFC + clave SAT"))
+
+	def _validate_target(self):
 		if self.target_type == "Item" and not self.target_item:
-			from frappe import throw
-
-			throw(_("El campo 'Item' es obligatorio cuando el tipo de destino es 'Item'"))
+			frappe.throw(_("El campo 'Item' es obligatorio cuando el tipo de destino es 'Item'"))
 		if self.target_type == "ExpenseAccount" and not self.target_account:
-			from frappe import throw
-
-			throw(
+			frappe.throw(
 				_("El campo 'Cuenta de Gasto' es obligatorio cuando el tipo de destino es 'ExpenseAccount'")
 			)

--- a/facturacion_mexico/cfdi_recibidos/doctype/cfdi_concepto_mapping/cfdi_concepto_mapping.py
+++ b/facturacion_mexico/cfdi_recibidos/doctype/cfdi_concepto_mapping/cfdi_concepto_mapping.py
@@ -1,0 +1,16 @@
+from frappe import _
+from frappe.model.document import Document
+
+
+class CFDIConceptoMapping(Document):
+	def validate(self):
+		if self.target_type == "Item" and not self.target_item:
+			from frappe import throw
+
+			throw(_("El campo 'Item' es obligatorio cuando el tipo de destino es 'Item'"))
+		if self.target_type == "ExpenseAccount" and not self.target_account:
+			from frappe import throw
+
+			throw(
+				_("El campo 'Cuenta de Gasto' es obligatorio cuando el tipo de destino es 'ExpenseAccount'")
+			)

--- a/facturacion_mexico/cfdi_recibidos/services/concept_classifier.py
+++ b/facturacion_mexico/cfdi_recibidos/services/concept_classifier.py
@@ -1,0 +1,98 @@
+"""
+ConceptClassifier — clasifica conceptos de un CFDI Recibido via CFDI Concepto Mapping.
+
+Matching MVP (3 niveles, sin regex ni priority):
+  1. company + supplier_rfc + sat_product_key  (exacto)
+  2. supplier_rfc + sat_product_key vacío       (fallback por proveedor)
+  3. sat_product_key + supplier vacío           (fallback por clave SAT)
+
+El resultado NO se almacena en CFDI Recibido Concepto.
+El estado del padre (Listo / Falta clasif.) se actualiza directamente.
+"""
+
+import frappe
+
+
+def classify_concepts(cfdi_recibido_name: str) -> dict:
+	"""
+	Aplica reglas de CFDI Concepto Mapping sobre todos los conceptos del CFDI.
+
+	Retorna: {status, total, matched, unmatched, message}
+	"""
+	doc = frappe.get_doc("CFDI Recibido", cfdi_recibido_name)
+
+	if not doc.conceptos:
+		doc.db_set("status", "Listo")
+		return _result("ok", 0, 0, 0, "Sin conceptos — marcado como Listo")
+
+	supplier_rfc = doc.supplier_rfc or ""
+	company = doc.company or ""
+
+	matched = 0
+	unmatched_keys = []
+
+	for concepto in doc.conceptos:
+		sat_key = concepto.sat_product_key or ""
+		rule = _find_rule(company, supplier_rfc, sat_key)
+		if rule:
+			matched += 1
+		else:
+			unmatched_keys.append(sat_key or "(sin clave SAT)")
+
+	total = len(doc.conceptos)
+	unmatched = total - matched
+
+	if unmatched == 0:
+		doc.db_set("status", "Listo")
+		return _result("ok", total, matched, 0, "Todos los conceptos clasificados")
+
+	doc.db_set("status", "Falta clasif.")
+	return _result(
+		"falta_clasif",
+		total,
+		matched,
+		unmatched,
+		f"Sin regla para: {', '.join(set(unmatched_keys))}",
+	)
+
+
+def _find_rule(company: str, supplier_rfc: str, sat_product_key: str) -> dict | None:
+	"""
+	Busca la primera regla activa aplicable en 3 niveles de especificidad.
+	Retorna el registro de CFDI Concepto Mapping o None.
+	"""
+	filters_levels = [
+		# Nivel 1: exacto — company + supplier_rfc + sat_product_key
+		{"is_active": 1, "supplier_rfc": supplier_rfc, "sat_product_key": sat_product_key},
+		# Nivel 2: fallback por proveedor — supplier_rfc, cualquier clave SAT
+		{"is_active": 1, "supplier_rfc": supplier_rfc, "sat_product_key": ["in", ["", None]]},
+		# Nivel 3: fallback por clave SAT — cualquier proveedor
+		{"is_active": 1, "supplier_rfc": ["in", ["", None]], "sat_product_key": sat_product_key},
+	]
+
+	fields = ["name", "target_type", "target_item", "target_account", "target_cost_center"]
+
+	for filters in filters_levels:
+		if not supplier_rfc and "supplier_rfc" in filters and filters.get("supplier_rfc") == supplier_rfc:
+			# Skip exact/proveedor levels if no rfc available and it's required in filter
+			pass
+		result = frappe.db.get_value("CFDI Concepto Mapping", filters, fields, as_dict=True)
+		if result:
+			return result
+
+	return None
+
+
+def get_rule_for_concept(company: str, supplier_rfc: str, sat_product_key: str) -> dict | None:
+	"""Expone la búsqueda de regla para uso externo (API, tests)."""
+	return _find_rule(company, supplier_rfc, sat_product_key)
+
+
+def _result(status: str, total: int, matched: int, unmatched: int, message: str) -> dict:
+	return {
+		"status": status,
+		"total": total,
+		"matched": matched,
+		"unmatched": unmatched,
+		"message": message,
+	}

--- a/facturacion_mexico/cfdi_recibidos/services/concept_classifier.py
+++ b/facturacion_mexico/cfdi_recibidos/services/concept_classifier.py
@@ -61,21 +61,36 @@ def _find_rule(company: str, supplier_rfc: str, sat_product_key: str) -> dict | 
 	Busca la primera regla activa aplicable en 3 niveles de especificidad.
 	Retorna el registro de CFDI Concepto Mapping o None.
 	"""
+	# Reglas globales (company="") aplican a cualquier empresa — siempre se incluyen en la búsqueda
+	company_filter = ["in", [company, "", None]]
+
 	filters_levels = [
 		# Nivel 1: exacto — company + supplier_rfc + sat_product_key
-		{"is_active": 1, "supplier_rfc": supplier_rfc, "sat_product_key": sat_product_key},
+		{
+			"is_active": 1,
+			"company": company_filter,
+			"supplier_rfc": supplier_rfc,
+			"sat_product_key": sat_product_key,
+		},
 		# Nivel 2: fallback por proveedor — supplier_rfc, cualquier clave SAT
-		{"is_active": 1, "supplier_rfc": supplier_rfc, "sat_product_key": ["in", ["", None]]},
+		{
+			"is_active": 1,
+			"company": company_filter,
+			"supplier_rfc": supplier_rfc,
+			"sat_product_key": ["in", ["", None]],
+		},
 		# Nivel 3: fallback por clave SAT — cualquier proveedor
-		{"is_active": 1, "supplier_rfc": ["in", ["", None]], "sat_product_key": sat_product_key},
+		{
+			"is_active": 1,
+			"company": company_filter,
+			"supplier_rfc": ["in", ["", None]],
+			"sat_product_key": sat_product_key,
+		},
 	]
 
 	fields = ["name", "target_type", "target_item", "target_account", "target_cost_center"]
 
 	for filters in filters_levels:
-		if not supplier_rfc and "supplier_rfc" in filters and filters.get("supplier_rfc") == supplier_rfc:
-			# Skip exact/proveedor levels if no rfc available and it's required in filter
-			pass
 		result = frappe.db.get_value("CFDI Concepto Mapping", filters, fields, as_dict=True)
 		if result:
 			return result

--- a/facturacion_mexico/cfdi_recibidos/services/supplier_resolver.py
+++ b/facturacion_mexico/cfdi_recibidos/services/supplier_resolver.py
@@ -1,0 +1,55 @@
+"""
+SupplierResolver — resuelve el proveedor de un CFDI Recibido por RFC.
+
+Busca Supplier donde tax_id == supplier_rfc del CFDI.
+No autocrea proveedores.
+"""
+
+import frappe
+
+
+def resolve_supplier(cfdi_recibido_name: str, supplier_override: str | None = None) -> dict:
+	"""
+	Intenta asignar el proveedor al CFDI Recibido.
+
+	Si supplier_override se proporciona, usa ese Supplier directamente
+	(vinculación manual desde UI aunque el RFC no coincida).
+	Si no, busca por Supplier.tax_id == cfdi_recibido.supplier_rfc.
+
+	Retorna: {status, supplier, message}
+	"""
+	doc = frappe.get_doc("CFDI Recibido", cfdi_recibido_name)
+
+	if supplier_override:
+		return _assign_supplier(doc, supplier_override, manual=True)
+
+	if not doc.supplier_rfc:
+		return _result("error", None, "El CFDI no tiene RFC de emisor")
+
+	supplier = frappe.db.get_value("Supplier", {"tax_id": doc.supplier_rfc}, "name")
+
+	if supplier:
+		return _assign_supplier(doc, supplier, manual=False)
+
+	doc.db_set("status", "Falta proveedor")
+	return _result("falta_proveedor", None, f"No existe Supplier con RFC {doc.supplier_rfc}")
+
+
+def _assign_supplier(doc, supplier_name: str, manual: bool) -> dict:
+	"""Asigna el proveedor y avanza el estado del CFDI."""
+	if not frappe.db.exists("Supplier", supplier_name):
+		return _result("error", None, f"Proveedor {supplier_name} no existe")
+
+	doc.db_set("supplier", supplier_name)
+
+	# Advance status: check if concepts need classification next
+	current_status = frappe.db.get_value("CFDI Recibido", doc.name, "status")
+	if current_status in ("Falta proveedor", "Cargado", "Parseado"):
+		doc.db_set("status", "Parseado")
+
+	source = "manual" if manual else "RFC"
+	return _result("ok", supplier_name, f"Proveedor asignado por {source}")
+
+
+def _result(status: str, supplier: str | None, message: str) -> dict:
+	return {"status": status, "supplier": supplier, "message": message}

--- a/facturacion_mexico/cfdi_recibidos/tests/test_concept_classifier.py
+++ b/facturacion_mexico/cfdi_recibidos/tests/test_concept_classifier.py
@@ -67,6 +67,19 @@ def _cleanup_rules(supplier_rfc: str, sat_key: str = ""):
 		frappe.db.commit()
 
 
+def _get_expense_account() -> str:
+	"""Devuelve una cuenta de gasto válida en el site de pruebas."""
+	for filters in [
+		{"account_type": "Expense Account", "company": TEST_COMPANY, "is_group": 0},
+		{"root_type": "Expense", "company": TEST_COMPANY, "is_group": 0},
+		{"root_type": "Expense", "is_group": 0},
+	]:
+		account = frappe.db.get_value("Account", filters, "name")
+		if account:
+			return account
+	frappe.throw("No se encontró ninguna cuenta de tipo Expense en el site de pruebas")
+
+
 class TestMappingValidation(unittest.TestCase):
 	def test_item_requiere_target_item(self):
 		doc = frappe.new_doc("CFDI Concepto Mapping")
@@ -94,19 +107,12 @@ class TestMappingValidation(unittest.TestCase):
 
 class TestMatchingExacto(unittest.TestCase):
 	def setUp(self):
-		# Buscar una cuenta de tipo Expense disponible
-		self.account = frappe.db.get_value(
-			"Account",
-			{"account_type": "Expense Account", "company": TEST_COMPANY, "is_group": 0},
-			"name",
-		)
-		if not self.account:
-			self.account = frappe.db.get_value("Account", {"account_type": "Expense", "is_group": 0}, "name")
+		self.account = _get_expense_account()
 		self.rule = _make_rule(
 			TEST_RFC,
 			TEST_SAT_KEY,
 			"ExpenseAccount",
-			target_account=self.account or "Expenses - TEC",
+			target_account=self.account,
 		)
 		self.cfdi = _make_cfdi(
 			"001A",
@@ -148,14 +154,7 @@ class TestMatchingExacto(unittest.TestCase):
 
 class TestMatchingFallback(unittest.TestCase):
 	def setUp(self):
-		self.account = (
-			frappe.db.get_value(
-				"Account",
-				{"account_type": "Expense Account", "company": TEST_COMPANY, "is_group": 0},
-				"name",
-			)
-			or "Expenses - TEC"
-		)
+		self.account = _get_expense_account()
 		# Regla con sat_product_key vacío — aplica a cualquier clave del proveedor
 		self.rule = _make_rule(TEST_RFC, "", "ExpenseAccount", target_account=self.account)
 		self.cfdi = _make_cfdi(

--- a/facturacion_mexico/cfdi_recibidos/tests/test_concept_classifier.py
+++ b/facturacion_mexico/cfdi_recibidos/tests/test_concept_classifier.py
@@ -1,0 +1,230 @@
+"""
+Tests de ConceptClassifier y CFDI Concepto Mapping — Fase 2.
+
+unittest.TestCase con contexto Frappe activo.
+"""
+
+import unittest
+
+import frappe
+
+from facturacion_mexico.cfdi_recibidos.services.concept_classifier import (
+	classify_concepts,
+	get_rule_for_concept,
+)
+
+TEST_COMPANY = "_Test Company"
+TEST_RFC = "CNA201211FM9"
+TEST_SAT_KEY = "43231500"
+UUID_BASE = "CLSF0001-0001-0001-0001-"
+
+
+def _make_cfdi(uuid_suffix: str, conceptos: list | None = None) -> str:
+	doc = frappe.new_doc("CFDI Recibido")
+	doc.company = TEST_COMPANY
+	doc.uuid = f"{UUID_BASE}{uuid_suffix}"
+	doc.supplier_rfc = TEST_RFC
+	doc.supplier_name = "Test Supplier"
+	doc.receiver_rfc = frappe.db.get_value("Company", TEST_COMPANY, "tax_id") or "RFC000000000"
+	doc.status = "Parseado"
+	doc.cfdi_type = "I"
+	doc.xml_hash = frappe.generate_hash()[:64]
+	for c in conceptos or []:
+		doc.append("conceptos", c)
+	doc.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return doc.name
+
+
+def _make_rule(supplier_rfc: str, sat_key: str, target_type: str, **kwargs) -> str:
+	doc = frappe.new_doc("CFDI Concepto Mapping")
+	doc.supplier_rfc = supplier_rfc
+	doc.sat_product_key = sat_key
+	doc.target_type = target_type
+	doc.is_active = 1
+	for k, v in kwargs.items():
+		setattr(doc, k, v)
+	doc.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return doc.name
+
+
+def _cleanup_cfdi(uuid_suffix: str):
+	name = frappe.db.get_value("CFDI Recibido", {"uuid": f"{UUID_BASE}{uuid_suffix}"}, "name")
+	if name:
+		frappe.delete_doc("CFDI Recibido", name, force=True)
+		frappe.db.commit()
+
+
+def _cleanup_rules(supplier_rfc: str, sat_key: str = ""):
+	filters = {"supplier_rfc": supplier_rfc}
+	if sat_key:
+		filters["sat_product_key"] = sat_key
+	names = frappe.db.get_all("CFDI Concepto Mapping", filters=filters, pluck="name")
+	for name in names:
+		frappe.delete_doc("CFDI Concepto Mapping", name, force=True)
+	if names:
+		frappe.db.commit()
+
+
+class TestMappingValidation(unittest.TestCase):
+	def test_item_requiere_target_item(self):
+		doc = frappe.new_doc("CFDI Concepto Mapping")
+		doc.supplier_rfc = "TEST000000AAA"
+		doc.target_type = "Item"
+		with self.assertRaises(Exception):
+			doc.insert(ignore_permissions=True)
+
+	def test_expense_account_requiere_target_account(self):
+		doc = frappe.new_doc("CFDI Concepto Mapping")
+		doc.supplier_rfc = "TEST000000AAA"
+		doc.target_type = "ExpenseAccount"
+		with self.assertRaises(Exception):
+			doc.insert(ignore_permissions=True)
+
+	def test_child_no_tiene_mapped_fields(self):
+		meta = frappe.get_meta("CFDI Recibido Concepto")
+		field_names = [f.fieldname for f in meta.fields]
+		self.assertNotIn("mapped_type", field_names)
+		self.assertNotIn("mapped_item", field_names)
+		self.assertNotIn("mapped_account", field_names)
+		self.assertNotIn("mapped_cost_center", field_names)
+		self.assertNotIn("classification_status", field_names)
+
+
+class TestMatchingExacto(unittest.TestCase):
+	def setUp(self):
+		# Buscar una cuenta de tipo Expense disponible
+		self.account = frappe.db.get_value(
+			"Account",
+			{"account_type": "Expense Account", "company": TEST_COMPANY, "is_group": 0},
+			"name",
+		)
+		if not self.account:
+			self.account = frappe.db.get_value("Account", {"account_type": "Expense", "is_group": 0}, "name")
+		self.rule = _make_rule(
+			TEST_RFC,
+			TEST_SAT_KEY,
+			"ExpenseAccount",
+			target_account=self.account or "Expenses - TEC",
+		)
+		self.cfdi = _make_cfdi(
+			"001A",
+			[
+				{
+					"sat_product_key": TEST_SAT_KEY,
+					"description": "Servicio",
+					"quantity": 1,
+					"unit_key": "E48",
+					"unit": "Servicio",
+					"unit_price": 100,
+					"amount": 100,
+					"discount": 0,
+					"tax_object": "02",
+					"taxes_json": "{}",
+				}
+			],
+		)
+
+	def tearDown(self):
+		_cleanup_cfdi("001A")
+		_cleanup_rules(TEST_RFC, TEST_SAT_KEY)
+
+	def test_matching_exacto(self):
+		rule = get_rule_for_concept(TEST_COMPANY, TEST_RFC, TEST_SAT_KEY)
+		self.assertIsNotNone(rule)
+
+	def test_classify_todos_listo(self):
+		result = classify_concepts(self.cfdi)
+		self.assertEqual(result["status"], "ok")
+		self.assertEqual(result["matched"], 1)
+		self.assertEqual(result["unmatched"], 0)
+
+	def test_status_doc_listo(self):
+		classify_concepts(self.cfdi)
+		status = frappe.db.get_value("CFDI Recibido", self.cfdi, "status")
+		self.assertEqual(status, "Listo")
+
+
+class TestMatchingFallback(unittest.TestCase):
+	def setUp(self):
+		self.account = (
+			frappe.db.get_value(
+				"Account",
+				{"account_type": "Expense Account", "company": TEST_COMPANY, "is_group": 0},
+				"name",
+			)
+			or "Expenses - TEC"
+		)
+		# Regla con sat_product_key vacío — aplica a cualquier clave del proveedor
+		self.rule = _make_rule(TEST_RFC, "", "ExpenseAccount", target_account=self.account)
+		self.cfdi = _make_cfdi(
+			"001B",
+			[
+				{
+					"sat_product_key": "99999999",
+					"description": "Otro servicio",
+					"quantity": 1,
+					"unit_key": "E48",
+					"unit": "S",
+					"unit_price": 50,
+					"amount": 50,
+					"discount": 0,
+					"tax_object": "02",
+					"taxes_json": "{}",
+				}
+			],
+		)
+
+	def tearDown(self):
+		_cleanup_cfdi("001B")
+		_cleanup_rules(TEST_RFC, "")
+
+	def test_fallback_proveedor_sin_sat_key(self):
+		rule = get_rule_for_concept(TEST_COMPANY, TEST_RFC, "99999999")
+		self.assertIsNotNone(rule)
+
+	def test_classify_listo_via_fallback(self):
+		result = classify_concepts(self.cfdi)
+		self.assertEqual(result["status"], "ok")
+
+
+class TestSinMatch(unittest.TestCase):
+	def setUp(self):
+		self.cfdi = _make_cfdi(
+			"001C",
+			[
+				{
+					"sat_product_key": "SINMATCH00",
+					"description": "Sin regla",
+					"quantity": 1,
+					"unit_key": "E48",
+					"unit": "S",
+					"unit_price": 10,
+					"amount": 10,
+					"discount": 0,
+					"tax_object": "02",
+					"taxes_json": "{}",
+				}
+			],
+		)
+
+	def tearDown(self):
+		_cleanup_cfdi("001C")
+
+	def test_sin_match_retorna_falta_clasif(self):
+		result = classify_concepts(self.cfdi)
+		self.assertEqual(result["status"], "falta_clasif")
+		self.assertEqual(result["unmatched"], 1)
+
+	def test_status_doc_falta_clasif(self):
+		classify_concepts(self.cfdi)
+		status = frappe.db.get_value("CFDI Recibido", self.cfdi, "status")
+		self.assertEqual(status, "Falta clasif.")
+
+	def test_child_no_recibe_clasificacion(self):
+		classify_concepts(self.cfdi)
+		doc = frappe.get_doc("CFDI Recibido", self.cfdi)
+		for c in doc.conceptos:
+			self.assertFalse(hasattr(c, "mapped_type"))
+			self.assertFalse(hasattr(c, "mapped_item"))

--- a/facturacion_mexico/cfdi_recibidos/tests/test_supplier_resolver.py
+++ b/facturacion_mexico/cfdi_recibidos/tests/test_supplier_resolver.py
@@ -1,0 +1,115 @@
+"""
+Tests de SupplierResolver — Fase 2.
+
+unittest.TestCase con contexto Frappe activo.
+Crea y limpia registros reales en BD de pruebas.
+"""
+
+import unittest
+
+import frappe
+
+from facturacion_mexico.cfdi_recibidos.services.supplier_resolver import resolve_supplier
+
+TEST_RFC = "PROV9001011AA"
+TEST_COMPANY = "_Test Company"
+TEST_UUID_BASE = "SUPP0001-0001-0001-0001-"
+
+
+def _get_or_create_supplier(rfc: str) -> str:
+	"""Obtiene o crea un Supplier de prueba con el RFC dado."""
+	existing = frappe.db.get_value("Supplier", {"tax_id": rfc}, "name")
+	if existing:
+		return existing
+	sup = frappe.new_doc("Supplier")
+	sup.supplier_name = f"Proveedor Test {rfc}"
+	sup.supplier_group = frappe.db.get_value("Supplier Group", {}, "name") or "All Supplier Groups"
+	sup.tax_id = rfc
+	sup.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return sup.name
+
+
+def _make_cfdi(uuid_suffix: str, supplier_rfc: str, company: str) -> str:
+	"""Crea un CFDI Recibido mínimo para pruebas."""
+	doc = frappe.new_doc("CFDI Recibido")
+	doc.company = company
+	doc.uuid = f"{TEST_UUID_BASE}{uuid_suffix}"
+	doc.supplier_rfc = supplier_rfc
+	doc.supplier_name = "Proveedor Test"
+	doc.receiver_rfc = frappe.db.get_value("Company", company, "tax_id") or "RFC000000000"
+	doc.status = "Parseado"
+	doc.cfdi_type = "I"
+	doc.xml_hash = frappe.generate_hash()[:64]
+	doc.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return doc.name
+
+
+def _cleanup(uuid_suffix: str):
+	name = frappe.db.get_value("CFDI Recibido", {"uuid": f"{TEST_UUID_BASE}{uuid_suffix}"}, "name")
+	if name:
+		frappe.delete_doc("CFDI Recibido", name, force=True)
+		frappe.db.commit()
+
+
+class TestSupplierResolverAuto(unittest.TestCase):
+	def setUp(self):
+		self.supplier = _get_or_create_supplier(TEST_RFC)
+		self.cfdi = _make_cfdi("000A", TEST_RFC, TEST_COMPANY)
+
+	def tearDown(self):
+		_cleanup("000A")
+
+	def test_resuelve_por_rfc(self):
+		result = resolve_supplier(self.cfdi)
+		self.assertEqual(result["status"], "ok")
+		self.assertEqual(result["supplier"], self.supplier)
+
+	def test_asigna_supplier_al_doc(self):
+		resolve_supplier(self.cfdi)
+		supplier_en_doc = frappe.db.get_value("CFDI Recibido", self.cfdi, "supplier")
+		self.assertEqual(supplier_en_doc, self.supplier)
+
+	def test_status_avanza(self):
+		resolve_supplier(self.cfdi)
+		status = frappe.db.get_value("CFDI Recibido", self.cfdi, "status")
+		self.assertNotEqual(status, "Falta proveedor")
+
+
+class TestSupplierResolverSinMatch(unittest.TestCase):
+	def setUp(self):
+		self.cfdi = _make_cfdi("000B", "RFC_SIN_MATCH_999", TEST_COMPANY)
+
+	def tearDown(self):
+		_cleanup("000B")
+
+	def test_status_falta_proveedor(self):
+		result = resolve_supplier(self.cfdi)
+		self.assertEqual(result["status"], "falta_proveedor")
+		self.assertIsNone(result["supplier"])
+
+	def test_doc_queda_falta_proveedor(self):
+		resolve_supplier(self.cfdi)
+		status = frappe.db.get_value("CFDI Recibido", self.cfdi, "status")
+		self.assertEqual(status, "Falta proveedor")
+
+
+class TestSupplierResolverManual(unittest.TestCase):
+	def setUp(self):
+		self.supplier = _get_or_create_supplier(TEST_RFC)
+		# CFDI con RFC distinto al del supplier — solo vinculación manual puede resolverlo
+		self.cfdi = _make_cfdi("000C", "RFC_DIFERENTE_ABC", TEST_COMPANY)
+
+	def tearDown(self):
+		_cleanup("000C")
+
+	def test_vinculacion_manual_aunque_rfc_no_coincida(self):
+		result = resolve_supplier(self.cfdi, supplier_override=self.supplier)
+		self.assertEqual(result["status"], "ok")
+		self.assertEqual(result["supplier"], self.supplier)
+
+	def test_supplier_asignado_manualmente(self):
+		resolve_supplier(self.cfdi, supplier_override=self.supplier)
+		supplier_en_doc = frappe.db.get_value("CFDI Recibido", self.cfdi, "supplier")
+		self.assertEqual(supplier_en_doc, self.supplier)

--- a/facturacion_mexico/cfdi_recibidos/tests/test_supplier_resolver.py
+++ b/facturacion_mexico/cfdi_recibidos/tests/test_supplier_resolver.py
@@ -21,9 +21,18 @@ def _get_or_create_supplier(rfc: str) -> str:
 	existing = frappe.db.get_value("Supplier", {"tax_id": rfc}, "name")
 	if existing:
 		return existing
+
+	supplier_group = frappe.db.get_value("Supplier Group", {"is_group": 0}, "name")
+	if not supplier_group:
+		sg = frappe.new_doc("Supplier Group")
+		sg.supplier_group_name = "Test Suppliers"
+		sg.insert(ignore_permissions=True)
+		frappe.db.commit()
+		supplier_group = sg.name
+
 	sup = frappe.new_doc("Supplier")
 	sup.supplier_name = f"Proveedor Test {rfc}"
-	sup.supplier_group = frappe.db.get_value("Supplier Group", {}, "name") or "All Supplier Groups"
+	sup.supplier_group = supplier_group
 	sup.tax_id = rfc
 	sup.insert(ignore_permissions=True)
 	frappe.db.commit()


### PR DESCRIPTION
## Objetivo

Completar Fase 2 del módulo CFDI Recibidos: resolver proveedor por RFC y clasificar
conceptos via reglas de mapping, dejando los XMLs en estado "Listo" para generar
Purchase Invoice en Fase 3.

## Cambios principales

### DocType nuevo: `CFDI Concepto Mapping`
- Reglas de clasificación con 3 niveles de especificidad:
  1. `company + supplier_rfc + sat_product_key` (exacto)
  2. `supplier_rfc + sat_product_key vacío` (fallback por proveedor)
  3. `sat_product_key + supplier vacío` (fallback por clave SAT)
- `target_type`: Item o ExpenseAccount
- Sin regex, sin priority, sin GroupedItem (diferidos a fase futura)

### Servicio: `SupplierResolver`
- Busca `Supplier.tax_id == supplier_rfc` automáticamente
- Vinculación manual aunque el RFC no coincida exactamente
- No autocrea Suppliers — evita duplicados en maestro

### Servicio: `ConceptClassifier`
- Aplica reglas de CFDI Concepto Mapping sobre todos los conceptos
- Estado derivado en servidor: "Listo" / "Falta clasif."
- No almacena resultado en child `CFDI Recibido Concepto`

### API: 3 endpoints nuevos en `cfdi_recibidos/api.py`
- `resolve_supplier(cfdi_recibido, supplier?)` — auto o manual
- `classify_concepts(cfdi_recibido)` — aplica mapping
- `save_mapping_rule(...)` — crea o actualiza regla (upsert por company+rfc+sat_key)

## Validaciones realizadas

- ✅ 18/18 tests automáticos (test_supplier_resolver + test_concept_classifier)
- ✅ bench migrate limpio — CFDI Concepto Mapping visible en Desk
- ✅ Validaciones de mapping correctas (target_item obligatorio si Item, etc.)
- ✅ SupplierResolver: auto por RFC, manual sin coincidencia RFC, sin match → "Falta proveedor"
- ✅ ConceptClassifier + API probados manualmente (11/11 casos)
- ✅ ruff check + ruff format: 0 errores
- ✅ mkdocs build --strict: exit 0

## Fuera de alcance

- UI inline en bandeja (diferida a Fase 2.5 o Fase 3)
- Regex y priority en mapping (diferidos)
- GroupedItem (diferido)
- Generación de Purchase Invoice (Fase 3)
- Custom Fields en Purchase Invoice

## Riesgos / pendientes

- Falta prueba manual explícita: fallback `supplier_rfc + any clave SAT`
- Falta prueba manual explícita: `save_mapping_rule` actualización de regla existente
- CLAUDE.md no refleja aún `CFDI Concepto Mapping` en tabla de DocTypes (cosmético)
- Vincular proveedor con RFC diferente puede crear inconsistencias si existen duplicados en maestro — la UI deberá mostrar advertencia (pendiente Fase 2.5)
- `CONTINUITY.md` pendiente de crear/actualizar post-merge (tarea post-PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added three new API endpoints for CFDI Recibidos (Phase 2): automatic supplier resolution, concept classification, and mapping rule management.
* Introduced CFDI Concepto Mapping feature to create and manage mapping rules between supplier invoices and ERP accounts/items.
* Enabled automatic supplier assignment and intelligent concept classification for received documents.

**Tests**
* Added comprehensive unit tests for supplier resolution and concept classification workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luisrms69/facturacion_mexico/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->