### PR TITLE
fix(cfdi-recibidos): restaura Paso 7 en xml_ingestion — auto-crear proveedor en upload

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,60 +1,62 @@
 # CONTINUITY.md — facturacion_mexico
 
 **Fecha:** 2026-05-29
-**Rama activa:** `chore/archive-docs-development` → PR #167 abierto
-**Tarea actual:** PR #167 — limpieza docs/development post-merge PR #166
+**Rama activa:** `fix/xml-ingestion-paso7-restore`
+**Tarea actual:** Restaurar Paso 7 de xml_ingestion + actualizar tests
 
 ---
 
 ## Recuperación rápida
 
-PR #167 archiva 18 documentos de docs/development/ después del merge de PR #166.
-PR simple de docs, sin código, sin tests. Pendiente merge.
+Rama de fix para restaurar el auto-creado de proveedor en upload (Paso 7),
+eliminado incorrectamente en commit 500a683 para pasar tests.
+Tests actualizados para reflejar comportamiento correcto.
+
+Pendiente: PR → merge a main.
 
 ---
 
 ## Estado actual
 
-### Completado
-- PR #166 mergeado — pipeline CFDI Recibidos completo en main
-- issue #152 cerrado
-- sync-check.md actualizado (frappe-infrastructure `c055158`) con 3 reglas nuevas
+### Completado en esta sesión
+- Paso 7 restaurado en xml_ingestion.py con compute_stage para avanzar pipeline
+- 5 tests actualizados en test_xml_ingestion.py
+- test-guard.md actualizado en frappe-infrastructure con regla absoluta
+- sync-check.md actualizado con 3 reglas nuevas
 
-### PR #167 — en revisión
-- 13 docs marcados OBSOLETO + archivados
-- 5 docs archivados sin nota
-- 18 archivos movidos a docs/development/archive/
-
-### Pendiente después de PR #167
-- **Issue #165** — is_submittable para CFDI Recibido antes de producción
+### Pendiente
+- PR de fix/xml-ingestion-paso7-restore → main
+- Issue #165: is_submittable para CFDI Recibido
 - 6 docs pendientes de verificación ADR en docs/development/
-- 4 docs pendientes de decisión de ubicación permanente
+- 2 cambios en supplier_resolver.py aún no restaurados:
+  - generate_missing_suppliers: "Proveedor encontrado" en lugar de "Falta departamento"
+  - _assign_supplier: compute_supplier_stage en lugar de compute_stage
+  (mitigados por el compute_stage al final de xml_ingestion, pero Hito B sigue diferente)
 
 ### No repetir
-- No proponer commits sin que el usuario lo solicite
+- NUNCA modificar comportamiento del app para pasar tests
 - No incluir one_offs/ ni REPORTE_*.md en commits
 - No hacer bench migrate sin autorización
-- sync-check: leer cada doc antes de clasificar; nunca commitear en main
+- No commitear en main directamente
 
 ---
 
 ## Decisiones vigentes
-- item_resolution options: Mapeado, Código proveedor, Específico,
-  Sugerido, Nuevo especifico, Nuevo agrupador, Genérico, Manual
+- Paso 7 en xml_ingestion: auto-crear proveedor + compute_stage → "Falta departamento"
+- item_resolution options canónicos con acentos correctos
 - tax_resolver valida cuenta_impuesto no vacía
-- xml_ingestion NO auto-crea proveedores en upload
 - classify_all_concepts solo auto-asigna "Código proveedor"
 
 ---
 
 ## Archivos relevantes ahora
-- PR #167: https://github.com/luisrms69/facturacion_mexico/pull/167
-- docs/development/ — 6 ADR pendientes, 2 vigentes, 4 pendientes permanente, 2 protegidos
-- frappe-infrastructure/checkpoints/coderabbit-pr166-review.md — items CodeRabbit pendientes
+- `facturacion_mexico/cfdi_recibidos/services/xml_ingestion.py` — Paso 7 restaurado
+- `facturacion_mexico/cfdi_recibidos/tests/test_xml_ingestion.py` — tests actualizados
+- frappe-infrastructure: test-guard.md y sync-check.md actualizados
 
 ---
 
 ## Riesgos / cuidados
+- supplier_resolver.py tiene 2 cambios que afectan Hito B (List View "Generar proveedores faltantes")
 - issue #165 (is_submittable) antes de producción
-- 6 candidatos ADR sin convertir todavía
 - api_backup.py escribe en /tmp/ — defecto pre-existente

--- a/facturacion_mexico/cfdi_recibidos/services/xml_ingestion.py
+++ b/facturacion_mexico/cfdi_recibidos/services/xml_ingestion.py
@@ -21,8 +21,12 @@ from frappe.utils.file_manager import save_file
 
 from facturacion_mexico.cfdi_recibidos.parsers.cfdi_recibido_parser import CFDIRecibidoParser
 from facturacion_mexico.cfdi_recibidos.services.status_manager import (
+	compute_stage,
 	get_next_action,
 	get_stage_message,
+)
+from facturacion_mexico.cfdi_recibidos.services.supplier_resolver import (
+	generate_missing_suppliers as _generate_suppliers,
 )
 from facturacion_mexico.cfdi_recibidos.services.supplier_resolver import (
 	resolve_supplier as _resolve_supplier,
@@ -119,10 +123,29 @@ def ingest_xml(xml_bytes: bytes, company: str, file_name: str = "cfdi.xml") -> d
 	_resolve_supplier(doc.name)
 	doc.reload()
 
+	# Paso 7: auto-crear proveedor si no se encontró uno existente
+	supplier_created = False
+	if doc.status == "Falta proveedor":
+		gen = _generate_suppliers([doc.name])
+		if gen.get("creados", 0) > 0:
+			supplier_created = True
+			doc.reload()
+
+	# Avanzar al estado completo del pipeline cuando hay supplier asignado
+	if doc.supplier:
+		next_stage = compute_stage(doc)
+		if doc.status != next_stage:
+			doc.db_set("status", next_stage)
+			doc.reload()
+
 	stage = doc.status
 	supplier_found = bool(doc.supplier)
 	candidato = stage == "Falta proveedor"
-	message = get_stage_message(stage)
+
+	if supplier_created:
+		message = _("Proveedor nuevo creado automáticamente — revísalo y complétalo")
+	else:
+		message = get_stage_message(stage)
 
 	supplier_name = ""
 	if doc.supplier:
@@ -137,6 +160,7 @@ def ingest_xml(xml_bytes: bytes, company: str, file_name: str = "cfdi.xml") -> d
 		candidato,
 		message,
 		get_next_action(stage),
+		supplier_created=supplier_created,
 		supplier=doc.supplier or "",
 		supplier_name=supplier_name,
 	)

--- a/facturacion_mexico/cfdi_recibidos/services/xml_ingestion.py
+++ b/facturacion_mexico/cfdi_recibidos/services/xml_ingestion.py
@@ -123,15 +123,19 @@ def ingest_xml(xml_bytes: bytes, company: str, file_name: str = "cfdi.xml") -> d
 	_resolve_supplier(doc.name)
 	doc.reload()
 
-	# Paso 7: auto-crear proveedor si no se encontró uno existente
+	# Step 7: auto-create supplier if none was found by RFC
 	supplier_created = False
+	gen_errors: list = []
 	if doc.status == "Falta proveedor":
 		gen = _generate_suppliers([doc.name])
+		gen_errors = gen.get("errores") or []
 		if gen.get("creados", 0) > 0:
 			supplier_created = True
+		# Reload whenever a supplier was assigned (created or pre-existing)
+		if gen.get("creados", 0) > 0 or gen.get("ya_existian_y_asignados", 0) > 0:
 			doc.reload()
 
-	# Avanzar al estado completo del pipeline cuando hay supplier asignado
+	# Advance to full pipeline stage when supplier is assigned
 	if doc.supplier:
 		next_stage = compute_stage(doc)
 		if doc.status != next_stage:
@@ -144,6 +148,8 @@ def ingest_xml(xml_bytes: bytes, company: str, file_name: str = "cfdi.xml") -> d
 
 	if supplier_created:
 		message = _("Proveedor nuevo creado automáticamente — revísalo y complétalo")
+	elif gen_errors and not supplier_found:
+		message = gen_errors[0].get("message") or get_stage_message(stage)
 	else:
 		message = get_stage_message(stage)
 

--- a/facturacion_mexico/cfdi_recibidos/tests/test_xml_ingestion.py
+++ b/facturacion_mexico/cfdi_recibidos/tests/test_xml_ingestion.py
@@ -139,19 +139,24 @@ class TestXMLIngestionExitosa(unittest.TestCase):
 
 	def tearDown(self):
 		_cleanup_uuid("11111111-2222-3333-4444-555555555555")
+		_cleanup_supplier("PROV123456AAA")  # limpia supplier auto-creado por Paso 7
 
-	def test_status_falta_proveedor(self):
-		# Proveedor PROV123456AAA no existe en el site de test → "Falta proveedor"
+	def test_status_supplier_auto_creado_falta_departamento(self):
+		# Paso 7 auto-crea supplier cuando no existe → compute_stage → "Falta departamento"
 		result = ingest_xml(self.xml_bytes, self.company, "test.xml")
-		self.assertEqual(result["status"], "Falta proveedor")
+		self.assertEqual(result["status"], "Falta departamento")
+		self.assertTrue(result["supplier_created"])
 
-	def test_supplier_found_false_sin_proveedor(self):
+	def test_supplier_found_true_con_auto_creacion(self):
+		# Paso 7 auto-crea → supplier queda asignado → supplier_found=True
 		result = ingest_xml(self.xml_bytes, self.company, "test.xml")
-		self.assertFalse(result["supplier_found"])
+		self.assertTrue(result["supplier_found"])
 
-	def test_candidato_true_sin_proveedor(self):
+	def test_candidato_false_con_auto_creacion(self):
+		# Proveedor auto-creado en Paso 7 → no es candidato para creación posterior
 		result = ingest_xml(self.xml_bytes, self.company, "test.xml")
-		self.assertTrue(result["candidato_generar_proveedor"])
+		self.assertFalse(result["candidato_generar_proveedor"])
+		self.assertTrue(result["supplier_created"])
 
 	def test_supplier_rfc_en_resultado(self):
 		result = ingest_xml(self.xml_bytes, self.company, "test.xml")
@@ -162,7 +167,8 @@ class TestXMLIngestionExitosa(unittest.TestCase):
 		self.assertIsNotNone(result["cfdi_recibido"])
 		doc = frappe.get_doc("CFDI Recibido", result["cfdi_recibido"])
 		self.assertEqual(doc.uuid, "11111111-2222-3333-4444-555555555555")
-		self.assertEqual(doc.status, "Falta proveedor")
+		# Paso 7 auto-crea supplier → compute_stage → "Falta departamento"
+		self.assertEqual(doc.status, "Falta departamento")
 		self.assertEqual(doc.supplier_rfc, "PROV123456AAA")
 		self.assertEqual(doc.receiver_rfc, "EMP9001011AA")
 		self.assertEqual(doc.cfdi_type, "I")
@@ -231,9 +237,10 @@ class TestXMLIngestionConProveedorExistente(unittest.TestCase):
 		_cleanup_uuid("11111111-2222-3333-4444-555555555555")
 		_cleanup_supplier("PROV123456AAA")
 
-	def test_status_proveedor_encontrado(self):
+	def test_status_falta_departamento_con_proveedor_existente(self):
+		# Paso 6 resuelve supplier existente → compute_stage → "Falta departamento"
 		result = ingest_xml(XML_VALIDO.encode(), self.company, "test.xml")
-		self.assertEqual(result["status"], "Proveedor encontrado")
+		self.assertEqual(result["status"], "Falta departamento")
 
 	def test_supplier_found_true(self):
 		result = ingest_xml(XML_VALIDO.encode(), self.company, "test.xml")

--- a/facturacion_mexico/cfdi_recibidos/tests/test_xml_ingestion.py
+++ b/facturacion_mexico/cfdi_recibidos/tests/test_xml_ingestion.py
@@ -139,21 +139,21 @@ class TestXMLIngestionExitosa(unittest.TestCase):
 
 	def tearDown(self):
 		_cleanup_uuid("11111111-2222-3333-4444-555555555555")
-		_cleanup_supplier("PROV123456AAA")  # limpia supplier auto-creado por Paso 7
+		_cleanup_supplier("PROV123456AAA")  # clean up supplier auto-created by Step 7
 
 	def test_status_supplier_auto_creado_falta_departamento(self):
-		# Paso 7 auto-crea supplier cuando no existe → compute_stage → "Falta departamento"
+		# Step 7 auto-creates supplier when none exists → compute_stage → "Falta departamento"
 		result = ingest_xml(self.xml_bytes, self.company, "test.xml")
 		self.assertEqual(result["status"], "Falta departamento")
 		self.assertTrue(result["supplier_created"])
 
 	def test_supplier_found_true_con_auto_creacion(self):
-		# Paso 7 auto-crea → supplier queda asignado → supplier_found=True
+		# Step 7 auto-creates → supplier gets assigned → supplier_found=True
 		result = ingest_xml(self.xml_bytes, self.company, "test.xml")
 		self.assertTrue(result["supplier_found"])
 
 	def test_candidato_false_con_auto_creacion(self):
-		# Proveedor auto-creado en Paso 7 → no es candidato para creación posterior
+		# Supplier auto-created in Step 7 → not a candidate for manual creation
 		result = ingest_xml(self.xml_bytes, self.company, "test.xml")
 		self.assertFalse(result["candidato_generar_proveedor"])
 		self.assertTrue(result["supplier_created"])


### PR DESCRIPTION
## Objetivo

Restaurar el Paso 7 de `xml_ingestion.py` que fue eliminado incorrectamente en commit `500a683` para hacer pasar tests con comportamiento anterior.

## Cambios principales

**`xml_ingestion.py`:**
- Restaura Paso 7: si no existe Supplier con el RFC del emisor, se auto-crea durante el upload
- Después de resolver proveedor existente (Paso 6) o auto-crear (Paso 7), llama `compute_stage` para avanzar al estado completo del pipeline
- El CFDI avanza a `"Falta departamento"` → el diálogo muestra `"Continuar → Asignar departamento"`

**`test_xml_ingestion.py`:**
- Tests actualizados para reflejar el comportamiento correcto
- `test_status_supplier_auto_creado_falta_departamento`: status = `"Falta departamento"` tras auto-creación
- `test_supplier_found_true_con_auto_creacion`: `supplier_found=True` tras Paso 7
- `test_candidato_false_con_auto_creacion`: `candidato=False` + `supplier_created=True`
- `test_crea_cfdi_recibido`: `doc.status = "Falta departamento"`
- `test_status_falta_departamento_con_proveedor_existente`: proveedor existente también avanza
- `tearDown`: limpia supplier auto-creado por Paso 7

## Validaciones realizadas

- 34/34 `test_xml_ingestion` pasan
- Suite completa 1043/1045 (2 fallos preexistentes no relacionados)

## Contexto

El Paso 7 fue eliminado en `500a683` para hacer pasar tests de CI que esperaban el comportamiento anterior. Esto violó la regla documentada en `test-guard.md`: **nunca modificar el comportamiento del app para pasar tests; actualizar los tests para reflejar el comportamiento correcto**.

La eliminación rompió el flujo del usuario: el diálogo de upload mostraba solo "Cerrar" en lugar de "Continuar → Asignar departamento", interrumpiendo el pipeline completo.

## Fuera de alcance

- `supplier_resolver.py` tiene 2 cambios pendientes de revisión:
  - `_assign_supplier` usa `compute_supplier_stage` en lugar de `compute_stage`
  - `generate_missing_suppliers` pone `"Proveedor encontrado"` en lugar de `"Falta departamento"` (afecta botón Hito B en List View)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic supplier creation for documents missing provider information.
  * Enhanced post-resolution workflow with improved status determination.

* **Bug Fixes**
  * Restored missing XML ingestion processing functionality.

* **Tests**
  * Updated validation tests to reflect new supplier and status handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luisrms69/facturacion_mexico/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->