### PR TITLE
docs(cfdi-recibidos): API reference y guía de usuario Fase 1 + Fase 2

### DIFF
--- a/docs/api/cfdi-recibidos.md
+++ b/docs/api/cfdi-recibidos.md
@@ -1,0 +1,257 @@
+# CFDI Recibidos - API Reference
+
+Documentación de los endpoints para ingesta y clasificación de CFDIs recibidos (XML de proveedores).
+
+---
+
+## Endpoints disponibles
+
+| Endpoint | Método | Descripción |
+|---|---|---|
+| `upload_xml` | POST (form-data) | Ingesta uno o varios XMLs CFDI 4.0 |
+| `resolve_supplier` | POST | Asigna proveedor por RFC o vinculación manual |
+| `classify_concepts` | POST | Aplica reglas de clasificación a los conceptos del CFDI |
+| `save_mapping_rule` | POST | Crea o actualiza una regla de CFDI Concepto Mapping |
+
+Todos los endpoints están bajo:
+
+```
+/api/method/facturacion_mexico.cfdi_recibidos.api.<endpoint>
+```
+
+---
+
+## `upload_xml`
+
+Carga uno o varios archivos XML CFDI 4.0 y los persiste como documentos **CFDI Recibido**.
+
+### Parámetros (form-data)
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `company` | string | ✅ | Nombre de la empresa en ERPNext |
+| `files` | archivo(s) | ✅ | Uno o más archivos XML (campo `files` o `file`) |
+
+### Respuesta
+
+Lista de resultados por archivo:
+
+```json
+[
+  {
+    "file_name": "factura_proveedor.xml",
+    "status": "ok",
+    "cfdi_recibido": "CFDI-REC-0001",
+    "uuid": "6128396f-c09b-4ec6-8699-43855fd7d7a2",
+    "message": "CFDI procesado correctamente"
+  }
+]
+```
+
+| Campo | Valores posibles | Descripción |
+|---|---|---|
+| `status` | `ok` / `duplicado` / `error` | Resultado del procesamiento |
+| `cfdi_recibido` | string / null | Nombre del doc creado |
+| `uuid` | string / null | UUID extraído del XML |
+| `message` | string | Descripción del resultado |
+
+### Comportamiento por estado
+
+- **`ok`** — CFDI procesado y creado en estado `Parseado`. RFC del receptor coincide con `Company.tax_id`.
+- **`duplicado`** — Ya existe un CFDI Recibido con ese UUID. No se crea documento nuevo.
+- **`error`** — XML inválido, CFDI versión 3.3, o RFC receptor no corresponde a la empresa. El documento se crea en estado `Error` con `error_message`.
+
+### Validaciones internas
+
+1. Calcula SHA256 del XML para detectar archivos idénticos
+2. Parsea el XML (solo CFDI 4.0 — rechaza versión 3.3)
+3. Detecta duplicados por UUID antes de insertar
+4. Valida que `receiver_rfc` del XML coincida con `Company.tax_id`
+5. Persiste conceptos como filas child en `CFDI Recibido Concepto`
+6. Adjunta el XML original como archivo privado al documento
+
+---
+
+## `resolve_supplier`
+
+Asigna el proveedor al CFDI Recibido. Busca automáticamente por RFC o acepta vinculación manual.
+
+### Parámetros
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `cfdi_recibido` | string | ✅ | Nombre del CFDI Recibido |
+| `supplier` | string | ❌ | Supplier específico (vinculación manual) |
+
+### Respuesta
+
+```json
+{
+  "status": "ok",
+  "supplier": "Proveedor Ejemplo S.A.",
+  "message": "Proveedor asignado por RFC"
+}
+```
+
+| `status` | Descripción |
+|---|---|
+| `ok` | Proveedor asignado correctamente |
+| `falta_proveedor` | No existe `Supplier` con `tax_id` igual al RFC del CFDI |
+| `error` | Error interno (CFDI sin RFC emisor, Supplier inexistente, etc.) |
+
+### Modos de operación
+
+**Automático** (sin `supplier`): busca `Supplier` donde `tax_id == cfdi_recibido.supplier_rfc`. No autocrea proveedores.
+
+**Manual** (con `supplier`): asigna el Supplier indicado directamente, aunque el RFC no coincida. Útil para CFDIs de proveedores sin `tax_id` configurado en ERPNext.
+
+### Efecto en el estado del CFDI
+
+- Si se asigna proveedor: estado avanza a `Parseado` (listo para clasificar conceptos).
+- Si no se encuentra: estado queda en `Falta proveedor`.
+
+---
+
+## `classify_concepts`
+
+Aplica las reglas de **CFDI Concepto Mapping** sobre todos los conceptos del CFDI y actualiza su estado.
+
+### Parámetros
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `cfdi_recibido` | string | ✅ | Nombre del CFDI Recibido |
+
+### Respuesta
+
+```json
+{
+  "status": "ok",
+  "total": 3,
+  "matched": 3,
+  "unmatched": 0,
+  "message": "Todos los conceptos clasificados"
+}
+```
+
+| `status` | Descripción |
+|---|---|
+| `ok` | Todos los conceptos tienen regla aplicable → CFDI pasa a `Listo` |
+| `falta_clasif` | Al menos un concepto sin regla → CFDI pasa a `Falta clasif.` |
+
+### Algoritmo de matching (3 niveles)
+
+Para cada concepto, busca en `CFDI Concepto Mapping` en orden de especificidad decreciente:
+
+| Nivel | Condiciones | Descripción |
+|---|---|---|
+| 1 | `company` + `supplier_rfc` + `sat_product_key` | Exacto — empresa + proveedor + clave SAT |
+| 2 | `company` + `supplier_rfc` + `sat_product_key` vacío | Fallback por proveedor — cualquier clave SAT |
+| 3 | `company` + `supplier_rfc` vacío + `sat_product_key` | Fallback por clave SAT — cualquier proveedor |
+
+Las reglas con `company` vacío son **globales** y aplican a cualquier empresa.
+Solo se consideran reglas con `is_active = 1`.
+
+---
+
+## `save_mapping_rule`
+
+Crea o actualiza una regla en **CFDI Concepto Mapping**. Si ya existe una regla con la misma combinación `(company, supplier_rfc, sat_product_key)`, la actualiza. Si no, crea una nueva.
+
+### Parámetros
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `target_type` | string | ✅ | `"Item"` o `"ExpenseAccount"` |
+| `supplier_rfc` | string | ❌ | RFC del proveedor (vacío = cualquier proveedor) |
+| `sat_product_key` | string | ❌ | Clave SAT del producto/servicio (vacío = cualquier clave) |
+| `target_item` | string | ❌ | Nombre del Item en ERPNext (requerido si `target_type = "Item"`) |
+| `target_account` | string | ❌ | Nombre de la cuenta de gasto (requerido si `target_type = "ExpenseAccount"`) |
+| `target_cost_center` | string | ❌ | Centro de costo (opcional) |
+| `company` | string | ❌ | Empresa (vacío = regla global) |
+
+### Respuesta
+
+```json
+{
+  "status": "ok",
+  "mapping": "CFDI-MAP-0001",
+  "message": "Regla creada: CFDI-MAP-0001"
+}
+```
+
+### Ejemplos
+
+**Regla exacta para un proveedor específico:**
+```json
+{
+  "target_type": "ExpenseAccount",
+  "supplier_rfc": "PROV901011AAA",
+  "sat_product_key": "43231500",
+  "target_account": "Gastos de Tecnología - MX",
+  "company": "Mi Empresa S.A. de C.V."
+}
+```
+
+**Regla global para toda la empresa (cualquier proveedor, cualquier clave SAT):**
+```json
+{
+  "target_type": "ExpenseAccount",
+  "supplier_rfc": "",
+  "sat_product_key": "",
+  "target_account": "Gastos Generales - MX",
+  "company": "Mi Empresa S.A. de C.V."
+}
+```
+
+---
+
+## DocTypes relacionados
+
+### CFDI Recibido
+
+Documento principal que representa un CFDI recibido de un proveedor.
+
+| Campo | Descripción |
+|---|---|
+| `uuid` | UUID único del CFDI (clave de deduplicación) |
+| `company` | Empresa receptora |
+| `supplier_rfc` | RFC del emisor (proveedor) |
+| `supplier` | Link al `Supplier` en ERPNext (asignado por `resolve_supplier`) |
+| `status` | `Parseado` / `Falta proveedor` / `Falta clasif.` / `Listo` / `Error` |
+| `cfdi_type` | Tipo de comprobante: `I` (Ingreso), `E` (Egreso), `P` (Pago), etc. |
+| `xml_file` | URL del XML original adjunto (privado) |
+| `xml_hash` | SHA256 del XML para detección de duplicados |
+| `conceptos` | Child table — filas `CFDI Recibido Concepto` |
+
+### CFDI Recibido Concepto
+
+Fila child del CFDI Recibido. Representa una línea del XML.
+
+| Campo | Descripción |
+|---|---|
+| `sat_product_key` | Clave SAT del producto/servicio |
+| `description` | Descripción del concepto |
+| `quantity` | Cantidad |
+| `unit_price` | Precio unitario |
+| `amount` | Importe total |
+| `taxes_json` | Impuestos del concepto en JSON |
+
+### CFDI Concepto Mapping
+
+Reglas de clasificación para mapear conceptos de CFDIs recibidos a Items o cuentas de gasto.
+
+| Campo | Descripción |
+|---|---|
+| `company` | Empresa a la que aplica (vacío = global) |
+| `supplier_rfc` | RFC del proveedor (vacío = cualquier proveedor) |
+| `sat_product_key` | Clave SAT (vacío = cualquier clave) |
+| `target_type` | `Item` o `ExpenseAccount` |
+| `target_item` | Item de ERPNext destino |
+| `target_account` | Cuenta de gasto destino |
+| `target_cost_center` | Centro de costo (opcional) |
+| `is_active` | Activa / inactiva (solo reglas activas aplican en el matching) |
+
+!!! warning "Unicidad de reglas"
+    No puede existir más de una regla activa con la misma combinación `(company, supplier_rfc, sat_product_key)`.
+    El DocType valida esto en `validate()` y la API lo maneja como upsert.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,6 +13,9 @@ APIs para gestión de múltiples branches y coordinación.
 ### Addendas
 Generación dinámica de addendas según reglas de negocio.
 
+### CFDI Recibidos
+Ingesta, validación y clasificación de CFDIs recibidos de proveedores.
+
 ### Catalogos SAT
 Sincronización y gestión de catalogos oficiales del SAT.
 

--- a/docs/user-guide/cfdi-recibidos.md
+++ b/docs/user-guide/cfdi-recibidos.md
@@ -1,0 +1,134 @@
+# CFDI Recibidos
+
+Guía para registrar y clasificar comprobantes fiscales recibidos de proveedores.
+
+---
+
+## ¿Qué es un CFDI Recibido?
+
+Un CFDI Recibido es el XML que emite un proveedor cuando te vende un bien o servicio. Este módulo permite cargar esos XMLs a ERPNext, validarlos contra el SAT, identificar al proveedor automáticamente y clasificar cada concepto para facilitar el registro contable.
+
+---
+
+## Flujo de trabajo
+
+```
+1. Cargar XML  →  2. Resolver proveedor  →  3. Clasificar conceptos  →  4. Listo
+   (upload_xml)    (resolve_supplier)        (classify_concepts)
+```
+
+Cada paso avanza el estado del documento:
+
+| Estado | Significado |
+|---|---|
+| `Parseado` | XML cargado y válido, proveedor pendiente |
+| `Falta proveedor` | No se encontró Supplier con el RFC del emisor |
+| `Falta clasif.` | Proveedor asignado, pero hay conceptos sin regla |
+| `Listo` | Todos los conceptos clasificados — listo para registro contable |
+| `Error` | El RFC receptor del CFDI no corresponde a la empresa, o XML inválido |
+
+---
+
+## Paso 1 — Cargar el XML
+
+Desde la API o desde la interfaz, carga el XML del CFDI recibido indicando la empresa receptora.
+
+El sistema valida automáticamente:
+
+- Que el XML sea **CFDI versión 4.0** (los CFDI 3.3 son rechazados)
+- Que el **RFC receptor** en el XML coincida con el RFC configurado en la empresa de ERPNext
+- Que el UUID no sea **duplicado** (si ya existe, retorna el documento existente)
+
+Si la validación pasa, se crea el documento `CFDI Recibido` con todos los datos del comprobante y el XML adjunto de forma privada.
+
+---
+
+## Paso 2 — Resolver proveedor
+
+El sistema busca automáticamente un `Supplier` en ERPNext cuyo campo **Tax ID** coincida con el RFC emisor del CFDI.
+
+!!! info "Vinculación automática"
+    Si encuentras que el proveedor no se resuelve automáticamente, verifica que el campo `Tax ID` del `Supplier` esté configurado con el RFC correcto.
+
+**Si el proveedor no existe en ERPNext:**
+
+El documento queda en estado `Falta proveedor`. Tienes dos opciones:
+
+1. **Crear el proveedor** en ERPNext con el RFC correcto en `Tax ID`, y luego ejecutar `resolve_supplier` nuevamente.
+2. **Vinculación manual**: llamar a `resolve_supplier` con el parámetro `supplier` para asignar directamente un Supplier aunque el RFC no coincida.
+
+!!! warning "Este módulo no autocrea proveedores"
+    Por diseño, el sistema no crea Suppliers automáticamente. Es necesario que el proveedor ya exista en ERPNext.
+
+---
+
+## Paso 3 — Clasificar conceptos
+
+Cada línea del CFDI (concepto) necesita una **regla de clasificación** que indique a qué Item o cuenta de gasto de ERPNext corresponde.
+
+Las reglas se configuran en el DocType **CFDI Concepto Mapping**.
+
+### Crear reglas de clasificación
+
+Puedes crear reglas desde el Desk (DocType `CFDI Concepto Mapping`) o via la API `save_mapping_rule`.
+
+Una regla define:
+
+- **¿A qué empresa aplica?** — vacío significa que aplica a todas las empresas
+- **¿A qué proveedor aplica?** — por RFC, o vacío para cualquier proveedor
+- **¿A qué clave SAT aplica?** — la clave del producto/servicio, o vacío para cualquier clave
+- **¿A qué destino mapea?** — un `Item` de ERPNext o una cuenta de `Gastos`
+
+### Niveles de especificidad
+
+Cuando se clasifica un concepto, el sistema busca la regla más específica disponible:
+
+| Nivel | Qué aplica |
+|---|---|
+| **1 — Exacto** | Empresa + RFC proveedor + clave SAT exactos |
+| **2 — Proveedor** | Empresa + RFC proveedor (cualquier clave SAT) |
+| **3 — Clave SAT** | Empresa + clave SAT (cualquier proveedor) |
+
+Si ninguna regla aplica, el concepto queda sin clasificar y el CFDI pasa a `Falta clasif.`
+
+### Ejemplo de configuración de reglas
+
+**Caso típico: proveedor de software con clave SAT 43231500**
+```
+Empresa:          Mi Empresa S.A. de C.V.
+RFC proveedor:    SOFT901011AAA
+Clave SAT:        43231500
+Tipo destino:     Cuenta de Gasto
+Cuenta:           Gastos de Software - MX
+```
+
+**Fallback genérico para gastos varios (cualquier proveedor, cualquier clave)**
+```
+Empresa:          Mi Empresa S.A. de C.V.
+RFC proveedor:    (vacío)
+Clave SAT:        (vacío)
+Tipo destino:     Cuenta de Gasto
+Cuenta:           Gastos Generales - MX
+```
+
+!!! tip "Estrategia recomendada"
+    Empieza con reglas genéricas (fallbacks) y agrega reglas específicas conforme identifiques proveedores frecuentes. El sistema siempre usa la regla más específica disponible.
+
+---
+
+## Preguntas frecuentes
+
+**¿Qué pasa si cargo el mismo XML dos veces?**
+El sistema detecta el duplicado por UUID y retorna el documento existente sin crear uno nuevo.
+
+**¿Puedo cargar CFDIs de versión 3.3?**
+No. Este módulo solo soporta CFDI 4.0. Los XMLs de versión 3.3 son rechazados con un mensaje de error explícito.
+
+**¿El RFC del CFDI debe coincidir exactamente con el RFC de la empresa?**
+Sí. Si el RFC receptor en el XML no coincide con `Company.tax_id` en ERPNext, el CFDI queda en estado `Error`. Verifica que el RFC de la empresa esté correctamente configurado en ERPNext.
+
+**¿Qué es una regla global?**
+Una regla con `company` vacío aplica a todas las empresas del sistema. Útil para configuraciones comunes entre múltiples empresas.
+
+**¿Puedo desactivar una regla sin borrarla?**
+Sí. Cada regla en `CFDI Concepto Mapping` tiene el campo `is_active`. Las reglas inactivas no participan en el proceso de clasificación.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -11,6 +11,7 @@ Documentación completa para usuarios del sistema de facturación electrónica.
 
 ### Funcionalidades Principales
 - **CFDI 4.0** - Timbrado y validación
+- **CFDI Recibidos** - Ingesta y clasificación de comprobantes de proveedores
 - **Multi-sucursal** - Gestión de branches
 - **Addendas** - Generación dinámica
 - **Email Automático** - [Automatización CFDI por email](email-automation.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,10 +57,12 @@ nav:
     - Multi-sucursal: user-guide/multisucursal.md
     - Addendas: user-guide/addendas.md
     - Facturas en Borrador: user-guide/draft-invoices.md
+    - CFDI Recibidos: user-guide/cfdi-recibidos.md
     - Troubleshooting: user-guide/troubleshooting.md
   - API Reference:
     - api/index.md
     - CFDI: api/cfdi.md
+    - CFDI Recibidos: api/cfdi-recibidos.md
     - Multi-sucursal: api/multisucursal.md
     - Addendas: api/addendas.md
     - Draft Management: api/draft-management.md


### PR DESCRIPTION
## Objetivo

Documentar la funcionalidad de CFDI Recibidos introducida en PR #156 (Fase 1) y PR #157 (Fase 2), que se mergeó sin documentación en mkdocs.

## Cambios principales

- **`docs/api/cfdi-recibidos.md`** (nuevo): referencia completa de los 4 endpoints — `upload_xml`, `resolve_supplier`, `classify_concepts`, `save_mapping_rule` — con parámetros, respuestas, ejemplos y descripción de los DocTypes relacionados (`CFDI Recibido`, `CFDI Recibido Concepto`, `CFDI Concepto Mapping`). Incluye documentación del algoritmo de matching en 3 niveles.
- **`docs/user-guide/cfdi-recibidos.md`** (nuevo): guía del workflow completo para el usuario — diagrama de estados, pasos de ingesta → proveedor → clasificación, estrategia de reglas con ejemplos, y preguntas frecuentes.
- **`mkdocs.yml`**: 2 entradas nuevas en nav — "CFDI Recibidos" bajo Guía de Usuario y API Reference.
- **`docs/api/index.md`** y **`docs/user-guide/index.md`**: mención de CFDI Recibidos en los índices de sección.

## Validaciones realizadas

- `mkdocs build --strict` pasa sin errores ni warnings
- Todos los links internos de los nuevos archivos son válidos
- Cobertura: los 4 endpoints whitelisted, los 3 DocTypes y el flujo completo de estados

## Fuera de alcance

- Actualización de docs de módulos preexistentes (CFDI emisión, addendas, etc.)
- Docs de Fase 3 (PurchaseInvoiceBuilder — pendiente issue #152)

## Riesgos / pendientes

- La sección `/pr-ready` paso 10 no se ejecutó en PR #156 ni #157. Este PR cierra ese gap.
- El módulo de docs existente tiene algunos anchors rotos pre-existentes en `user-guide/setup-mapeos-sat.md` (INFO en build, no warnings — no bloquean `--strict`).

Cierra deuda técnica de documentación de PR #156 y PR #157.