### PR TITLE
fix(cfdi-recibidos): usar fecha XML en PI y restringir SQL dashboard

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,55 +1,63 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-06-04
-**Rama activa:** `main` (post-merge PR #178)
-**Tarea actual:** Preparar micro-PR de fixes CodeRabbit + continuar roadmap Fase 4
+**Fecha:** 2026-06-05
+**Rama activa:** `fix/pi-posting-date-y-dashboard-sql`
+**Tarea actual:** Commit listo — validado en GUI, pendiente push + PR
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-PR #178 mergeado. Pendiente micro-PR con 3 fixes de CodeRabbit (PR #177 + #178).
-Después de ese micro-PR, siguiente tarea es Fase 4 — Registrar pago (#153).
+Rama `fix/pi-posting-date-y-dashboard-sql` con dos correcciones puntuales listas para PR.
 
 Objetivo inmediato:
-1. Micro-PR de fixes CodeRabbit (ver propuesta en frappe-infrastructure/checkpoints/micro-pr-coderabbit-followup.md)
-2. Iniciar Fase 4 — botón "Registrar Pago" con API nativa ERPNext (#153)
+Push → PR.
 
 Criterio de avance:
-Micro-PR mergeado + issue #153 iniciado.
+PR mergeado, main sincronizado.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- PR #177 mergeado: wizard PTCT porcentual + cargar_reglas Pagos ✅
-- PR #178 mergeado: simplificación resolución contable 2 modos estrictos ✅
-- bench migrate: test-facturacion.localhost + facturacion-v16.dev + actiglobal-restore.dev ✅
+
+- PR #177, #178, #179 mergeados ✅
+- posting_date fix: set_posting_time=1 + guard issue_date vacío + tests ✅ (confirmado GUI)
+- DashboardWidgetConfig: write quitado a Accounts Manager ✅
 
 ### Pendiente inmediato
-1. Micro-PR: 3 fixes CodeRabbit (propuesta lista en checkpoints)
-2. Issue #153: Fase 4 — Registrar Pago via API nativa ERPNext
+
+1. Push + PR de la rama actual
+2. Iniciar Fase 4 — Registrar Pago (#153) después del merge
 
 ### No repetir
+
 - Mapeo Equivalencias SAT eliminado — no reintroducir
-- actiglobal-restore.dev: problema enc_key DFP External Storage — no escribir
+- actiglobal-restore.dev: enc_key DFP — no escribir
+- Sin `set_posting_time = 1`, ERPNext ignora posting_date y usa today() — ya corregido
 
 ---
 
 ## Decisiones vigentes
-- Resolución contable CFDI Recibidos: 2 modos (Manual / Automatico CoA SAT), sin fallbacks
-- fm_codigo_sufijo_sat se puebla via after_migrate (81 item groups)
-- Micro-PR CodeRabbit pendiente: ver frappe-infrastructure/checkpoints/micro-pr-coderabbit-followup.md
+
+- PI posting_date = issue_date del XML, usando `set_posting_time = 1`
+- Si issue_date vacío → ValidationError, no se crea PI (no fallback a today)
+- DashboardWidgetConfig write = solo System Manager
+- auditoria_fiscal.py WHERE: confirmado seguro (campos internos + valores parametrizados)
+- ereceipts expire_ereceipts: confirmado seguro (scheduler, sin input externo)
+- Resolución contable CFDI Recibidos: 2 modos, sin fallbacks
 
 ---
 
-## Archivos relevantes ahora
+## Archivos modificados en esta rama
 
-### Leer primero
-- `frappe-infrastructure/checkpoints/micro-pr-coderabbit-followup.md` — propuesta micro-PR
+- `cfdi_recibidos/services/purchase_invoice_builder.py` — set_posting_time + guard issue_date
+- `cfdi_recibidos/tests/test_purchase_invoice_builder.py` — 3 tests fechas
+- `dashboard_fiscal/doctype/dashboard_widget_config/dashboard_widget_config.json` — permisos
 
 ### No tocar
+
 - `one_offs/` — no se commitean
-- `actiglobal-restore.dev` — problema enc_key DFP External Storage
+- `actiglobal-restore.dev` — enc_key DFP External Storage

--- a/facturacion_mexico/cfdi_recibidos/services/purchase_invoice_builder.py
+++ b/facturacion_mexico/cfdi_recibidos/services/purchase_invoice_builder.py
@@ -342,9 +342,17 @@ def _check_idempotency(cfdi_doc) -> "dict | None":
 
 
 def _build_pi_doc(cfdi_doc):
+	if not cfdi_doc.issue_date:
+		frappe.throw(
+			_("CFDI '{0}' no tiene fecha de emisión. No se puede generar Purchase Invoice.").format(
+				cfdi_doc.name
+			),
+			frappe.ValidationError,
+		)
 	pi = frappe.new_doc("Purchase Invoice")
 	pi.supplier = cfdi_doc.supplier
 	pi.company = cfdi_doc.company
+	pi.set_posting_time = 1  # requerido para que ERPNext respete posting_date != hoy
 	pi.posting_date = cfdi_doc.issue_date
 	pi.due_date = cfdi_doc.issue_date
 	pi.bill_date = cfdi_doc.issue_date

--- a/facturacion_mexico/cfdi_recibidos/tests/test_purchase_invoice_builder.py
+++ b/facturacion_mexico/cfdi_recibidos/tests/test_purchase_invoice_builder.py
@@ -360,18 +360,35 @@ class TestPurchaseInvoiceBuilder(unittest.TestCase):
 		pi = frappe.get_doc("Purchase Invoice", result["purchase_invoice"])
 		self.assertEqual(pi.fm_cfdi_uuid, self._uuid("003"))
 
-	def test_posting_date_es_hoy(self):
+	def test_posting_date_igual_a_fecha_xml(self):
+		"""posting_date de la PI = fecha de emisión del XML, no la fecha de hoy."""
 		cfdi = self._make_cfdi("004")
 		result = build_purchase_invoice(cfdi)
 		pi = frappe.get_doc("Purchase Invoice", result["purchase_invoice"])
-		self.assertEqual(str(pi.posting_date), today())
+		cfdi_issue_date = frappe.db.get_value("CFDI Recibido", cfdi, "issue_date")
+		self.assertEqual(str(pi.posting_date), str(cfdi_issue_date))
 
-	def test_bill_date_es_fecha_emision(self):
+	def test_fechas_con_xml_antiguo(self):
+		"""CFDI con fecha antigua: posting_date, bill_date y due_date = fecha del XML."""
 		issue = "2024-03-15"
 		cfdi = self._make_cfdi("005", issue_date=issue)
 		result = build_purchase_invoice(cfdi)
 		pi = frappe.get_doc("Purchase Invoice", result["purchase_invoice"])
+		self.assertEqual(str(pi.posting_date), issue)
 		self.assertEqual(str(pi.bill_date), issue)
+		self.assertEqual(str(pi.due_date), issue)
+
+	def test_falla_si_issue_date_vacio(self):
+		"""CFDI sin fecha de emisión debe fallar con ValidationError — no usar today() como fallback."""
+		cfdi = self._make_cfdi("005B", issue_date="2024-03-15")
+		# Vaciar issue_date directamente en BD para simular XML sin fecha
+		frappe.db.set_value("CFDI Recibido", cfdi, "issue_date", None)
+		frappe.db.commit()
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			build_purchase_invoice(cfdi)
+		self.assertIn("fecha de emisión", str(ctx.exception))
+		# No debe existir PI vinculada
+		self.assertIsNone(frappe.db.get_value("CFDI Recibido", cfdi, "purchase_invoice"))
 
 	def test_cfdi_status_convertido(self):
 		cfdi = self._make_cfdi("006")

--- a/facturacion_mexico/dashboard_fiscal/doctype/dashboard_widget_config/dashboard_widget_config.json
+++ b/facturacion_mexico/dashboard_fiscal/doctype/dashboard_widget_config/dashboard_widget_config.json
@@ -344,16 +344,13 @@
    "write": 1
   },
   {
-   "create": 1,
-   "delete": 1,
    "email": 1,
    "export": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "Accounts Manager",
-   "share": 1,
-   "write": 1
+   "share": 1
   },
   {
    "create": 1,


### PR DESCRIPTION
## Objetivo

Corrige dos desviaciones detectadas antes de seguir con Fase 4:

1. Purchase Invoice generada desde CFDI Recibidos debe usar la fecha del XML como posting_date.
2. DashboardWidgetConfig no debe permitir edición de custom_query por Accounts Manager.

## Cambios

- Purchase Invoice Builder:
  - Usa issue_date del CFDI como posting_date, bill_date y due_date.
  - Agrega set_posting_time=1 para evitar que ERPNext sobrescriba posting_date con today().
  - Si issue_date está vacío, falla con ValidationError y no crea PI.

- Tests:
  - Agrega cobertura para XML con fecha antigua.
  - Agrega cobertura para issue_date vacío.
  - Corrige test existente de posting_date.

- DashboardWidgetConfig:
  - Quita create/write/delete al rol Accounts Manager.
  - Accounts Manager conserva lectura.
  - System Manager conserva permisos de configuración.

## Validaciones realizadas

- test_purchase_invoice_builder: 45/45 ✅
- GUI confirmada: posting_date correcto en PI generada desde XML ✅
- working tree limpio ✅

## Fuera de alcance

- No cambia Fase 4.
- No cambia flujo de pagos/reembolsos.
- No cambia custom_query ni lógica de widgets.

## Documentación

No aplica — correcciones de bug (posting_date) y restricción de permisos; sin cambio en modelo de datos ni funcionalidad nueva visible al usuario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure CFDI documents have a valid issue date before allowing purchase invoice creation.

* **Changes**
  * Posting dates for purchase invoices now use the CFDI issue date for proper date tracking.
  * Updated permissions for dashboard widget configuration to improve access control.

* **Documentation**
  * Updated development continuity records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->