### PR TITLE
fix(cfdi-recibidos): permite departamentos grupo en mapeo y asignación

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,45 +2,40 @@
 
 **Fecha:** 2026-06-08
 **Rama activa:** `fix/cfdi-recibidos-department-grupos`
-**Tarea actual:** PR abierto — fix departamentos grupo en CFDI Recibidos
+**Tarea actual:** PR #187 listo para merge — fix departamentos grupo CFDI Recibidos
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Fix de 5 filtros `is_group=0` que impedían seleccionar departamentos grupo
-en el módulo CFDI Recibidos. PR abierto para revisión y merge.
+PR #187 revisado por CodeRabbit (solo comentarios sobre CONTINUITY.md, ignorables).
+Listo para Squash and Merge.
 
 Plan que estoy siguiendo:
-Issue surgido en reunión con cliente — departamentos RRHH tipo grupo deben
-poder mapearse en Configuración CFDI Recibidos.
+Merge PR #187 → bench update en producción actiglobal → validar con cliente.
 
 Objetivo inmediato:
-Merge del PR → bench update en producción → validar con cliente.
+Hacer merge del PR #187.
 
 Criterio de avance:
-Departamentos grupo visibles en Configuración CFDI Recibidos y en modal
-"Asignar Departamentos" en lista de CFDI Recibidos.
+main sincronizado con el fix. Producción actualizada con migrate + build.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- ✅ PR #185 mergeado — fix install + wizard IVA 0% + addendas + crash migrate
-- ✅ acg-v16.dev configurado completo (CoA, fiscal, 119 items, La Comer)
-
-### En progreso
-- PR fix/cfdi-recibidos-department-grupos — 1 commit, abierto
+- ✅ PR #185 mergeado — fix install + wizard fiscal IVA 0% + addendas
+- ✅ PR #187 abierto — fix departamentos grupo CFDI Recibidos (CodeRabbit OK)
 
 ### Pendiente inmediato
-1. Merge del PR
+1. Merge PR #187
 2. bench update + migrate + build en producción (actiglobal)
-3. Restore ACG en producción (pendiente desde sesión anterior)
+3. Restore ACG en producción (pendiente)
 
 ### No repetir
-- Había 5 puntos con is_group=0 para Department — todos corregidos
+- Había 5 puntos con is_group=0 para Department — todos corregidos en este PR
 - cost_center, item_group, account, supplier_group mantienen is_group=0
 
 ---
@@ -50,12 +45,10 @@ Departamentos grupo visibles en Configuración CFDI Recibidos y en modal
 - Department en CFDI Recibidos es llave interna para 601-604, NO se traslada a PI
 - PI recibe solo cuentas contables hoja válidas
 - Resolución 601-604 por coincidencia exacta sin fallback a padre
-- is_your_company_address workaround ERPNext 16.21.1 — mantener hasta que ERPNext lo declare
 
 ---
 
 ## Riesgos
 
-- bench migrate requerido post-merge (mapeo_departamento_cfdi_recibido.json cambió)
-- bench build requerido post-merge (cfdi_recibido.js y cfdi_recibido_list.js cambiaron)
-- Issue #186: IEPS combustibles — aún pendiente
+- Requiere bench migrate + bench build al deployar en producción
+- Issue #186: IEPS combustibles — pendiente investigación

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,67 +1,66 @@
 # CONTINUITY.md — facturacion_mexico
 
 **Fecha:** 2026-06-08
-**Rama activa:** `feat/iva-tasa-0-exportacion-label-fix`
-**Tarea actual:** PR abierto — pendiente merge y bench update en producción
+**Rama activa:** `main`
+**Tarea actual:** Post-merge PR #185 — próximo: restore backup ACG en producción
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-PR con 4 fixes surgidos de la implementación del sitio acg-v16.dev (cliente ACG).
-El PR está abierto. Después del merge: bench update en servidor de producción ACG
-y restore del backup de acg-v16.dev.
+PR #185 mergeado y main sincronizado. El sitio acg-v16.dev está completamente
+configurado para el cliente ACG. El siguiente paso es restaurar el backup en
+el servidor de producción ACG y correr bench migrate.
 
 Plan que estoy siguiendo:
-`docs/usuario/getting-started.md` — ACG completó Fases 0-4 en acg-v16.dev.
+`docs/usuario/getting-started.md` — ACG en Fase lista para producción.
 
 Objetivo inmediato:
-Merge del PR → bench update en producción → restore del backup acg-v16.dev.
+Restore del backup acg-v16.dev en servidor de producción del cliente ACG.
 
 Criterio de avance:
-bench update limpio en producción (sin crash de migrate).
+bench migrate limpio en producción + primer CFDI de prueba timbrado.
 
 ---
 
 ## Estado actual
 
-### Ya completado
-- ✅ acg-v16.dev configurado completamente (CoA, fiscal, items, La Comer)
-- ✅ PR abierto con 4 commits
+### Ya cerrado
+- ✅ PR #185 mergeado — fix install + wizard IVA 0% + addendas + crash bench migrate
+- ✅ acg-v16.dev configurado completo (CoA, fiscal, 119 items, La Comer, 24 sucursales)
+- ✅ Issue #186 abierto — revisión templates IEPS por variante
 
 ### Pendiente inmediato
-1. Esperar CodeRabbit y hacer merge del PR
-2. bench update en servidor de producción ACG
-3. Restore backup `20260607_205644-acg-v16_dev-database.sql.gz` en producción
-4. bench migrate post-restore en producción
+1. Restore backup en producción ACG
+2. bench migrate post-restore
+3. Prueba de timbrado CFDI con sandbox FacturAPI
 
 ### No repetir
-- `is_your_company_address` ya está como Custom Field — no volver a depurar
-- El crash de migrate (CharacterLengthExceededError) estaba en enforce_sat_uom.py — ya corregido
-- Los TEST_GENERIC/AUTOMOTIVE/RETAIL fueron eliminados de install.py — no recrear
-- Antes del merge: correr /update-continuity y commitear el resultado final a la rama
+- `is_your_company_address` sin prefijo fm_* es excepción documentada — no cambiar
+- Los one_offs de ACG ya fueron ejecutados y eliminados
+- bench migrate sin --site afecta todos los sites del bench
 
 ---
 
 ## Decisiones vigentes
 
-- `is_your_company_address` workaround temporal ERPNext 16.21.1 — remover cuando ERPNext lo declare
-- Addenda La Comer está en fixtures (se aplica en bench migrate)
-- Las 24 direcciones de sucursales La Comer son datos del cliente, no fixture
-- Multi-Sucursal NO está implementado — el código muerto fue eliminado en este PR
+- `is_your_company_address` workaround ERPNext 16.21.1 — remover cuando ERPNext lo declare
+- Addenda La Comer en fixtures — se aplica automáticamente en bench migrate
+- Issue #186: revisión IEPS combustibles — no urgente para ACG
 
 ---
 
 ## Backup para restore a producción
 
 - DB: `/home/erpnext/frappe-bench-v16/sites/acg-v16.dev/private/backups/20260607_205644-acg-v16_dev-database.sql.gz`
-- Files public: `.../20260607_205644-acg-v16_dev-files.tar`
-- Files private: `.../20260607_205644-acg-v16_dev-private-files.tar`
+- Public: `.../20260607_205644-acg-v16_dev-files.tar`
+- Private: `.../20260607_205644-acg-v16_dev-private-files.tar`
+- Checkpoint: `frappe-infrastructure/checkpoints/20260607-205635-facturacion_mexico-acg-v16.dev/`
 
 ---
 
 ## Riesgos
 
-- facturacion-v16.dev y llantascs-v16.dev necesitan `bench migrate` para fix de Address
-- 2 reglas Cobro duplicadas en CRFM (209-01) — investigar post-PR
+- C5 pendiente: escape XML en template La Comer (|e en campos de texto libre)
+- Issue #186: IEPS combustibles — pendiente investigación

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,66 +1,61 @@
 # CONTINUITY.md — facturacion_mexico
 
 **Fecha:** 2026-06-08
-**Rama activa:** `main`
-**Tarea actual:** Post-merge PR #185 — próximo: restore backup ACG en producción
+**Rama activa:** `fix/cfdi-recibidos-department-grupos`
+**Tarea actual:** PR abierto — fix departamentos grupo en CFDI Recibidos
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-PR #185 mergeado y main sincronizado. El sitio acg-v16.dev está completamente
-configurado para el cliente ACG. El siguiente paso es restaurar el backup en
-el servidor de producción ACG y correr bench migrate.
+Fix de 5 filtros `is_group=0` que impedían seleccionar departamentos grupo
+en el módulo CFDI Recibidos. PR abierto para revisión y merge.
 
 Plan que estoy siguiendo:
-`docs/usuario/getting-started.md` — ACG en Fase lista para producción.
+Issue surgido en reunión con cliente — departamentos RRHH tipo grupo deben
+poder mapearse en Configuración CFDI Recibidos.
 
 Objetivo inmediato:
-Restore del backup acg-v16.dev en servidor de producción del cliente ACG.
+Merge del PR → bench update en producción → validar con cliente.
 
 Criterio de avance:
-bench migrate limpio en producción + primer CFDI de prueba timbrado.
+Departamentos grupo visibles en Configuración CFDI Recibidos y en modal
+"Asignar Departamentos" en lista de CFDI Recibidos.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- ✅ PR #185 mergeado — fix install + wizard IVA 0% + addendas + crash bench migrate
-- ✅ acg-v16.dev configurado completo (CoA, fiscal, 119 items, La Comer, 24 sucursales)
-- ✅ Issue #186 abierto — revisión templates IEPS por variante
+- ✅ PR #185 mergeado — fix install + wizard IVA 0% + addendas + crash migrate
+- ✅ acg-v16.dev configurado completo (CoA, fiscal, 119 items, La Comer)
+
+### En progreso
+- PR fix/cfdi-recibidos-department-grupos — 1 commit, abierto
 
 ### Pendiente inmediato
-1. Restore backup en producción ACG
-2. bench migrate post-restore
-3. Prueba de timbrado CFDI con sandbox FacturAPI
+1. Merge del PR
+2. bench update + migrate + build en producción (actiglobal)
+3. Restore ACG en producción (pendiente desde sesión anterior)
 
 ### No repetir
-- `is_your_company_address` sin prefijo fm_* es excepción documentada — no cambiar
-- Los one_offs de ACG ya fueron ejecutados y eliminados
-- bench migrate sin --site afecta todos los sites del bench
+- Había 5 puntos con is_group=0 para Department — todos corregidos
+- cost_center, item_group, account, supplier_group mantienen is_group=0
 
 ---
 
 ## Decisiones vigentes
 
-- `is_your_company_address` workaround ERPNext 16.21.1 — remover cuando ERPNext lo declare
-- Addenda La Comer en fixtures — se aplica automáticamente en bench migrate
-- Issue #186: revisión IEPS combustibles — no urgente para ACG
-
----
-
-## Backup para restore a producción
-
-- DB: `/home/erpnext/frappe-bench-v16/sites/acg-v16.dev/private/backups/20260607_205644-acg-v16_dev-database.sql.gz`
-- Public: `.../20260607_205644-acg-v16_dev-files.tar`
-- Private: `.../20260607_205644-acg-v16_dev-private-files.tar`
-- Checkpoint: `frappe-infrastructure/checkpoints/20260607-205635-facturacion_mexico-acg-v16.dev/`
+- Department en CFDI Recibidos es llave interna para 601-604, NO se traslada a PI
+- PI recibe solo cuentas contables hoja válidas
+- Resolución 601-604 por coincidencia exacta sin fallback a padre
+- is_your_company_address workaround ERPNext 16.21.1 — mantener hasta que ERPNext lo declare
 
 ---
 
 ## Riesgos
 
-- C5 pendiente: escape XML en template La Comer (|e en campos de texto libre)
-- Issue #186: IEPS combustibles — pendiente investigación
+- bench migrate requerido post-merge (mapeo_departamento_cfdi_recibido.json cambió)
+- bench build requerido post-merge (cfdi_recibido.js y cfdi_recibido_list.js cambiaron)
+- Issue #186: IEPS combustibles — aún pendiente

--- a/facturacion_mexico/cfdi_recibidos/doctype/cfdi_recibido/cfdi_recibido.js
+++ b/facturacion_mexico/cfdi_recibidos/doctype/cfdi_recibido/cfdi_recibido.js
@@ -398,7 +398,6 @@ function _set_company_filters(frm) {
 		return {
 			filters: {
 				company: frm.doc.company,
-				is_group: 0,
 			},
 		};
 	});

--- a/facturacion_mexico/cfdi_recibidos/doctype/cfdi_recibido/cfdi_recibido_list.js
+++ b/facturacion_mexico/cfdi_recibidos/doctype/cfdi_recibido/cfdi_recibido_list.js
@@ -346,7 +346,6 @@ function _load_departments_then_show(candidates, company, listview) {
 			doctype: "Department",
 			filters: [
 				["company", "=", company],
-				["is_group", "=", 0],
 				["disabled", "=", 0],
 			],
 			fields: ["name"],

--- a/facturacion_mexico/cfdi_recibidos/doctype/configuracion_cfdi_recibidos/configuracion_cfdi_recibidos.py
+++ b/facturacion_mexico/cfdi_recibidos/doctype/configuracion_cfdi_recibidos/configuracion_cfdi_recibidos.py
@@ -58,7 +58,7 @@ class ConfiguracionCFDIRecibidos(Document):
 
 		departments = frappe.get_all(
 			"Department",
-			filters={"is_group": 0, "disabled": 0, "company": self.company},
+			filters={"disabled": 0, "company": self.company},
 			pluck="name",
 			order_by="name",
 		)

--- a/facturacion_mexico/cfdi_recibidos/doctype/mapeo_departamento_cfdi_recibido/mapeo_departamento_cfdi_recibido.json
+++ b/facturacion_mexico/cfdi_recibidos/doctype/mapeo_departamento_cfdi_recibido/mapeo_departamento_cfdi_recibido.json
@@ -13,8 +13,7 @@
    "fieldtype": "Link",
    "options": "Department",
    "reqd": 1,
-   "in_list_view": 1,
-   "link_filters": "[[\"Department\", \"is_group\", \"=\", 0]]"
+   "in_list_view": 1
   },
   {
    "fieldname": "familia_sat",

--- a/facturacion_mexico/cfdi_recibidos/queries.py
+++ b/facturacion_mexico/cfdi_recibidos/queries.py
@@ -16,7 +16,6 @@ def department_query(
 		SELECT name, department_name
 		FROM `tabDepartment`
 		WHERE disabled = 0
-		  AND is_group = 0
 		  AND company = %(company)s
 		  AND (name LIKE %(txt)s OR department_name LIKE %(txt)s)
 		ORDER BY name


### PR DESCRIPTION
## Objetivo

Corregir 5 filtros `is_group=0` que impedían seleccionar departamentos grupo
en el módulo CFDI Recibidos. En ERPNext RRHH, departamentos padre/grupo sí
pueden tener empleados asignados directamente — el filtro era incorrecto.

## Cambios principales

- **`configuracion_cfdi_recibidos.py`**: elimina `is_group=0` de la autopopulación de la tabla de mapeo
- **`mapeo_departamento_cfdi_recibido.json`**: elimina `link_filters` que restringía el dropdown a solo hojas
- **`cfdi_recibido.js`**: elimina `is_group=0` del `set_query("department")` en el form
- **`cfdi_recibido_list.js`**: elimina `is_group=0` del `frappe.client.get_list` en modal "Asignar Departamentos"
- **`queries.py`**: elimina `AND is_group = 0` del `department_query` server-side

`cost_center`, `item_group`, `account` y `supplier_group` conservan `is_group=0`.

## Documentación actualizada

No aplica — corrección de filtros incorrectos, sin comportamiento nuevo observable.

## Validaciones realizadas

- Probado en `actiglobal-restore.dev` (localhost:8406)
- `bench migrate` corrió limpio ✅
- `bench build --app facturacion_mexico` corrió limpio ✅
- Departamentos grupo visibles en Configuración CFDI Recibidos ✅
- Departamentos grupo visibles en modal "Asignar Departamentos" ✅
- `ruff check` + `ruff format` sin errores ✅
- `prettier@2.7.1` sin cambios ✅

## Fuera de alcance

- Resolución 601-604: sin cambios — por Departamento exacto sin fallback
- Purchase Invoice: sin cambios — no recibe `department`, solo cuentas hoja
- Comportamiento de RRHH: sin cambios

## Riesgos / pendientes

- Requiere `bench migrate` + `bench build --app facturacion_mexico` al deployar
- Issue #186 (IEPS combustibles) sigue pendiente

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted department filters in CFDI Recibidos module to now include group departments in selection flows, expanding available department assignment options.

* **Documentation**
  * Updated project continuity tracking with current development status, requirements, and active task information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->