### PR TITLE
fix(fiscal): eliminar fallbacks silenciosos — clave SAT y forma de pago (#161 #162)

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,61 +2,64 @@
 
 **Fecha:** 2026-06-06
 **Rama activa:** `fix/issue-162-clave-sat-obligatoria`
-**Tarea actual:** Commit listo — pendiente push + PR
+**Tarea actual:** Dos commits listos — pendiente push + PR
 
 ---
 
 ## Recuperación rápida
 
-Estoy trabajando en:
-Issue #162 — eliminar fallback "01010101" para clave SAT en timbrado.
+Esta rama contiene correcciones para los issues #162 y #161:
 
-Objetivo inmediato:
-Push → PR.
+- **Commit 1 (`05d11bc`)** — issue #162: eliminar fallback "01010101" clave SAT en timbrado
+- **Commit 2 (pendiente push)** — issue #161: eliminar inferencia forma de pago por string-slice
 
-Criterio de avance:
-PR mergeado, main sincronizado, continuar con issue #161 (Complemento Pago) o Fase 4.
+Objetivo inmediato: push → PR.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-
 - PR #177–#180 mergeados ✅
-- Issue #162: fallback "01010101" eliminado, 3 capas de defensa implementadas ✅
+- Issue #162: fallback "01010101" eliminado — 3 capas de defensa ✅
+- Issue #161: string-slice eliminado — helper `_resolver_forma_pago_sat` ✅
 - Validado en GUI (actiglobal-restore.dev:8406) ✅
+- Suite completa: 1136 tests — 2 failures preexistentes no relacionados ✅
 
 ### Pendiente inmediato
-
-1. Push + PR de la rama actual
-2. Decidir: issue #161 (Complemento Pago fallbacks) o Fase 4 (#153)
+1. Push + PR de esta rama
+2. Decidir siguiente frente: issue #163 (limpieza técnica) o Fase 4 pagos (#153)
 
 ### No repetir
-
-- Sin `set_posting_time = 1` → ERPNext silencia posting_date — ya corregido (PR #180)
-- `or "01010101"` como fallback — eliminado en esta rama
+- `or "01010101"` como fallback de clave SAT — eliminado (#162)
+- `[:2].strip()` como inferencia de forma de pago SAT — eliminado (#161)
+- `fm_codigo_sat` / `custom_forma_pago_sat` — campos fantasma, no crear ni usar
 
 ---
 
 ## Decisiones vigentes
 
 - Clave SAT obligatoria en flujo fiscal (no global en Item)
-- 3 capas de defensa: SI validate hook (automated_tax) → FFM.validate() → timbrado_api
-- Mensaje de error en español claro: "Clave SAT de Producto o Servicio"
-- DashboardWidgetConfig write = solo System Manager (PR #180)
-- PI posting_date = issue_date del XML (PR #180)
+- Forma de pago SAT solo desde MoP del fixture con patrón `^\d{2} - .+$` + lookup en Forma Pago SAT
+- MoP nativos ERPNext (Cash, Wire Transfer, etc.) deshabilitados en fixture
+- Mensaje de error en español claro y accionable
 
 ---
 
-## Archivos modificados en esta rama
+## Archivos de esta rama
 
-- `timbrado_api.py` — _validate_items_clave_sat_for_timbrado + defensa final + sin "01010101"
-- `factura_fiscal_mexico.py` — _validate_items_clave_sat en validate()
+### issue #162 (commit 05d11bc)
+- `timbrado_api.py` — `_validate_items_clave_sat_for_timbrado` + defensa final + sin "01010101"
+- `factura_fiscal_mexico.py` — `_validate_items_clave_sat` en `validate()`
 - `hooks_handlers/sales_invoice_automated_tax.py` — mensaje error mejorado
-- `tests/test_issue162_clave_sat_obligatoria.py` — 9 tests nuevos
+- `tests/test_issue162_clave_sat_obligatoria.py` — 9 tests
+
+### issue #161 (commit pendiente)
+- `complementos_pago/api.py` — `_resolver_forma_pago_sat` + reemplaza string-slice
+- `fixtures/mode_of_payment.json` — MoP nativos con `enabled: 0`
+- `complementos_pago/tests/test_resolver_forma_pago_sat.py` — 16 tests
 
 ### No tocar
-
 - `one_offs/` — no se commitean
 - `actiglobal-restore.dev` — enc_key DFP External Storage (no adjuntos)
+- E-Receipts, Factura Global, CFDI Recibidos — fuera de alcance de esta rama

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,21 +1,21 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-06-05
-**Rama activa:** `fix/pi-posting-date-y-dashboard-sql`
-**Tarea actual:** Commit listo — validado en GUI, pendiente push + PR
+**Fecha:** 2026-06-06
+**Rama activa:** `fix/issue-162-clave-sat-obligatoria`
+**Tarea actual:** Commit listo — pendiente push + PR
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Rama `fix/pi-posting-date-y-dashboard-sql` con dos correcciones puntuales listas para PR.
+Issue #162 — eliminar fallback "01010101" para clave SAT en timbrado.
 
 Objetivo inmediato:
 Push → PR.
 
 Criterio de avance:
-PR mergeado, main sincronizado.
+PR mergeado, main sincronizado, continuar con issue #161 (Complemento Pago) o Fase 4.
 
 ---
 
@@ -23,41 +23,40 @@ PR mergeado, main sincronizado.
 
 ### Ya cerrado
 
-- PR #177, #178, #179 mergeados ✅
-- posting_date fix: set_posting_time=1 + guard issue_date vacío + tests ✅ (confirmado GUI)
-- DashboardWidgetConfig: write quitado a Accounts Manager ✅
+- PR #177–#180 mergeados ✅
+- Issue #162: fallback "01010101" eliminado, 3 capas de defensa implementadas ✅
+- Validado en GUI (actiglobal-restore.dev:8406) ✅
 
 ### Pendiente inmediato
 
 1. Push + PR de la rama actual
-2. Iniciar Fase 4 — Registrar Pago (#153) después del merge
+2. Decidir: issue #161 (Complemento Pago fallbacks) o Fase 4 (#153)
 
 ### No repetir
 
-- Mapeo Equivalencias SAT eliminado — no reintroducir
-- actiglobal-restore.dev: enc_key DFP — no escribir
-- Sin `set_posting_time = 1`, ERPNext ignora posting_date y usa today() — ya corregido
+- Sin `set_posting_time = 1` → ERPNext silencia posting_date — ya corregido (PR #180)
+- `or "01010101"` como fallback — eliminado en esta rama
 
 ---
 
 ## Decisiones vigentes
 
-- PI posting_date = issue_date del XML, usando `set_posting_time = 1`
-- Si issue_date vacío → ValidationError, no se crea PI (no fallback a today)
-- DashboardWidgetConfig write = solo System Manager
-- auditoria_fiscal.py WHERE: confirmado seguro (campos internos + valores parametrizados)
-- ereceipts expire_ereceipts: confirmado seguro (scheduler, sin input externo)
-- Resolución contable CFDI Recibidos: 2 modos, sin fallbacks
+- Clave SAT obligatoria en flujo fiscal (no global en Item)
+- 3 capas de defensa: SI validate hook (automated_tax) → FFM.validate() → timbrado_api
+- Mensaje de error en español claro: "Clave SAT de Producto o Servicio"
+- DashboardWidgetConfig write = solo System Manager (PR #180)
+- PI posting_date = issue_date del XML (PR #180)
 
 ---
 
 ## Archivos modificados en esta rama
 
-- `cfdi_recibidos/services/purchase_invoice_builder.py` — set_posting_time + guard issue_date
-- `cfdi_recibidos/tests/test_purchase_invoice_builder.py` — 3 tests fechas
-- `dashboard_fiscal/doctype/dashboard_widget_config/dashboard_widget_config.json` — permisos
+- `timbrado_api.py` — _validate_items_clave_sat_for_timbrado + defensa final + sin "01010101"
+- `factura_fiscal_mexico.py` — _validate_items_clave_sat en validate()
+- `hooks_handlers/sales_invoice_automated_tax.py` — mensaje error mejorado
+- `tests/test_issue162_clave_sat_obligatoria.py` — 9 tests nuevos
 
 ### No tocar
 
 - `one_offs/` — no se commitean
-- `actiglobal-restore.dev` — enc_key DFP External Storage
+- `actiglobal-restore.dev` — enc_key DFP External Storage (no adjuntos)

--- a/facturacion_mexico/complementos_pago/api.py
+++ b/facturacion_mexico/complementos_pago/api.py
@@ -44,8 +44,7 @@ def crear_complemento_pago_desde_pe(payment_entry_name: str) -> dict:
 	if not si_ppd:
 		frappe.throw(
 			_(
-				"No hay facturas PPD timbradas válidas referenciadas en este Payment Entry. "
-				"Verificar que fm_es_ppd=1 y fm_fiscal_status=TIMBRADO."
+				"No hay facturas PPD timbradas válidas referenciadas en este Payment Entry. Verificar que fm_es_ppd=1 y fm_fiscal_status=TIMBRADO."
 			)
 		)
 
@@ -115,8 +114,7 @@ def _resolver_forma_pago_sat(mode_of_payment: str | None) -> str:
 	if not mode_of_payment:
 		frappe.throw(
 			_(
-				"El Payment Entry no tiene Forma de Pago configurada. "
-				"Configure un modo de pago del catálogo SAT antes de crear el complemento."
+				"El Payment Entry no tiene Forma de Pago configurada. Configure un modo de pago del catálogo SAT antes de crear el complemento."
 			),
 			frappe.ValidationError,
 			title=_("Forma de Pago Faltante"),
@@ -132,8 +130,7 @@ def _resolver_forma_pago_sat(mode_of_payment: str | None) -> str:
 	if not enabled:
 		frappe.throw(
 			_(
-				"El modo de pago '{0}' está deshabilitado. "
-				"Seleccione un modo de pago del catálogo SAT activo."
+				"El modo de pago '{0}' está deshabilitado. Seleccione un modo de pago del catálogo SAT activo."
 			).format(mode_of_payment),
 			frappe.ValidationError,
 			title=_("Modo de Pago Deshabilitado"),
@@ -143,9 +140,7 @@ def _resolver_forma_pago_sat(mode_of_payment: str | None) -> str:
 	if not match:
 		frappe.throw(
 			_(
-				"El modo de pago '{0}' no corresponde al catálogo SAT. "
-				"Use un modo de pago con formato 'NN - Descripción' "
-				"(ejemplo: '03 - Transferencia electrónica de fondos')."
+				"El modo de pago '{0}' no corresponde al catálogo SAT. Use un modo de pago con formato 'NN - Descripción' (ejemplo: '03 - Transferencia electrónica de fondos')."
 			).format(mode_of_payment),
 			frappe.ValidationError,
 			title=_("Modo de Pago No Compatible con SAT"),
@@ -156,9 +151,7 @@ def _resolver_forma_pago_sat(mode_of_payment: str | None) -> str:
 	if not frappe.db.exists("Forma Pago SAT", codigo):
 		frappe.throw(
 			_(
-				"El código '{0}' extraído del modo de pago '{1}' "
-				"no existe en el catálogo SAT de Forma de Pago. "
-				"Verifique la configuración del modo de pago."
+				"El código '{0}' extraído del modo de pago '{1}' no existe en el catálogo SAT de Forma de Pago. Verifique la configuración del modo de pago."
 			).format(codigo, mode_of_payment),
 			frappe.ValidationError,
 			title=_("Código SAT No Válido"),

--- a/facturacion_mexico/complementos_pago/api.py
+++ b/facturacion_mexico/complementos_pago/api.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import date, datetime
 
 import frappe
@@ -49,15 +50,7 @@ def crear_complemento_pago_desde_pe(payment_entry_name: str) -> dict:
 		)
 
 	# --- Obtener forma de pago SAT desde mode_of_payment ---
-	# ERPNext ya tiene mode_of_payment — tomamos los primeros 2 caracteres como código SAT
-	if not pe.get("mode_of_payment"):
-		frappe.throw(
-			_(
-				"El Payment Entry no tiene Forma de Pago configurada. "
-				"Configure Mode of Payment antes de crear el complemento."
-			)
-		)
-	forma_pago_sat = (pe.mode_of_payment or "")[:2].strip()
+	forma_pago_sat = _resolver_forma_pago_sat(pe.get("mode_of_payment"))
 
 	# --- Crear complemento ---
 	complemento = frappe.new_doc("Complemento Pago MX")
@@ -101,6 +94,77 @@ def crear_complemento_pago_desde_pe(payment_entry_name: str) -> dict:
 
 	frappe.logger().info(f"Complemento {complemento.name} creado para PE {pe.name}")
 	return {"complemento_name": complemento.name}
+
+
+_PATRON_MOP_SAT = re.compile(r"^(\d{2}) - .+$")
+
+
+def _resolver_forma_pago_sat(mode_of_payment: str | None) -> str:
+	"""Resuelve el código SAT de Forma de Pago desde un Mode of Payment del fixture del app.
+
+	Validaciones en orden:
+	1. mode_of_payment no vacío
+	2. Mode of Payment existe en BD
+	3. Mode of Payment está habilitado
+	4. Nombre cumple patrón estricto ^(\\d{2}) - .+$
+	5. Código extraído existe en DocType 'Forma Pago SAT'
+
+	Sin fallback. Sin inferencia. Falla explícitamente si el MoP no
+	corresponde al catálogo SAT (ej: Cash, Wire Transfer, Check).
+	"""
+	if not mode_of_payment:
+		frappe.throw(
+			_(
+				"El Payment Entry no tiene Forma de Pago configurada. "
+				"Configure un modo de pago del catálogo SAT antes de crear el complemento."
+			),
+			frappe.ValidationError,
+			title=_("Forma de Pago Faltante"),
+		)
+
+	enabled = frappe.db.get_value("Mode of Payment", mode_of_payment, "enabled")
+	if enabled is None:
+		frappe.throw(
+			_("El modo de pago '{0}' no existe en el sistema.").format(mode_of_payment),
+			frappe.ValidationError,
+			title=_("Modo de Pago No Encontrado"),
+		)
+	if not enabled:
+		frappe.throw(
+			_(
+				"El modo de pago '{0}' está deshabilitado. "
+				"Seleccione un modo de pago del catálogo SAT activo."
+			).format(mode_of_payment),
+			frappe.ValidationError,
+			title=_("Modo de Pago Deshabilitado"),
+		)
+
+	match = _PATRON_MOP_SAT.match(mode_of_payment)
+	if not match:
+		frappe.throw(
+			_(
+				"El modo de pago '{0}' no corresponde al catálogo SAT. "
+				"Use un modo de pago con formato 'NN - Descripción' "
+				"(ejemplo: '03 - Transferencia electrónica de fondos')."
+			).format(mode_of_payment),
+			frappe.ValidationError,
+			title=_("Modo de Pago No Compatible con SAT"),
+		)
+
+	codigo = match.group(1)
+
+	if not frappe.db.exists("Forma Pago SAT", codigo):
+		frappe.throw(
+			_(
+				"El código '{0}' extraído del modo de pago '{1}' "
+				"no existe en el catálogo SAT de Forma de Pago. "
+				"Verifique la configuración del modo de pago."
+			).format(codigo, mode_of_payment),
+			frappe.ValidationError,
+			title=_("Código SAT No Válido"),
+		)
+
+	return codigo
 
 
 def _obtener_si_ppd_validas(pe) -> list:

--- a/facturacion_mexico/complementos_pago/tests/test_resolver_forma_pago_sat.py
+++ b/facturacion_mexico/complementos_pago/tests/test_resolver_forma_pago_sat.py
@@ -1,155 +1,136 @@
 """
 Tests para _resolver_forma_pago_sat (issue #161).
 
-Verifica que el helper rechaza modos de pago no SAT y resuelve
-correctamente los del fixture del app.
+Usa documentos reales de Mode of Payment y Forma Pago SAT del fixture del app.
+No mockea frappe.db.* ni frappe.get_doc (RG-003).
 """
-
-import re
-from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from facturacion_mexico.complementos_pago.api import _resolver_forma_pago_sat
-
-
-def _mock_get_value(enabled_map):
-	"""Retorna side_effect para frappe.db.get_value."""
-
-	def side_effect(doctype, name, field):
-		if doctype == "Mode of Payment" and field == "enabled":
-			return enabled_map.get(name)
-		return None
-
-	return side_effect
-
-
-def _mock_exists(existing):
-	"""Retorna side_effect para frappe.db.exists."""
-
-	def side_effect(doctype, name):
-		if doctype == "Forma Pago SAT":
-			return name in existing
-		return False
-
-	return side_effect
+from facturacion_mexico.complementos_pago.api import _PATRON_MOP_SAT, _resolver_forma_pago_sat
 
 
 class TestResolverFormaPagoSAT(FrappeTestCase):
-	"""Tests unitarios para _resolver_forma_pago_sat."""
+	"""Tests para _resolver_forma_pago_sat usando documentos reales."""
 
-	# -- Casos válidos --
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		suffix = frappe.generate_hash()[:6]
+
+		# MoP deshabilitado — para test de disabled
+		cls.mop_disabled = f"TEST-MOP-DIS-{suffix}"
+		frappe.get_doc(
+			{
+				"doctype": "Mode of Payment",
+				"mode_of_payment": cls.mop_disabled,
+				"enabled": 0,
+				"type": "General",
+			}
+		).insert(ignore_permissions=True)
+
+		# MoP con formato SAT pero código "55" que no existe en Forma Pago SAT
+		cls.mop_fake_sat = f"55 - TEST-{suffix}"
+		frappe.get_doc(
+			{
+				"doctype": "Mode of Payment",
+				"mode_of_payment": cls.mop_fake_sat,
+				"enabled": 1,
+				"type": "General",
+			}
+		).insert(ignore_permissions=True)
+
+	@classmethod
+	def tearDownClass(cls):
+		super().tearDownClass()
+		frappe.db.delete("Mode of Payment", cls.mop_disabled)
+		frappe.db.delete("Mode of Payment", cls.mop_fake_sat)
+		frappe.db.commit()
+
+	# -- Casos válidos con fixtures reales --
 
 	def test_resuelve_transferencia_electronica(self):
-		"""MoP SAT válido '03 - Transferencia...' → código '03'."""
-		mop = "03 - Transferencia electrónica de fondos"
-		with (
-			patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 1})),
-			patch("frappe.db.exists", side_effect=_mock_exists({"03"})),
-		):
-			self.assertEqual(_resolver_forma_pago_sat(mop), "03")
+		"""MoP SAT '03 - Transferencia...' del fixture → código '03'."""
+		result = _resolver_forma_pago_sat("03 - Transferencia electrónica de fondos")
+		self.assertEqual(result, "03")
 
 	def test_resuelve_efectivo(self):
-		"""MoP SAT válido '01 - Efectivo' → código '01'."""
-		mop = "01 - Efectivo"
-		with (
-			patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 1})),
-			patch("frappe.db.exists", side_effect=_mock_exists({"01"})),
-		):
-			self.assertEqual(_resolver_forma_pago_sat(mop), "01")
+		"""MoP SAT '01 - Efectivo' del fixture → código '01'."""
+		result = _resolver_forma_pago_sat("01 - Efectivo")
+		self.assertEqual(result, "01")
 
 	def test_resuelve_por_definir_99(self):
-		"""MoP SAT '99 - Por definir' → código '99'."""
-		mop = "99 - Por definir"
-		with (
-			patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 1})),
-			patch("frappe.db.exists", side_effect=_mock_exists({"99"})),
-		):
-			self.assertEqual(_resolver_forma_pago_sat(mop), "99")
+		"""MoP SAT '99 - Por definir' del fixture → código '99'."""
+		result = _resolver_forma_pago_sat("99 - Por definir")
+		self.assertEqual(result, "99")
 
 	# -- Casos de bloqueo --
 
-	def test_bloquea_mop_vacio(self):
-		"""None → ValidationError 'Forma de Pago Faltante'."""
+	def test_bloquea_mop_vacio_none(self):
+		"""None → ValidationError."""
 		with self.assertRaises(frappe.ValidationError) as ctx:
 			_resolver_forma_pago_sat(None)
 		self.assertIn("Forma de Pago", str(ctx.exception))
 
-	def test_bloquea_string_vacio(self):
+	def test_bloquea_mop_string_vacio(self):
 		"""String vacío → ValidationError."""
 		with self.assertRaises(frappe.ValidationError):
 			_resolver_forma_pago_sat("")
 
+	def test_bloquea_mop_inexistente_en_bd(self):
+		"""MoP que no existe en BD → ValidationError."""
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			_resolver_forma_pago_sat("MOP-FANTASMA-XYZ-99999")
+		self.assertIn("no existe", str(ctx.exception))
+
+	def test_bloquea_mop_deshabilitado(self):
+		"""MoP con enabled=0 → ValidationError."""
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			_resolver_forma_pago_sat(self.mop_disabled)
+		self.assertIn("deshabilitado", str(ctx.exception))
+
 	def test_bloquea_cash(self):
 		"""MoP nativo 'Cash' no cumple patrón → ValidationError."""
-		with patch("frappe.db.get_value", side_effect=_mock_get_value({"Cash": 1})):
-			with self.assertRaises(frappe.ValidationError) as ctx:
-				_resolver_forma_pago_sat("Cash")
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			_resolver_forma_pago_sat("Cash")
 		self.assertIn("catálogo SAT", str(ctx.exception))
 
 	def test_bloquea_wire_transfer(self):
-		"""MoP nativo 'Wire Transfer' → ValidationError."""
-		with patch("frappe.db.get_value", side_effect=_mock_get_value({"Wire Transfer": 1})):
-			with self.assertRaises(frappe.ValidationError):
-				_resolver_forma_pago_sat("Wire Transfer")
+		"""MoP nativo 'Wire Transfer' no cumple patrón → ValidationError."""
+		with self.assertRaises(frappe.ValidationError):
+			_resolver_forma_pago_sat("Wire Transfer")
 
 	def test_bloquea_check(self):
 		"""MoP nativo 'Check' → ValidationError."""
-		with patch("frappe.db.get_value", side_effect=_mock_get_value({"Check": 1})):
-			with self.assertRaises(frappe.ValidationError):
-				_resolver_forma_pago_sat("Check")
+		with self.assertRaises(frappe.ValidationError):
+			_resolver_forma_pago_sat("Check")
 
 	def test_bloquea_credit_card(self):
-		"""MoP nativo 'Credit Card' → ValidationError (patrón no cumple)."""
-		with patch("frappe.db.get_value", side_effect=_mock_get_value({"Credit Card": 1})):
-			with self.assertRaises(frappe.ValidationError):
-				_resolver_forma_pago_sat("Credit Card")
-
-	def test_bloquea_mop_deshabilitado(self):
-		"""MoP con enabled=0 → ValidationError 'Modo de Pago Deshabilitado'."""
-		mop = "03 - Transferencia electrónica de fondos"
-		with patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 0})):
-			with self.assertRaises(frappe.ValidationError) as ctx:
-				_resolver_forma_pago_sat(mop)
-		self.assertIn("deshabilitado", str(ctx.exception))
-
-	def test_bloquea_mop_inexistente_en_bd(self):
-		"""MoP que no existe en BD (get_value devuelve None) → ValidationError."""
-		with patch("frappe.db.get_value", return_value=None):
-			with self.assertRaises(frappe.ValidationError) as ctx:
-				_resolver_forma_pago_sat("55 - Inexistente")
-		self.assertIn("no existe", str(ctx.exception))
+		"""MoP nativo 'Credit Card' → ValidationError."""
+		with self.assertRaises(frappe.ValidationError):
+			_resolver_forma_pago_sat("Credit Card")
 
 	def test_bloquea_patron_sin_guion(self):
-		"""Nombre sin ' - ' → ValidationError."""
-		with patch("frappe.db.get_value", side_effect=_mock_get_value({"01Efectivo": 1})):
-			with self.assertRaises(frappe.ValidationError):
-				_resolver_forma_pago_sat("01Efectivo")
+		"""Nombre sin ' - ' no cumple patrón → ValidationError."""
+		with self.assertRaises(frappe.ValidationError):
+			_resolver_forma_pago_sat("01Efectivo")
 
 	def test_bloquea_letras_en_prefijo(self):
-		"""Prefijo con letras 'AB - Algo' no cumple patrón \\d{2}."""
-		with patch("frappe.db.get_value", side_effect=_mock_get_value({"AB - Algo": 1})):
-			with self.assertRaises(frappe.ValidationError):
-				_resolver_forma_pago_sat("AB - Algo")
+		"""Prefijo con letras 'AB - Algo' → ValidationError."""
+		with self.assertRaises(frappe.ValidationError):
+			_resolver_forma_pago_sat("AB - Algo")
 
 	def test_bloquea_codigo_no_en_catalogo_sat(self):
-		"""Nombre cumple patrón pero código no está en Forma Pago SAT → ValidationError."""
-		mop = "55 - Inventado"
-		with (
-			patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 1})),
-			patch("frappe.db.exists", side_effect=_mock_exists(set())),
-		):
-			with self.assertRaises(frappe.ValidationError) as ctx:
-				_resolver_forma_pago_sat(mop)
+		"""MoP con formato correcto pero código '55' no en Forma Pago SAT → ValidationError."""
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			_resolver_forma_pago_sat(self.mop_fake_sat)
 		self.assertIn("catálogo SAT", str(ctx.exception))
 
 	# -- Verificación del patrón regex --
 
 	def test_patron_acepta_formatos_validos(self):
 		"""El patrón regex acepta nombres válidos del fixture."""
-		from facturacion_mexico.complementos_pago.api import _PATRON_MOP_SAT
-
 		validos = [
 			"01 - Efectivo",
 			"03 - Transferencia electrónica de fondos",
@@ -161,8 +142,6 @@ class TestResolverFormaPagoSAT(FrappeTestCase):
 
 	def test_patron_rechaza_formatos_invalidos(self):
 		"""El patrón regex rechaza nombres no SAT."""
-		from facturacion_mexico.complementos_pago.api import _PATRON_MOP_SAT
-
 		invalidos = [
 			"Cash",
 			"Wire Transfer",

--- a/facturacion_mexico/complementos_pago/tests/test_resolver_forma_pago_sat.py
+++ b/facturacion_mexico/complementos_pago/tests/test_resolver_forma_pago_sat.py
@@ -1,0 +1,176 @@
+"""
+Tests para _resolver_forma_pago_sat (issue #161).
+
+Verifica que el helper rechaza modos de pago no SAT y resuelve
+correctamente los del fixture del app.
+"""
+
+import re
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.complementos_pago.api import _resolver_forma_pago_sat
+
+
+def _mock_get_value(enabled_map):
+	"""Retorna side_effect para frappe.db.get_value."""
+
+	def side_effect(doctype, name, field):
+		if doctype == "Mode of Payment" and field == "enabled":
+			return enabled_map.get(name)
+		return None
+
+	return side_effect
+
+
+def _mock_exists(existing):
+	"""Retorna side_effect para frappe.db.exists."""
+
+	def side_effect(doctype, name):
+		if doctype == "Forma Pago SAT":
+			return name in existing
+		return False
+
+	return side_effect
+
+
+class TestResolverFormaPagoSAT(FrappeTestCase):
+	"""Tests unitarios para _resolver_forma_pago_sat."""
+
+	# -- Casos válidos --
+
+	def test_resuelve_transferencia_electronica(self):
+		"""MoP SAT válido '03 - Transferencia...' → código '03'."""
+		mop = "03 - Transferencia electrónica de fondos"
+		with (
+			patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 1})),
+			patch("frappe.db.exists", side_effect=_mock_exists({"03"})),
+		):
+			self.assertEqual(_resolver_forma_pago_sat(mop), "03")
+
+	def test_resuelve_efectivo(self):
+		"""MoP SAT válido '01 - Efectivo' → código '01'."""
+		mop = "01 - Efectivo"
+		with (
+			patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 1})),
+			patch("frappe.db.exists", side_effect=_mock_exists({"01"})),
+		):
+			self.assertEqual(_resolver_forma_pago_sat(mop), "01")
+
+	def test_resuelve_por_definir_99(self):
+		"""MoP SAT '99 - Por definir' → código '99'."""
+		mop = "99 - Por definir"
+		with (
+			patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 1})),
+			patch("frappe.db.exists", side_effect=_mock_exists({"99"})),
+		):
+			self.assertEqual(_resolver_forma_pago_sat(mop), "99")
+
+	# -- Casos de bloqueo --
+
+	def test_bloquea_mop_vacio(self):
+		"""None → ValidationError 'Forma de Pago Faltante'."""
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			_resolver_forma_pago_sat(None)
+		self.assertIn("Forma de Pago", str(ctx.exception))
+
+	def test_bloquea_string_vacio(self):
+		"""String vacío → ValidationError."""
+		with self.assertRaises(frappe.ValidationError):
+			_resolver_forma_pago_sat("")
+
+	def test_bloquea_cash(self):
+		"""MoP nativo 'Cash' no cumple patrón → ValidationError."""
+		with patch("frappe.db.get_value", side_effect=_mock_get_value({"Cash": 1})):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				_resolver_forma_pago_sat("Cash")
+		self.assertIn("catálogo SAT", str(ctx.exception))
+
+	def test_bloquea_wire_transfer(self):
+		"""MoP nativo 'Wire Transfer' → ValidationError."""
+		with patch("frappe.db.get_value", side_effect=_mock_get_value({"Wire Transfer": 1})):
+			with self.assertRaises(frappe.ValidationError):
+				_resolver_forma_pago_sat("Wire Transfer")
+
+	def test_bloquea_check(self):
+		"""MoP nativo 'Check' → ValidationError."""
+		with patch("frappe.db.get_value", side_effect=_mock_get_value({"Check": 1})):
+			with self.assertRaises(frappe.ValidationError):
+				_resolver_forma_pago_sat("Check")
+
+	def test_bloquea_credit_card(self):
+		"""MoP nativo 'Credit Card' → ValidationError (patrón no cumple)."""
+		with patch("frappe.db.get_value", side_effect=_mock_get_value({"Credit Card": 1})):
+			with self.assertRaises(frappe.ValidationError):
+				_resolver_forma_pago_sat("Credit Card")
+
+	def test_bloquea_mop_deshabilitado(self):
+		"""MoP con enabled=0 → ValidationError 'Modo de Pago Deshabilitado'."""
+		mop = "03 - Transferencia electrónica de fondos"
+		with patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 0})):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				_resolver_forma_pago_sat(mop)
+		self.assertIn("deshabilitado", str(ctx.exception))
+
+	def test_bloquea_mop_inexistente_en_bd(self):
+		"""MoP que no existe en BD (get_value devuelve None) → ValidationError."""
+		with patch("frappe.db.get_value", return_value=None):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				_resolver_forma_pago_sat("55 - Inexistente")
+		self.assertIn("no existe", str(ctx.exception))
+
+	def test_bloquea_patron_sin_guion(self):
+		"""Nombre sin ' - ' → ValidationError."""
+		with patch("frappe.db.get_value", side_effect=_mock_get_value({"01Efectivo": 1})):
+			with self.assertRaises(frappe.ValidationError):
+				_resolver_forma_pago_sat("01Efectivo")
+
+	def test_bloquea_letras_en_prefijo(self):
+		"""Prefijo con letras 'AB - Algo' no cumple patrón \\d{2}."""
+		with patch("frappe.db.get_value", side_effect=_mock_get_value({"AB - Algo": 1})):
+			with self.assertRaises(frappe.ValidationError):
+				_resolver_forma_pago_sat("AB - Algo")
+
+	def test_bloquea_codigo_no_en_catalogo_sat(self):
+		"""Nombre cumple patrón pero código no está en Forma Pago SAT → ValidationError."""
+		mop = "55 - Inventado"
+		with (
+			patch("frappe.db.get_value", side_effect=_mock_get_value({mop: 1})),
+			patch("frappe.db.exists", side_effect=_mock_exists(set())),
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				_resolver_forma_pago_sat(mop)
+		self.assertIn("catálogo SAT", str(ctx.exception))
+
+	# -- Verificación del patrón regex --
+
+	def test_patron_acepta_formatos_validos(self):
+		"""El patrón regex acepta nombres válidos del fixture."""
+		from facturacion_mexico.complementos_pago.api import _PATRON_MOP_SAT
+
+		validos = [
+			"01 - Efectivo",
+			"03 - Transferencia electrónica de fondos",
+			"99 - Por definir",
+			"28 - Tarjeta de débito",
+		]
+		for v in validos:
+			self.assertIsNotNone(_PATRON_MOP_SAT.match(v), f"Debería aceptar: {v}")
+
+	def test_patron_rechaza_formatos_invalidos(self):
+		"""El patrón regex rechaza nombres no SAT."""
+		from facturacion_mexico.complementos_pago.api import _PATRON_MOP_SAT
+
+		invalidos = [
+			"Cash",
+			"Wire Transfer",
+			"Check",
+			"Credit Card",
+			"Bank Draft",
+			"Cheque",
+			"1 - Solo un dígito",
+		]
+		for v in invalidos:
+			self.assertIsNone(_PATRON_MOP_SAT.match(v), f"Debería rechazar: {v}")

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -195,6 +195,28 @@ class FacturaFiscalMexico(Document):
 		self.validate_cfdi_use()
 		self.validate_payment_method()
 		self.validate_ppd_vs_forma_pago()
+		self._validate_items_clave_sat()
+
+	def _validate_items_clave_sat(self):
+		"""Verificar que todos los ítems del SI tienen Clave SAT Producto/Servicio."""
+		if not self.sales_invoice:
+			return
+		si = frappe.get_doc("Sales Invoice", self.sales_invoice)
+		missing = []
+		for item in si.items:
+			clave = frappe.db.get_value("Item", item.item_code, "fm_producto_servicio_sat")
+			if not clave:
+				missing.append(f"• {item.item_code} ({item.item_name or item.item_code})")
+		if missing:
+			frappe.throw(
+				_(
+					"No se puede procesar esta Factura Fiscal: los siguientes ítems no tienen "
+					"Clave SAT Producto/Servicio configurada:\n\n{0}\n\n"
+					"Configure el campo 'Clave SAT Producto/Servicio' en cada ítem antes de continuar."
+				).format("\n".join(missing)),
+				frappe.ValidationError,
+				title=_("Claves SAT Faltantes"),
+			)
 
 	def _normalize_sync(self):
 		"""Normalizar estado de sincronización a minúsculas."""

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -209,7 +209,7 @@ class FacturaFiscalMexico(Document):
 				missing.append(f"• {item.item_code} ({item.item_name or item.item_code})")
 		if missing:
 			frappe.throw(
-				_("ítems sin Clave SAT Producto/Servicio:\n\n{0}").format("\n".join(missing)),
+				_("ítems sin Clave SAT Producto/Servicio:") + "\n\n" + "\n".join(missing),
 				frappe.ValidationError,
 				title=_("Claves SAT Faltantes"),
 			)

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -210,9 +210,7 @@ class FacturaFiscalMexico(Document):
 		if missing:
 			frappe.throw(
 				_(
-					"No se puede procesar esta Factura Fiscal: los siguientes ítems no tienen "
-					"Clave SAT Producto/Servicio configurada:\n\n{0}\n\n"
-					"Configure el campo 'Clave SAT Producto/Servicio' en cada ítem antes de continuar."
+					"No se puede procesar esta Factura Fiscal: los siguientes ítems no tienen Clave SAT Producto/Servicio configurada:\n\n{0}\n\nConfigure el campo 'Clave SAT Producto/Servicio' en cada ítem antes de continuar."
 				).format("\n".join(missing)),
 				frappe.ValidationError,
 				title=_("Claves SAT Faltantes"),

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -209,9 +209,7 @@ class FacturaFiscalMexico(Document):
 				missing.append(f"• {item.item_code} ({item.item_name or item.item_code})")
 		if missing:
 			frappe.throw(
-				_(
-					"No se puede procesar esta Factura Fiscal: los siguientes ítems no tienen Clave SAT Producto/Servicio configurada:\n\n{0}\n\nConfigure el campo 'Clave SAT Producto/Servicio' en cada ítem antes de continuar."
-				).format("\n".join(missing)),
+				_("ítems sin Clave SAT Producto/Servicio:\n\n{0}").format("\n".join(missing)),
 				frappe.ValidationError,
 				title=_("Claves SAT Faltantes"),
 			)

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -106,9 +106,7 @@ def _validate_items_clave_sat_for_timbrado(sales_invoice):
 			missing.append(f"• {item.item_code} ({item.item_name or item.item_code})")
 	if missing:
 		frappe.throw(
-			_(
-				"No se puede timbrar: los siguientes ítems no tienen Clave SAT Producto/Servicio configurada:\n\n{0}\n\nConfigure el campo en Item → 'Clave SAT Producto/Servicio'."
-			).format("\n".join(missing)),
+			_("No se puede timbrar: ítems sin Clave SAT:\n\n{0}").format("\n".join(missing)),
 			frappe.ValidationError,
 			title=_("Claves SAT Faltantes — Timbrado Bloqueado"),
 		)
@@ -538,10 +536,7 @@ class TimbradoAPI:
 			# si _validate_invoice_for_timbrado corrió primero.
 			if not item_doc.fm_producto_servicio_sat:
 				frappe.throw(
-					_(
-						"Ítem '{0}': Clave SAT Producto/Servicio no configurada. "
-						"Configúrela en Item antes de timbrar."
-					).format(item_doc.name),
+					_("Ítem '{0}': sin Clave SAT Producto/Servicio.").format(item_doc.name),
 					frappe.ValidationError,
 					title=_("Clave SAT Faltante"),
 				)

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -93,6 +93,29 @@ def _extract_sat_code_from_uom(uom_name):
 	return uom_mapping.get(uom_name, "H87")
 
 
+def _validate_items_clave_sat_for_timbrado(sales_invoice):
+	"""Verifica que todos los ítems del SI tienen Clave SAT Producto/Servicio.
+
+	Se llama en _validate_invoice_for_timbrado antes de construir el payload.
+	Falla rápido reportando todos los ítems faltantes en un solo error.
+	"""
+	missing = []
+	for item in sales_invoice.items:
+		clave = frappe.db.get_value("Item", item.item_code, "fm_producto_servicio_sat")
+		if not clave:
+			missing.append(f"• {item.item_code} ({item.item_name or item.item_code})")
+	if missing:
+		frappe.throw(
+			_(
+				"No se puede timbrar: los siguientes ítems no tienen "
+				"Clave SAT Producto/Servicio configurada:\n\n{0}\n\n"
+				"Configure el campo en Item → 'Clave SAT Producto/Servicio'."
+			).format("\n".join(missing)),
+			frappe.ValidationError,
+			title=_("Claves SAT Faltantes — Timbrado Bloqueado"),
+		)
+
+
 class TimbradoAPI:
 	"""API para timbrado de facturas usando FacturAPI.io."""
 
@@ -427,6 +450,8 @@ class TimbradoAPI:
 
 		validate_invoice_items_uom(sales_invoice.items)
 
+		_validate_items_clave_sat_for_timbrado(sales_invoice)
+
 	def _get_factura_fiscal(self, sales_invoice):
 		"""Obtener Factura Fiscal México existente."""
 		if not sales_invoice.fm_factura_fiscal_mx:
@@ -510,6 +535,18 @@ class TimbradoAPI:
 		items = []
 		for item in sales_invoice.items:
 			item_doc = frappe.get_doc("Item", item.item_code)
+
+			# Defensa final contra ausencia de clave SAT — no debe llegar aquí
+			# si _validate_invoice_for_timbrado corrió primero.
+			if not item_doc.fm_producto_servicio_sat:
+				frappe.throw(
+					_(
+						"Ítem '{0}': Clave SAT Producto/Servicio no configurada. "
+						"Configúrela en Item antes de timbrar."
+					).format(item_doc.name),
+					frappe.ValidationError,
+					title=_("Clave SAT Faltante"),
+				)
 
 			# E4.1: Leer taxes desde SI (NO calcular)
 			item_taxes_data = self._read_taxes_from_sales_invoice_item(item, sales_invoice)
@@ -647,7 +684,7 @@ class TimbradoAPI:
 				"quantity": abs(item.qty),  # SIs de devolución tienen qty negativa por diseño ERPNext
 				"product": {
 					"description": item.description or item.item_name,
-					"product_key": item_doc.fm_producto_servicio_sat or "01010101",
+					"product_key": item_doc.fm_producto_servicio_sat,
 					"price": flt(item.rate),
 					"tax_included": False,
 					"unit_key": _extract_sat_code_from_uom(item.uom),

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -106,7 +106,7 @@ def _validate_items_clave_sat_for_timbrado(sales_invoice):
 			missing.append(f"• {item.item_code} ({item.item_name or item.item_code})")
 	if missing:
 		frappe.throw(
-			_("No se puede timbrar: ítems sin Clave SAT:\n\n{0}").format("\n".join(missing)),
+			_("No se puede timbrar: ítems sin Clave SAT:") + "\n\n" + "\n".join(missing),
 			frappe.ValidationError,
 			title=_("Claves SAT Faltantes — Timbrado Bloqueado"),
 		)

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -107,9 +107,7 @@ def _validate_items_clave_sat_for_timbrado(sales_invoice):
 	if missing:
 		frappe.throw(
 			_(
-				"No se puede timbrar: los siguientes ítems no tienen "
-				"Clave SAT Producto/Servicio configurada:\n\n{0}\n\n"
-				"Configure el campo en Item → 'Clave SAT Producto/Servicio'."
+				"No se puede timbrar: los siguientes ítems no tienen Clave SAT Producto/Servicio configurada:\n\n{0}\n\nConfigure el campo en Item → 'Clave SAT Producto/Servicio'."
 			).format("\n".join(missing)),
 			frappe.ValidationError,
 			title=_("Claves SAT Faltantes — Timbrado Bloqueado"),

--- a/facturacion_mexico/fixtures/mode_of_payment.json
+++ b/facturacion_mexico/fixtures/mode_of_payment.json
@@ -218,5 +218,59 @@
   "modified": "2025-08-01 02:19:40.223135",
   "name": "03 - Transferencia electrónica de fondos",
   "type": "General"
+ },
+ {
+  "accounts": [],
+  "docstatus": 0,
+  "doctype": "Mode of Payment",
+  "enabled": 0,
+  "mode_of_payment": "Bank Draft",
+  "name": "Bank Draft",
+  "type": "General"
+ },
+ {
+  "accounts": [],
+  "docstatus": 0,
+  "doctype": "Mode of Payment",
+  "enabled": 0,
+  "mode_of_payment": "Cash",
+  "name": "Cash",
+  "type": "Cash"
+ },
+ {
+  "accounts": [],
+  "docstatus": 0,
+  "doctype": "Mode of Payment",
+  "enabled": 0,
+  "mode_of_payment": "Check",
+  "name": "Check",
+  "type": "General"
+ },
+ {
+  "accounts": [],
+  "docstatus": 0,
+  "doctype": "Mode of Payment",
+  "enabled": 0,
+  "mode_of_payment": "Cheque",
+  "name": "Cheque",
+  "type": "General"
+ },
+ {
+  "accounts": [],
+  "docstatus": 0,
+  "doctype": "Mode of Payment",
+  "enabled": 0,
+  "mode_of_payment": "Credit Card",
+  "name": "Credit Card",
+  "type": "General"
+ },
+ {
+  "accounts": [],
+  "docstatus": 0,
+  "doctype": "Mode of Payment",
+  "enabled": 0,
+  "mode_of_payment": "Wire Transfer",
+  "name": "Wire Transfer",
+  "type": "General"
  }
 ]

--- a/facturacion_mexico/hooks_handlers/sales_invoice_automated_tax.py
+++ b/facturacion_mexico/hooks_handlers/sales_invoice_automated_tax.py
@@ -452,5 +452,5 @@ def validate(doc, method=None):
 		sat_field = frappe.db.get_value("Item", row.item_code, "fm_producto_servicio_sat")
 		if not sat_field:
 			frappe.throw(
-				f"Línea {i} (Item: {row.item_code}) sin <b>ClaveProdServ SAT</b> configurada en el Item. No se puede guardar la factura."
+				f"Línea {i} (Item: {row.item_code}): sin <b>Clave SAT de Producto o Servicio</b> configurada. Asígnela en el artículo para poder facturar."
 			)

--- a/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
+++ b/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
@@ -126,11 +126,9 @@ class TestPrepareFActurapiDataSinFallback(FrappeTestCase):
 	def test_no_existe_fallback_01010101_en_codigo(self):
 		"""El string '01010101' no debe aparecer como fallback en timbrado_api.py."""
 		import re
+		from pathlib import Path
 
-		ruta = (
-			"/home/erpnext/frappe-bench-v16/apps/facturacion_mexico"
-			"/facturacion_mexico/facturacion_fiscal/timbrado_api.py"
-		)
+		ruta = Path(__file__).parent.parent / "facturacion_fiscal" / "timbrado_api.py"
 		with open(ruta) as f:
 			contenido = f.read()
 
@@ -144,11 +142,9 @@ class TestPrepareFActurapiDataSinFallback(FrappeTestCase):
 	def test_product_key_usa_campo_directo(self):
 		"""product_key en el payload debe usar fm_producto_servicio_sat directamente."""
 		import re
+		from pathlib import Path
 
-		ruta = (
-			"/home/erpnext/frappe-bench-v16/apps/facturacion_mexico"
-			"/facturacion_mexico/facturacion_fiscal/timbrado_api.py"
-		)
+		ruta = Path(__file__).parent.parent / "facturacion_fiscal" / "timbrado_api.py"
 		with open(ruta) as f:
 			contenido = f.read()
 

--- a/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
+++ b/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
@@ -1,0 +1,259 @@
+"""
+Tests para issue #162: eliminación del fallback "01010101" para Clave SAT Producto/Servicio.
+
+Cubre tres capas de defensa:
+  A) _validate_items_clave_sat_for_timbrado (módulo timbrado_api)
+  B) FFM.validate() → _validate_items_clave_sat
+  C) _prepare_facturapi_data → defensa final en el loop
+
+No cubre la capa de Sales Invoice validate (fuera del alcance de este issue).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.facturacion_fiscal.timbrado_api import _validate_items_clave_sat_for_timbrado
+
+
+def _make_si_items(items_data):
+	"""Helper: construye lista de items estilo Frappe para un SI mock."""
+	items = []
+	for d in items_data:
+		item = frappe._dict(
+			item_code=d["item_code"],
+			item_name=d.get("item_name", d["item_code"]),
+			qty=d.get("qty", 1),
+			rate=d.get("rate", 100),
+			uom=d.get("uom", "H87 - Pieza"),
+		)
+		items.append(item)
+	return items
+
+
+def _make_mock_si(items_data, name="TEST-SI-001"):
+	# frappe._dict no sirve aquí: .items() es el método dict, no la lista de ítems.
+	si = MagicMock()
+	si.name = name
+	si.docstatus = 1
+	si.items = _make_si_items(items_data)
+	return si
+
+
+class TestValidateItemsClavesSATTimbrado(FrappeTestCase):
+	"""Tests para _validate_items_clave_sat_for_timbrado en timbrado_api.py (Capa A)."""
+
+	def _make_get_value_mock(self, clave_map):
+		"""
+		Devuelve un side_effect para frappe.db.get_value que mapea item_code → clave SAT.
+		clave_map: {"ITEM-001": "43211501", "ITEM-002": None}
+		"""
+
+		def side_effect(doctype, name, field):
+			if doctype == "Item" and field == "fm_producto_servicio_sat":
+				return clave_map.get(name)
+			return None
+
+		return side_effect
+
+	def test_pasa_cuando_todos_tienen_clave_sat(self):
+		"""Ningún error cuando todos los ítems tienen fm_producto_servicio_sat."""
+		si = _make_mock_si(
+			[
+				{"item_code": "ITEM-001"},
+				{"item_code": "ITEM-002"},
+			]
+		)
+		clave_map = {"ITEM-001": "43211501", "ITEM-002": "80141600"}
+
+		with patch("frappe.db.get_value", side_effect=self._make_get_value_mock(clave_map)):
+			# No debe lanzar excepción
+			_validate_items_clave_sat_for_timbrado(si)
+
+	def test_bloquea_cuando_un_item_sin_clave_sat(self):
+		"""ValidationError cuando al menos un ítem carece de clave SAT."""
+		si = _make_mock_si(
+			[
+				{"item_code": "ITEM-CON-CLAVE", "item_name": "Producto configurado"},
+				{"item_code": "ITEM-SIN-CLAVE", "item_name": "Producto sin configurar"},
+			]
+		)
+		clave_map = {"ITEM-CON-CLAVE": "43211501", "ITEM-SIN-CLAVE": None}
+
+		with patch("frappe.db.get_value", side_effect=self._make_get_value_mock(clave_map)):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				_validate_items_clave_sat_for_timbrado(si)
+
+		self.assertIn("ITEM-SIN-CLAVE", str(ctx.exception))
+		self.assertIn("Clave SAT", str(ctx.exception))
+
+	def test_bloquea_cuando_todos_los_items_sin_clave_sat(self):
+		"""ValidationError acumula todos los ítems faltantes en un solo error."""
+		si = _make_mock_si(
+			[
+				{"item_code": "ITEM-A", "item_name": "Item A"},
+				{"item_code": "ITEM-B", "item_name": "Item B"},
+				{"item_code": "ITEM-C", "item_name": "Item C"},
+			]
+		)
+		clave_map = {"ITEM-A": None, "ITEM-B": None, "ITEM-C": None}
+
+		with patch("frappe.db.get_value", side_effect=self._make_get_value_mock(clave_map)):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				_validate_items_clave_sat_for_timbrado(si)
+
+		error_text = str(ctx.exception)
+		self.assertIn("ITEM-A", error_text)
+		self.assertIn("ITEM-B", error_text)
+		self.assertIn("ITEM-C", error_text)
+
+	def test_pasa_con_lista_vacia_de_items(self):
+		"""SI sin ítems no dispara la validación de clave SAT."""
+		si = _make_mock_si([])
+
+		with patch("frappe.db.get_value", return_value=None):
+			_validate_items_clave_sat_for_timbrado(si)
+
+
+class TestPrepareFActurapiDataSinFallback(FrappeTestCase):
+	"""Tests para la defensa final en _prepare_facturapi_data (Capa C).
+
+	Verifica que el fallback "01010101" fue eliminado y que el código
+	lanza error si se llega al loop con un ítem sin clave SAT.
+	"""
+
+	def test_no_existe_fallback_01010101_en_codigo(self):
+		"""El string '01010101' no debe aparecer como fallback en timbrado_api.py."""
+		import re
+
+		ruta = (
+			"/home/erpnext/frappe-bench-v16/apps/facturacion_mexico"
+			"/facturacion_mexico/facturacion_fiscal/timbrado_api.py"
+		)
+		with open(ruta) as f:
+			contenido = f.read()
+
+		# Buscar el patrón de fallback: fm_producto_servicio_sat or "01010101"
+		patron_fallback = re.search(r'fm_producto_servicio_sat\s+or\s+["\']01010101["\']', contenido)
+		self.assertIsNone(
+			patron_fallback,
+			"El fallback 'or \"01010101\"' todavía existe en timbrado_api.py — no fue eliminado.",
+		)
+
+	def test_product_key_usa_campo_directo(self):
+		"""product_key en el payload debe usar fm_producto_servicio_sat directamente."""
+		import re
+
+		ruta = (
+			"/home/erpnext/frappe-bench-v16/apps/facturacion_mexico"
+			"/facturacion_mexico/facturacion_fiscal/timbrado_api.py"
+		)
+		with open(ruta) as f:
+			contenido = f.read()
+
+		# Debe existir la asignación directa sin fallback
+		patron_directo = re.search(r'"product_key":\s*item_doc\.fm_producto_servicio_sat\s*,', contenido)
+		self.assertIsNotNone(
+			patron_directo,
+			"No se encontró la asignación directa 'product_key: item_doc.fm_producto_servicio_sat' "
+			"sin fallback en timbrado_api.py.",
+		)
+
+
+class TestFFMValidateClavesSAT(FrappeTestCase):
+	"""Tests para FFM._validate_items_clave_sat (Capa B).
+
+	Prueba el método directamente usando mocks para evitar dependencia de BD.
+	"""
+
+	def _make_ffm_doc(self, si_name="TEST-SI-001"):
+		"""Crea un documento FFM mock con sales_invoice configurado."""
+		ffm = MagicMock()
+		ffm.sales_invoice = si_name
+		return ffm
+
+	def _make_si_doc(self, items_data):
+		"""Crea un SI mock con ítems."""
+		si = MagicMock()
+		si.items = [
+			frappe._dict(
+				item_code=d["item_code"],
+				item_name=d.get("item_name", d["item_code"]),
+			)
+			for d in items_data
+		]
+		return si
+
+	def test_pasa_cuando_todos_tienen_clave_sat(self):
+		"""_validate_items_clave_sat no lanza error cuando todos los ítems tienen clave."""
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
+
+		si = self._make_si_doc(
+			[
+				{"item_code": "ITEM-001"},
+				{"item_code": "ITEM-002"},
+			]
+		)
+
+		def get_value_mock(doctype, name, field):
+			claves = {"ITEM-001": "43211501", "ITEM-002": "80141600"}
+			if doctype == "Item" and field == "fm_producto_servicio_sat":
+				return claves.get(name)
+			return None
+
+		# Instanciar sin BD usando __new__ para evitar __init__ de Frappe
+		ffm = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		ffm.sales_invoice = "TEST-SI-001"
+
+		with (
+			patch("frappe.get_doc", return_value=si),
+			patch("frappe.db.get_value", side_effect=get_value_mock),
+		):
+			ffm._validate_items_clave_sat()
+
+	def test_bloquea_cuando_item_sin_clave_sat(self):
+		"""_validate_items_clave_sat lanza ValidationError cuando falta clave SAT."""
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
+
+		si = self._make_si_doc(
+			[
+				{"item_code": "ITEM-OK", "item_name": "Con clave"},
+				{"item_code": "ITEM-SIN", "item_name": "Sin clave"},
+			]
+		)
+
+		def get_value_mock(doctype, name, field):
+			claves = {"ITEM-OK": "43211501", "ITEM-SIN": None}
+			if doctype == "Item" and field == "fm_producto_servicio_sat":
+				return claves.get(name)
+			return None
+
+		ffm = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		ffm.sales_invoice = "TEST-SI-001"
+
+		with (
+			patch("frappe.get_doc", return_value=si),
+			patch("frappe.db.get_value", side_effect=get_value_mock),
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				ffm._validate_items_clave_sat()
+
+		self.assertIn("ITEM-SIN", str(ctx.exception))
+
+	def test_no_valida_cuando_no_hay_sales_invoice(self):
+		"""_validate_items_clave_sat retorna sin error si sales_invoice está vacío."""
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
+
+		ffm = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		ffm.sales_invoice = None
+
+		with patch("frappe.get_doc") as mock_get_doc:
+			ffm._validate_items_clave_sat()
+			mock_get_doc.assert_not_called()

--- a/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
+++ b/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
@@ -6,10 +6,11 @@ Cubre tres capas de defensa:
   B) FFM.validate() → _validate_items_clave_sat
   C) _prepare_facturapi_data → defensa final en el loop
 
-No cubre la capa de Sales Invoice validate (fuera del alcance de este issue).
+Usa documentos reales (Items, Sales Invoices) — sin mocks de frappe.db.* ni frappe.get_doc (RG-003).
 """
 
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -17,122 +18,105 @@ from frappe.tests.utils import FrappeTestCase
 from facturacion_mexico.facturacion_fiscal.timbrado_api import _validate_items_clave_sat_for_timbrado
 
 
-def _make_si_items(items_data):
-	"""Helper: construye lista de items estilo Frappe para un SI mock."""
-	items = []
-	for d in items_data:
-		item = frappe._dict(
-			item_code=d["item_code"],
-			item_name=d.get("item_name", d["item_code"]),
-			qty=d.get("qty", 1),
-			rate=d.get("rate", 100),
-			uom=d.get("uom", "H87 - Pieza"),
-		)
-		items.append(item)
-	return items
-
-
-def _make_mock_si(items_data, name="TEST-SI-001"):
-	# frappe._dict no sirve aquí: .items() es el método dict, no la lista de ítems.
-	si = MagicMock()
-	si.name = name
-	si.docstatus = 1
-	si.items = _make_si_items(items_data)
-	return si
+def _item_group():
+	return frappe.db.get_value("Item Group", {"is_group": 0}, "name") or "Products"
 
 
 class TestValidateItemsClavesSATTimbrado(FrappeTestCase):
-	"""Tests para _validate_items_clave_sat_for_timbrado en timbrado_api.py (Capa A)."""
+	"""Capa A: tests para _validate_items_clave_sat_for_timbrado (función modular).
 
-	def _make_get_value_mock(self, clave_map):
-		"""
-		Devuelve un side_effect para frappe.db.get_value que mapea item_code → clave SAT.
-		clave_map: {"ITEM-001": "43211501", "ITEM-002": None}
-		"""
+	Usa Items reales. La SI se representa como MagicMock con .items conteniendo
+	item_codes reales — no se mockea frappe.db.*.
+	"""
 
-		def side_effect(doctype, name, field):
-			if doctype == "Item" and field == "fm_producto_servicio_sat":
-				return clave_map.get(name)
-			return None
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		suffix = frappe.generate_hash()[:6]
+		group = _item_group()
 
-		return side_effect
+		cls.item_con_clave = f"TEST-SAT-A-{suffix}"
+		frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": cls.item_con_clave,
+				"item_name": cls.item_con_clave,
+				"item_group": group,
+				"stock_uom": "Nos",
+				"fm_producto_servicio_sat": "84111506",
+			}
+		).insert(ignore_permissions=True)
+
+		cls.item_sin_clave = f"TEST-NOSAT-A-{suffix}"
+		frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": cls.item_sin_clave,
+				"item_name": cls.item_sin_clave,
+				"item_group": group,
+				"stock_uom": "Nos",
+			}
+		).insert(ignore_permissions=True)
+
+	@classmethod
+	def tearDownClass(cls):
+		super().tearDownClass()
+		frappe.db.delete("Item", cls.item_con_clave)
+		frappe.db.delete("Item", cls.item_sin_clave)
+		frappe.db.commit()
+
+	def _make_si(self, codes):
+		si = MagicMock()
+		si.items = [frappe._dict(item_code=c, item_name=c) for c in codes]
+		return si
 
 	def test_pasa_cuando_todos_tienen_clave_sat(self):
-		"""Ningún error cuando todos los ítems tienen fm_producto_servicio_sat."""
-		si = _make_mock_si(
-			[
-				{"item_code": "ITEM-001"},
-				{"item_code": "ITEM-002"},
-			]
-		)
-		clave_map = {"ITEM-001": "43211501", "ITEM-002": "80141600"}
-
-		with patch("frappe.db.get_value", side_effect=self._make_get_value_mock(clave_map)):
-			# No debe lanzar excepción
-			_validate_items_clave_sat_for_timbrado(si)
+		"""No error cuando todos los ítems tienen fm_producto_servicio_sat."""
+		_validate_items_clave_sat_for_timbrado(self._make_si([self.item_con_clave]))
 
 	def test_bloquea_cuando_un_item_sin_clave_sat(self):
 		"""ValidationError cuando al menos un ítem carece de clave SAT."""
-		si = _make_mock_si(
-			[
-				{"item_code": "ITEM-CON-CLAVE", "item_name": "Producto configurado"},
-				{"item_code": "ITEM-SIN-CLAVE", "item_name": "Producto sin configurar"},
-			]
-		)
-		clave_map = {"ITEM-CON-CLAVE": "43211501", "ITEM-SIN-CLAVE": None}
-
-		with patch("frappe.db.get_value", side_effect=self._make_get_value_mock(clave_map)):
-			with self.assertRaises(frappe.ValidationError) as ctx:
-				_validate_items_clave_sat_for_timbrado(si)
-
-		self.assertIn("ITEM-SIN-CLAVE", str(ctx.exception))
-		self.assertIn("Clave SAT", str(ctx.exception))
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			_validate_items_clave_sat_for_timbrado(self._make_si([self.item_con_clave, self.item_sin_clave]))
+		self.assertIn(self.item_sin_clave, str(ctx.exception))
 
 	def test_bloquea_cuando_todos_los_items_sin_clave_sat(self):
-		"""ValidationError acumula todos los ítems faltantes en un solo error."""
-		si = _make_mock_si(
-			[
-				{"item_code": "ITEM-A", "item_name": "Item A"},
-				{"item_code": "ITEM-B", "item_name": "Item B"},
-				{"item_code": "ITEM-C", "item_name": "Item C"},
-			]
-		)
-		clave_map = {"ITEM-A": None, "ITEM-B": None, "ITEM-C": None}
-
-		with patch("frappe.db.get_value", side_effect=self._make_get_value_mock(clave_map)):
+		"""ValidationError reporta todos los ítems faltantes en un solo error."""
+		item_b = f"TEST-NOSAT-B-{frappe.generate_hash()[:6]}"
+		frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": item_b,
+				"item_name": item_b,
+				"item_group": _item_group(),
+				"stock_uom": "Nos",
+			}
+		).insert(ignore_permissions=True)
+		try:
 			with self.assertRaises(frappe.ValidationError) as ctx:
-				_validate_items_clave_sat_for_timbrado(si)
-
-		error_text = str(ctx.exception)
-		self.assertIn("ITEM-A", error_text)
-		self.assertIn("ITEM-B", error_text)
-		self.assertIn("ITEM-C", error_text)
+				_validate_items_clave_sat_for_timbrado(self._make_si([self.item_sin_clave, item_b]))
+			error_text = str(ctx.exception)
+			self.assertIn(self.item_sin_clave, error_text)
+			self.assertIn(item_b, error_text)
+		finally:
+			frappe.db.delete("Item", item_b)
+			frappe.db.commit()
 
 	def test_pasa_con_lista_vacia_de_items(self):
-		"""SI sin ítems no dispara la validación de clave SAT."""
-		si = _make_mock_si([])
-
-		with patch("frappe.db.get_value", return_value=None):
-			_validate_items_clave_sat_for_timbrado(si)
+		"""SI sin ítems no dispara la validación."""
+		_validate_items_clave_sat_for_timbrado(self._make_si([]))
 
 
 class TestPrepareFActurapiDataSinFallback(FrappeTestCase):
-	"""Tests para la defensa final en _prepare_facturapi_data (Capa C).
-
-	Verifica que el fallback "01010101" fue eliminado y que el código
-	lanza error si se llega al loop con un ítem sin clave SAT.
-	"""
+	"""Capa C: verifica que el fallback '01010101' fue eliminado del código fuente."""
 
 	def test_no_existe_fallback_01010101_en_codigo(self):
 		"""El string '01010101' no debe aparecer como fallback en timbrado_api.py."""
 		import re
-		from pathlib import Path
 
 		ruta = Path(__file__).parent.parent / "facturacion_fiscal" / "timbrado_api.py"
-		with open(ruta) as f:
-			contenido = f.read()
+		contenido = ruta.read_text(encoding="utf-8")
 
-		# Buscar el patrón de fallback: fm_producto_servicio_sat or "01010101"
 		patron_fallback = re.search(r'fm_producto_servicio_sat\s+or\s+["\']01010101["\']', contenido)
 		self.assertIsNone(
 			patron_fallback,
@@ -142,104 +126,158 @@ class TestPrepareFActurapiDataSinFallback(FrappeTestCase):
 	def test_product_key_usa_campo_directo(self):
 		"""product_key en el payload debe usar fm_producto_servicio_sat directamente."""
 		import re
-		from pathlib import Path
 
 		ruta = Path(__file__).parent.parent / "facturacion_fiscal" / "timbrado_api.py"
-		with open(ruta) as f:
-			contenido = f.read()
+		contenido = ruta.read_text(encoding="utf-8")
 
-		# Debe existir la asignación directa sin fallback
 		patron_directo = re.search(r'"product_key":\s*item_doc\.fm_producto_servicio_sat\s*,', contenido)
 		self.assertIsNotNone(
 			patron_directo,
-			"No se encontró la asignación directa 'product_key: item_doc.fm_producto_servicio_sat' "
-			"sin fallback en timbrado_api.py.",
+			"No se encontró 'product_key: item_doc.fm_producto_servicio_sat' sin fallback.",
 		)
 
 
 class TestFFMValidateClavesSAT(FrappeTestCase):
-	"""Tests para FFM._validate_items_clave_sat (Capa B).
+	"""Capa B: tests para FFM._validate_items_clave_sat.
 
-	Prueba el método directamente usando mocks para evitar dependencia de BD.
+	Usa Items y Sales Invoices reales — sin mocks de frappe.get_doc (RG-003).
 	"""
 
-	def _make_ffm_doc(self, si_name="TEST-SI-001"):
-		"""Crea un documento FFM mock con sales_invoice configurado."""
-		ffm = MagicMock()
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		suffix = frappe.generate_hash()[:6]
+		group = _item_group()
+
+		# Items — ambos se crean CON clave SAT para pasar el hook de SI
+		cls.item_con_clave = f"TEST-SAT-C-{suffix}"
+		frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": cls.item_con_clave,
+				"item_name": cls.item_con_clave,
+				"item_group": group,
+				"stock_uom": "Nos",
+				"fm_producto_servicio_sat": "84111506",
+			}
+		).insert(ignore_permissions=True)
+
+		# Item para el caso malo: se crea con clave para poder insertar el SI;
+		# la clave se elimina DESPUÉS de crear el SI para simular dato corrupto.
+		cls.item_para_si_malo = f"TEST-SAT-TEMP-C-{suffix}"
+		frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": cls.item_para_si_malo,
+				"item_name": cls.item_para_si_malo,
+				"item_group": group,
+				"stock_uom": "Nos",
+				"fm_producto_servicio_sat": "84111506",
+			}
+		).insert(ignore_permissions=True)
+
+		# Company, Customer y Cost Center mínimos para crear SI
+		cls.company = frappe.db.get_value("Company", {}, "name") or "_Test Company"
+
+		cls.cost_center = frappe.db.get_value("Cost Center", {"is_group": 0, "company": cls.company}, "name")
+
+		cls.customer = "_Test Customer"
+		if not frappe.db.exists("Customer", cls.customer):
+			frappe.get_doc(
+				{
+					"doctype": "Customer",
+					"customer_name": cls.customer,
+					"customer_type": "Individual",
+					"customer_group": frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+					or "Individual",
+					"territory": frappe.db.get_value("Territory", {"is_group": 0}, "name")
+					or "All Territories",
+				}
+			).insert(ignore_permissions=True)
+
+		si_ok = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"customer": cls.customer,
+				"company": cls.company,
+				"cost_center": cls.cost_center,
+				"items": [
+					{
+						"item_code": cls.item_con_clave,
+						"qty": 1,
+						"rate": 100,
+						"uom": "Nos",
+						"cost_center": cls.cost_center,
+					}
+				],
+			}
+		)
+		si_ok.insert(ignore_permissions=True, ignore_mandatory=True)
+		cls.si_con_clave = si_ok.name
+
+		# SI para caso malo: se inserta mientras el item tiene clave SAT,
+		# luego se elimina la clave del item para que FFM._validate_items_clave_sat falle.
+		si_fail = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"customer": cls.customer,
+				"company": cls.company,
+				"cost_center": cls.cost_center,
+				"items": [
+					{
+						"item_code": cls.item_para_si_malo,
+						"qty": 1,
+						"rate": 100,
+						"uom": "Nos",
+						"cost_center": cls.cost_center,
+					}
+				],
+			}
+		)
+		si_fail.insert(ignore_permissions=True, ignore_mandatory=True)
+		cls.si_sin_clave = si_fail.name
+
+		# Ahora eliminar la clave SAT del item — FFM.validate() leerá estado actual del Item
+		frappe.db.set_value("Item", cls.item_para_si_malo, "fm_producto_servicio_sat", None)
+
+	@classmethod
+	def tearDownClass(cls):
+		super().tearDownClass()
+		for si in [cls.si_con_clave, cls.si_sin_clave]:
+			if frappe.db.exists("Sales Invoice", si):
+				frappe.db.delete("Sales Invoice", si)
+		for item in [cls.item_con_clave, cls.item_para_si_malo]:
+			if frappe.db.exists("Item", item):
+				frappe.db.delete("Item", item)
+		frappe.db.commit()
+
+	def _make_ffm(self, si_name):
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
+
+		ffm = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
 		ffm.sales_invoice = si_name
 		return ffm
 
-	def _make_si_doc(self, items_data):
-		"""Crea un SI mock con ítems."""
-		si = MagicMock()
-		si.items = [
-			frappe._dict(
-				item_code=d["item_code"],
-				item_name=d.get("item_name", d["item_code"]),
-			)
-			for d in items_data
-		]
-		return si
-
 	def test_pasa_cuando_todos_tienen_clave_sat(self):
-		"""_validate_items_clave_sat no lanza error cuando todos los ítems tienen clave."""
-		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
-			FacturaFiscalMexico,
-		)
-
-		si = self._make_si_doc(
-			[
-				{"item_code": "ITEM-001"},
-				{"item_code": "ITEM-002"},
-			]
-		)
-
-		def get_value_mock(doctype, name, field):
-			claves = {"ITEM-001": "43211501", "ITEM-002": "80141600"}
-			if doctype == "Item" and field == "fm_producto_servicio_sat":
-				return claves.get(name)
-			return None
-
-		# Instanciar sin BD usando __new__ para evitar __init__ de Frappe
-		ffm = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
-		ffm.sales_invoice = "TEST-SI-001"
-
-		with (
-			patch("frappe.get_doc", return_value=si),
-			patch("frappe.db.get_value", side_effect=get_value_mock),
-		):
-			ffm._validate_items_clave_sat()
+		"""_validate_items_clave_sat no lanza error con ítems con clave SAT."""
+		if not self.company:
+			self.skipTest("No hay Company configurada en el site de tests")
+		ffm = self._make_ffm(self.si_con_clave)
+		ffm._validate_items_clave_sat()
 
 	def test_bloquea_cuando_item_sin_clave_sat(self):
-		"""_validate_items_clave_sat lanza ValidationError cuando falta clave SAT."""
-		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
-			FacturaFiscalMexico,
-		)
-
-		si = self._make_si_doc(
-			[
-				{"item_code": "ITEM-OK", "item_name": "Con clave"},
-				{"item_code": "ITEM-SIN", "item_name": "Sin clave"},
-			]
-		)
-
-		def get_value_mock(doctype, name, field):
-			claves = {"ITEM-OK": "43211501", "ITEM-SIN": None}
-			if doctype == "Item" and field == "fm_producto_servicio_sat":
-				return claves.get(name)
-			return None
-
-		ffm = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
-		ffm.sales_invoice = "TEST-SI-001"
-
-		with (
-			patch("frappe.get_doc", return_value=si),
-			patch("frappe.db.get_value", side_effect=get_value_mock),
-		):
-			with self.assertRaises(frappe.ValidationError) as ctx:
-				ffm._validate_items_clave_sat()
-
-		self.assertIn("ITEM-SIN", str(ctx.exception))
+		"""_validate_items_clave_sat lanza ValidationError cuando falta clave SAT.
+		item_para_si_malo fue creado con clave para poder insertar el SI;
+		la clave se eliminó en setUpClass para simular un ítem corrupto/sin configurar.
+		"""
+		if not self.company:
+			self.skipTest("No hay Company configurada en el site de tests")
+		ffm = self._make_ffm(self.si_sin_clave)
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			ffm._validate_items_clave_sat()
+		self.assertIn(self.item_para_si_malo, str(ctx.exception))
 
 	def test_no_valida_cuando_no_hay_sales_invoice(self):
 		"""_validate_items_clave_sat retorna sin error si sales_invoice está vacío."""
@@ -249,7 +287,4 @@ class TestFFMValidateClavesSAT(FrappeTestCase):
 
 		ffm = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
 		ffm.sales_invoice = None
-
-		with patch("frappe.get_doc") as mock_get_doc:
-			ffm._validate_items_clave_sat()
-			mock_get_doc.assert_not_called()
+		ffm._validate_items_clave_sat()


### PR DESCRIPTION
## Objetivo

Eliminar dos fallbacks silenciosos que generaban CFDIs con datos fiscales incorrectos
sin avisar al usuario:

1. **#162** — Timbrado con `product_key: "01010101"` cuando un ítem no tenía
   Clave SAT Producto/Servicio configurada.
2. **#161** — Complemento Pago con forma de pago inferida por `[:2].strip()`
   del nombre del Mode of Payment (ej: `Cash` → `Ca`, `Wire Transfer` → `Wi`).

## Cambios principales

### issue #162 — Clave SAT obligatoria en flujo fiscal

- `timbrado_api.py`: nueva función `_validate_items_clave_sat_for_timbrado()` +
  defensa final en el loop de `_prepare_facturapi_data`. Elimina `or "01010101"`.
- `factura_fiscal_mexico.py`: nuevo método `_validate_items_clave_sat()` en
  `validate()` — bloquea creación/guardado de FFM si algún ítem carece de clave SAT.
- `sales_invoice_automated_tax.py`: mensaje de error mejorado
  ("ClaveProdServ SAT" → "Clave SAT de Producto o Servicio").
- `tests/test_issue162_clave_sat_obligatoria.py`: 9 tests nuevos.

### issue #161 — Forma de pago SAT explícita en Complemento Pago

- `complementos_pago/api.py`: nuevo helper `_resolver_forma_pago_sat()` con
  validación estricta en 5 pasos: MoP no vacío → existe en BD → habilitado →
  patrón `^\d{2} - .+$` → código en catálogo `Forma Pago SAT`.
  Reemplaza `(pe.mode_of_payment or "")[:2].strip()`. Sin fallback.
- `fixtures/mode_of_payment.json`: agrega MoP nativos ERPNext (`Bank Draft`,
  `Cash`, `Check`, `Cheque`, `Credit Card`, `Wire Transfer`) con `enabled: 0`.
  No se borran registros — solo se deshabilitan para selección futura.
- `complementos_pago/tests/test_resolver_forma_pago_sat.py`: 16 tests nuevos.

## Validaciones realizadas

- Suite completa ejecutada: **1136 tests**.
- 25 tests nuevos (9 de #162 + 16 de #161) — todos pasan.
- 2 failures preexistentes no relacionados:
  - `test_custom_fields_naming_consistency`: campos UAE VAT de ERPNext fuera del
    control de esta app.
  - `test_setup_expense_item_groups.TestEnsureExpenseItemGroups`: fallo en setUpClass
    preexistente no relacionado.
- Sin regresiones introducidas por esta rama.
- Validación GUI: `actiglobal-restore.dev:8406` — FFM bloqueado correctamente
  al crear con ítem sin Clave SAT.
- No requiere `bench migrate` (sin cambios de schema).
- No requiere `bench build`.

## Fuera de alcance

- E-Receipts (`ereceipts/api.py:328`) — también tiene `"01010101"` hardcoded;
  issue separado pendiente.
- Factura Global (`cfdi_global_builder.py:240`) — referencia rota `fm_codigo_sat`;
  issue separado pendiente.
- Campos fantasma `fm_forma_pago_sat`, `fm_codigo_sat`, `custom_forma_pago_sat` —
  documentados como deuda técnica; no eliminados en esta rama.
- Función `obtener_forma_pago_sat()` (dead code) — documentada; no eliminada.

## Riesgos / pendientes

- Payment Entries en producción con MoP nativo (`Cash`, etc.) recibirán error
  explícito al crear Complemento Pago. Error es claro y accionable (indica qué
  cambiar). No hay pérdida de datos.
- `enabled: 0` en MoP nativos no afecta transacciones históricas — solo
  oculta en dropdowns futuros.

Documentación: no aplica — correcciones de validación sin impacto en docs de usuario
ni arquitectura.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed fallback SAT product/service code; invoicing/timbrado now requires explicit SAT product/service keys.
  * Strengthened SAT payment-method validation to enforce format, existence and enabled status; clearer validation errors.

* **Documentation**
  * Updated continuity notes to reflect current tasks, status and touched areas.

* **Tests**
  * Expanded test suite to cover SAT code resolution, validation patterns and timbrado regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->