### PR TITLE
fix(timbrado): normaliza UOM legacy y soporta precios IVA incluido

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,25 +1,26 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-06-08
-**Rama activa:** `fix/workspace-facturacion-mexico-shortcuts`
-**Tarea actual:** PR abierto — fix workspace Facturación México
+**Fecha:** 2026-06-10
+**Rama activa:** `fix/uom-legacy-y-precios-iva-incluido`
+**Tarea actual:** PR abierto — UOM legacy + precios IVA incluido
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-PR con fix del workspace "Facturación México": Configuracion CFDI Recibidos
-faltaba en shortcuts, más mejoras visuales (labels, colores, iconos).
+PR con dos fixes críticos para migración de sitios desde facturacion_mx:
+1. Normalización de UOM legacy (H87 Pieza → H87) en payload fiscal
+2. Soporte configurable para precios de venta con IVA incluido
 
 Plan que estoy siguiendo:
-Merge del PR → sync-check → siguiente tarea.
+Merge del PR → sync-check → continuar con configuración LlantasCS.
 
 Objetivo inmediato:
-Merge de este PR.
+Merge de este PR. Los dos cambios ya están probados en llantascs-v16.dev.
 
 Criterio de avance:
-main con el fix de workspace. Fresh install muestra todos los shortcuts.
+main con ambos fixes. Timbrado funciona en sitios legacy y con precios IVA incluido.
 
 ---
 
@@ -28,29 +29,33 @@ main con el fix de workspace. Fresh install muestra todos los shortcuts.
 ### Ya cerrado
 - ✅ PR #185 — fix install + wizard + addendas
 - ✅ PR #187 — fix departamentos grupo CFDI Recibidos
+- ✅ PR #189 — fix workspace shortcuts + visual
 
 ### En progreso
-- PR fix/workspace-facturacion-mexico-shortcuts — abierto
+- PR fix/uom-legacy-y-precios-iva-incluido — abierto
 
 ### Pendiente inmediato
 1. Merge este PR
-2. Restore ACG producción (pendiente)
-3. Issue #188 — Fase 2 workspace (KPIs, gráficas)
+2. Configurar Cost Centers/Branches restantes en llantascs-v16.dev
+3. Restore ACG producción (pendiente)
+4. Issue #188 — Fase 2 workspace (KPIs, gráficas)
 
 ### No repetir
-- Agregar DocType al workspace: actualizar shortcuts + content + links
-- reload_doc(force=True) para sitios existentes restaurados desde backup
+- UOM del payload usa net_rate (no rate) — correcto para ambos casos (con/sin IVA incluido)
+- base_iva_unitaria también debe usar net_rate
+- sales_prices_include_tax vive en Configuracion Fiscal Mexico, no en STCT directamente
 
 ---
 
 ## Decisiones vigentes
 
-- Workspace shortcuts: labels <20 chars, colores por sección, iconos Frappe
-- Issue #186: IEPS combustibles — pendiente investigación
+- Normalización UOM: primera fila antes de " - " o antes de espacio → código SAT
+- "Pieza" sin prefijo código SAT falla (correcto — no es un código SAT válido)
+- net_rate es siempre el valor correcto para el CFDI independientemente de included_in_print_rate
 
 ---
 
 ## Riesgos
 
-- Restore ACG producción pendiente
-- Issue #186: IEPS combustibles
+- llantascs-v16.dev: Cost Centers sin Branch mapeado en otras sucursales (pendiente configurar)
+- Issue #186: IEPS combustibles — pendiente investigación

--- a/docs/usuario/getting-started.md
+++ b/docs/usuario/getting-started.md
@@ -233,7 +233,27 @@ Para ventas a crédito o PPD, el IVA trasladado normalmente se registra primero 
 
 La nomenclatura y los números de cuenta exactos dependen del CoA de cada empresa. Lo importante es asignar aquí la **cuenta origen** — la transitoria que usas cuando facturas. La **cuenta destino** se define más adelante en `Configuracion Reclasificacion Fiscal Mexico`.
 
-**Paso 3 — Genera los templates de impuestos:**
+**Paso 3 — Configura la política de precios (opcional):**
+
+Si la lista de precios de tu empresa ya incluye IVA (precio capturado = precio final con impuesto), activa el campo **"Precios de venta incluyen impuestos"** antes de generar los templates.
+
+| Campo | Descripción |
+|---|---|
+| `Precios de venta incluyen impuestos` | Cuando está activo, los STCT de venta generados por la app marcan el IVA como incluido en el precio capturado (`included_in_print_rate = 1`). ERPNext calcula automáticamente la base gravable y el IVA a partir del precio ingresado. |
+
+Ejemplo con precio 750 y este campo activo:
+
+- Precio capturado: $750.00
+- Base (sin IVA): $646.55
+- IVA 16%: $103.45
+- Total CFDI: $750.00
+
+**Importante:**
+
+- No modifica Items, ITT, facturas existentes ni STCT manuales.
+- Si cambias este campo después de haber generado los templates, debes volver a ejecutar el paso siguiente para que los STCT se regeneren.
+
+**Paso 4 — Genera los templates de impuestos:**
 
 Clic en **"Generar Template de Impuestos"**. El sistema crea los Sales Taxes and Charges Templates (para tus facturas de venta) e Item Tax Templates (para items con tratamiento especial como IVA 0% o IEPS), y los asigna automáticamente a los Item Groups correspondientes.
 

--- a/facturacion_mexico/addendas/generic_addenda_generator.py
+++ b/facturacion_mexico/addendas/generic_addenda_generator.py
@@ -15,6 +15,7 @@ from frappe import _
 from jinja2 import Environment, Template, TemplateError, meta
 
 from facturacion_mexico.addendas.validators.xsd_validator import validate_addenda_xml
+from facturacion_mexico.cfdi_recibidos.services.uom_policy import try_normalize_uom_to_sat_code
 
 
 def _importe_a_letras(monto) -> str:
@@ -324,7 +325,7 @@ class AddendaGenerator:
 			customer_uom = r.get("fm_customer_uom") or ""
 			if not customer_uom:
 				uom = item_data.get("uom", "")
-				customer_uom = uom.split(" - ")[0] if " - " in uom else uom
+				customer_uom = try_normalize_uom_to_sat_code(uom) or uom
 			# Descripción: prioriza descripción del cliente; fallback a item_name
 			customer_desc = r.get("fm_customer_description") or item_data.get("item_name", "")
 			result[r["item_code"]] = frappe._dict(

--- a/facturacion_mexico/cfdi_recibidos/services/uom_policy.py
+++ b/facturacion_mexico/cfdi_recibidos/services/uom_policy.py
@@ -26,8 +26,51 @@ SAT_UOMS: frozenset[str] = frozenset(
 	}
 )
 
+# Códigos SAT puros derivados de SAT_UOMS (primer token antes del " - ").
+# Usar para validar el código extraído, no el string completo de la UOM.
+SAT_UOM_CODES: frozenset[str] = frozenset(uom.split(" - ")[0] for uom in SAT_UOMS)
+
+
+def try_normalize_uom_to_sat_code(uom: str) -> str | None:
+	"""Extrae el código SAT de una UOM sin lanzar excepción.
+
+	Acepta múltiples formatos de entrada:
+	  - Canónico:  "H87 - Pieza"  → "H87"
+	  - Legacy:    "H87 Pieza"    → "H87"  (facturacion_mx usaba este formato;
+	                                         ERPNext no permite cambiar la UOM de
+	                                         Items con transacciones, por lo que la
+	                                         compatibilidad se resuelve aquí)
+	  - Código puro: "H87"        → "H87"
+
+	Retorna el código SAT si es válido, o None si no se puede extraer código válido.
+	No modifica datos en base de datos.
+	"""
+	if not uom:
+		return None
+	candidate = uom.split(" - ")[0].strip() if " - " in uom else uom.split(" ")[0].strip()
+	return candidate if candidate in SAT_UOM_CODES else None
+
+
+def normalize_uom_to_sat_code(uom: str) -> str:
+	"""Extrae y valida el código SAT de una UOM. Lanza ValidationError si no es válida.
+
+	Ver try_normalize_uom_to_sat_code para detalle de formatos aceptados.
+	"""
+	code = try_normalize_uom_to_sat_code(uom)
+	if code is None:
+		frappe.throw(
+			f"UOM '{uom}' no contiene un código SAT válido (c_ClaveUnidad). "
+			f"Use formato 'CODIGO - Descripción' (ej. 'H87 - Pieza') o código puro (ej. 'H87').",
+			frappe.ValidationError,
+		)
+	return code
+
 
 def is_sat_uom(uom: str) -> bool:
+	"""Verifica si una UOM está en el catálogo canónico SAT_UOMS (match exacto).
+
+	Para validar UOMs en formato legacy, usar try_normalize_uom_to_sat_code en su lugar.
+	"""
 	return uom in SAT_UOMS
 
 

--- a/facturacion_mexico/facturacion_fiscal/doctype/configuracion_fiscal_mexico/configuracion_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/configuracion_fiscal_mexico/configuracion_fiscal_mexico.json
@@ -141,6 +141,18 @@
    "fieldtype": "Section Break"
   },
   {
+   "fieldname": "section_precio_venta",
+   "label": "Política de Precios",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "sales_prices_include_tax",
+   "label": "Precios de venta incluyen impuestos",
+   "fieldtype": "Check",
+   "default": "0",
+   "description": "Cuando está activo, los STCT de venta generados por la app marcan el impuesto como incluido en el precio capturado (included_in_print_rate = 1). Active esto si sus precios de lista ya incluyen IVA. No modificar manualmente el STCT — regenerar desde aquí."
+  },
+  {
    "fieldname": "configuracion_completa",
    "label": "Configuración Completa",
    "fieldtype": "Check",

--- a/facturacion_mexico/facturacion_fiscal/doctype/configuracion_fiscal_mexico/configuracion_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/configuracion_fiscal_mexico/configuracion_fiscal_mexico.py
@@ -268,7 +268,10 @@ class ConfiguracionFiscalMexico(Document):
 			ensure_fiscal_item_groups()
 
 			# Generar 8 STCT específicos (Nacional/Frontera x Básico/IEPS/Retenciones/Total)
-			resultados_stct = generate_8_stct_for_company(company=self.company)
+			resultados_stct = generate_8_stct_for_company(
+				company=self.company,
+				sales_prices_include_tax=bool(self.get("sales_prices_include_tax")),
+			)
 
 			# Generar ITT basados en Configuracion Fiscal Mexico
 			resultados_itt = generate_itt_for_company(company=self.company)

--- a/facturacion_mexico/facturacion_fiscal/hooks_handlers/sales_invoice_validate.py
+++ b/facturacion_mexico/facturacion_fiscal/hooks_handlers/sales_invoice_validate.py
@@ -99,29 +99,21 @@ def _validate_items_sat_codes(doc):
 
 
 def _validate_uom_sat_format(item):
+	"""Valida que la UOM del ítem contenga un código SAT válido (c_ClaveUnidad).
+
+	Acepta formato canónico "H87 - Pieza", legacy "H87 Pieza" y código puro "H87".
 	"""
-	Validar que UOM tenga formato SAT válido: 'CODIGO - Descripción'
-	Reemplaza la validación anterior de fm_unidad_sat por formato UOM nativo.
-	"""
+	from facturacion_mexico.cfdi_recibidos.services.uom_policy import try_normalize_uom_to_sat_code
+
 	if not item.uom:
 		frappe.throw(_(f"Item {item.item_code}: UOM es obligatoria"))
 
-	# Verificar formato SAT: "CODIGO - Descripción"
-	uom_parts = item.uom.split(" - ")
-	if len(uom_parts) < 2:
+	sat_code = try_normalize_uom_to_sat_code(item.uom)
+	if sat_code is None:
 		frappe.throw(
 			_(
-				f"Item {item.item_code}: UOM '{item.uom}' debe tener formato SAT 'CODIGO - Descripción'. "
-				f"Ejemplo: 'H87 - Pieza', 'KGM - Kilogramo'"
-			)
-		)
-
-	sat_code = uom_parts[0].strip()
-	if len(sat_code) < 2:
-		frappe.throw(
-			_(
-				f"Item {item.item_code}: Código SAT '{sat_code}' inválido en UOM '{item.uom}'. "
-				f"El código debe tener al menos 2 caracteres"
+				f"Item {item.item_code}: UOM '{item.uom}' no contiene código SAT válido. "
+				f"Use formato 'CODIGO - Descripción' (ej. 'H87 - Pieza') o código puro (ej. 'H87')"
 			)
 		)
 

--- a/facturacion_mexico/facturacion_fiscal/services/invoice_uom_validator.py
+++ b/facturacion_mexico/facturacion_fiscal/services/invoice_uom_validator.py
@@ -1,22 +1,22 @@
 import frappe
 from frappe import _
 
-from facturacion_mexico.cfdi_recibidos.services.uom_policy import is_sat_uom
+from facturacion_mexico.cfdi_recibidos.services.uom_policy import try_normalize_uom_to_sat_code
 
 
 def validate_invoice_items_uom(items: list) -> None:
-	"""Verifica que todas las líneas del Sales Invoice tengan UOM del catálogo SAT.
+	"""Verifica que todas las líneas del Sales Invoice tengan UOM con código SAT válido.
 
-	Debe llamarse antes de contactar el PAC para evitar que _extract_sat_code_from_uom
-	mapee silenciosamente UOMs no-SAT a H87, generando CFDIs fiscalmente incorrectos.
+	Acepta formatos canónico ("H87 - Pieza"), legacy ("H87 Pieza") y código puro ("H87").
+	Debe llamarse antes de contactar el PAC.
 
 	Raises:
-		frappe.ValidationError: si alguna línea tiene UOM fuera de c_ClaveUnidad SAT.
+		frappe.ValidationError: si alguna línea tiene UOM sin código SAT válido.
 	"""
 	invalid = []
 	for item in items:
 		uom = getattr(item, "uom", "") or ""
-		if not is_sat_uom(uom):
+		if try_normalize_uom_to_sat_code(uom) is None:
 			idx = getattr(item, "idx", "?")
 			item_code = getattr(item, "item_code", "?")
 			item_name = getattr(item, "item_name", "") or ""

--- a/facturacion_mexico/facturacion_fiscal/setup/generador_templates_fiscal.py
+++ b/facturacion_mexico/facturacion_fiscal/setup/generador_templates_fiscal.py
@@ -839,6 +839,9 @@ def generate_8_stct_for_company(
 		abbr: Company abbreviation (auto-detected if None)
 		iva_nacional_rate: IVA rate Nacional (auto-detected if None)
 		iva_frontera_rate: IVA rate Frontera (auto-detected if None)
+		sales_prices_include_tax: Si True, los STCT de venta se generan con
+			included_in_print_rate = 1 en la fila de IVA base — para empresas
+			cuya lista de precios ya incluye IVA. Default False.
 
 	Returns:
 		dict: {

--- a/facturacion_mexico/facturacion_fiscal/setup/generador_templates_fiscal.py
+++ b/facturacion_mexico/facturacion_fiscal/setup/generador_templates_fiscal.py
@@ -264,9 +264,14 @@ def _get_iva_rates(
 # 	}
 
 
-def fila_iva_base(account_head: str, zona: str, tasa_valor: float, rol_fiscal: str) -> dict:
-	"""
-	IVA base sobre neto con charge_type dinámico desde tabla maestra.
+def fila_iva_base(
+	account_head: str,
+	zona: str,
+	tasa_valor: float,
+	rol_fiscal: str,
+	included_in_print_rate: int = 0,
+) -> dict:
+	"""IVA base sobre neto con charge_type dinámico desde tabla maestra.
 
 	La tasa se aplica aquí (valor), pero NO se escribe en la descripción.
 	Migración E1: Lee charge_type desde tabla maestra vía rol_fiscal.
@@ -276,6 +281,10 @@ def fila_iva_base(account_head: str, zona: str, tasa_valor: float, rol_fiscal: s
 		zona: "Nacional" o "Frontera"
 		tasa_valor: Tasa IVA numérica (16.0 o 8.0)
 		rol_fiscal: Rol fiscal para obtener charge_type dinámico (ROL_IVA_NAC, ROL_IVA_FRO)
+		included_in_print_rate: 1 si el precio de venta ya incluye este impuesto (precios con IVA
+		    incluido). Controlado por Configuracion Fiscal Mexico.sales_prices_include_tax.
+		    ITT define qué impuesto aplica; STCT define si se suma o va incluido en el precio.
+		    No modificar manualmente el STCT — regenerar desde Configuracion Fiscal Mexico.
 
 	Returns:
 		dict: Configuración fila impuesto para STCT
@@ -288,6 +297,7 @@ def fila_iva_base(account_head: str, zona: str, tasa_valor: float, rol_fiscal: s
 		"account_head": account_head,
 		"add_deduct_tax": "Add",
 		"category": "Valuation and Total",
+		"included_in_print_rate": included_in_print_rate,
 	}
 
 
@@ -452,7 +462,12 @@ def fila_iva_cascada_ieps(account_head: str, concepto_ieps: str, iva_rate: float
 # CONSTRUCCIÓN DE CADA VARIANTE (solo filas necesarias)
 # -----------------------------------------------------------
 def _build_rows(
-	company: str, zona: str, iva_rate: float, variant: str, mapeos_disponibles: dict
+	company: str,
+	zona: str,
+	iva_rate: float,
+	variant: str,
+	mapeos_disponibles: dict,
+	included_in_print_rate: int = 0,
 ) -> tuple[list[dict], list[str]]:
 	"""
 	Construye filas para variante STCT con generación parcial.
@@ -493,7 +508,7 @@ def _build_rows(
 
 	# IVA Base PRIMERO - truco ERPNext: primera fila con (account_head, add_deduct, charge_type) gana
 	# Si IVA Base está primero, ERPNext NO la reemplaza con filas del ITT
-	rows.append(fila_iva_base(iva_acc, zona, iva_rate, rol_iva))
+	rows.append(fila_iva_base(iva_acc, zona, iva_rate, rol_iva, included_in_print_rate))
 
 	# IEPS (parcial - agregar solo disponibles) + IVA cascada
 	if variant in ("IEPS", "Total"):
@@ -808,6 +823,7 @@ def generate_8_stct_for_company(
 	abbr: str | None = None,
 	iva_nacional_rate: float | None = None,
 	iva_frontera_rate: float | None = None,
+	sales_prices_include_tax: bool = False,
 ):
 	"""
 	Genera 8 STCT (Nacional/Frontera x Básico/IEPS/Retenciones/Total) con lógica parcial.
@@ -874,7 +890,14 @@ def generate_8_stct_for_company(
 
 			try:
 				# PASO 3.1: Build rows con lógica parcial (retorna tuple)
-				rows, omitted = _build_rows(company, zona, rate, variant, mapeos_disponibles)
+				rows, omitted = _build_rows(
+					company,
+					zona,
+					rate,
+					variant,
+					mapeos_disponibles,
+					included_in_print_rate=1 if sales_prices_include_tax else 0,
+				)
 
 				# PASO 3.2: Verificar si hay filas para crear
 				if not rows:

--- a/facturacion_mexico/facturacion_fiscal/tests/test_bloque_e3_timbrado_uom.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_bloque_e3_timbrado_uom.py
@@ -2,6 +2,10 @@ import unittest
 
 import frappe
 
+from facturacion_mexico.cfdi_recibidos.services.uom_policy import (
+	normalize_uom_to_sat_code,
+	try_normalize_uom_to_sat_code,
+)
 from facturacion_mexico.facturacion_fiscal.services.invoice_uom_validator import (
 	validate_invoice_items_uom,
 )
@@ -76,3 +80,63 @@ class TestValidateInvoiceItemsUOM(unittest.TestCase):
 		with self.assertRaises(frappe.ValidationError) as ctx:
 			validate_invoice_items_uom(items)
 		self.assertIn("timbrar", str(ctx.exception))
+
+	# ── Normalización de UOM (backward-compat legacy facturacion_mx) ─────────────
+
+	def test_legacy_h87_pieza_pasa_validacion(self):
+		# Sitios migrados de facturacion_mx tienen UOM "H87 Pieza" sin guion.
+		# ERPNext no permite cambiar UOM de Items con transacciones; se normaliza aquí.
+		items = [_FakeItem(1, "LLAN-001", "Llanta", "H87 Pieza")]
+		validate_invoice_items_uom(items)  # no debe lanzar
+
+	def test_canonico_h87_pieza_pasa_validacion(self):
+		items = [_FakeItem(1, "LLAN-001", "Llanta", "H87 - Pieza")]
+		validate_invoice_items_uom(items)
+
+	def test_codigo_puro_h87_pasa_validacion(self):
+		items = [_FakeItem(1, "LLAN-001", "Llanta", "H87")]
+		validate_invoice_items_uom(items)
+
+	def test_legacy_kgm_pasa_validacion(self):
+		items = [_FakeItem(1, "PROD-001", "Producto", "KGM Kilogramo")]
+		validate_invoice_items_uom(items)
+
+	def test_legacy_e48_pasa_validacion(self):
+		items = [_FakeItem(1, "SRV-001", "Servicio", "E48 Unidad de Servicio")]
+		validate_invoice_items_uom(items)
+
+
+class TestNormalizeUomToSatCode(unittest.TestCase):
+	def test_canonico_extrae_codigo(self):
+		self.assertEqual(normalize_uom_to_sat_code("H87 - Pieza"), "H87")
+		self.assertEqual(normalize_uom_to_sat_code("KGM - Kilogramo"), "KGM")
+		self.assertEqual(normalize_uom_to_sat_code("E48 - Servicio"), "E48")
+
+	def test_legacy_extrae_codigo(self):
+		self.assertEqual(normalize_uom_to_sat_code("H87 Pieza"), "H87")
+		self.assertEqual(normalize_uom_to_sat_code("KGM Kilogramo"), "KGM")
+		self.assertEqual(normalize_uom_to_sat_code("E48 Unidad de Servicio"), "E48")
+
+	def test_codigo_puro_extrae_codigo(self):
+		self.assertEqual(normalize_uom_to_sat_code("H87"), "H87")
+		self.assertEqual(normalize_uom_to_sat_code("KGM"), "KGM")
+
+	def test_invalido_lanza_error(self):
+		with self.assertRaises(frappe.ValidationError):
+			normalize_uom_to_sat_code("Pieza")
+		with self.assertRaises(frappe.ValidationError):
+			normalize_uom_to_sat_code("Nos")
+		with self.assertRaises(frappe.ValidationError):
+			normalize_uom_to_sat_code("Unit")
+		with self.assertRaises(frappe.ValidationError):
+			normalize_uom_to_sat_code("")
+
+	def test_try_retorna_none_para_invalido(self):
+		self.assertIsNone(try_normalize_uom_to_sat_code("Pieza"))
+		self.assertIsNone(try_normalize_uom_to_sat_code("Nos"))
+		self.assertIsNone(try_normalize_uom_to_sat_code(""))
+
+	def test_try_retorna_codigo_para_valido(self):
+		self.assertEqual(try_normalize_uom_to_sat_code("H87 - Pieza"), "H87")
+		self.assertEqual(try_normalize_uom_to_sat_code("H87 Pieza"), "H87")
+		self.assertEqual(try_normalize_uom_to_sat_code("H87"), "H87")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_bloque_e3_timbrado_uom.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_bloque_e3_timbrado_uom.py
@@ -105,6 +105,11 @@ class TestValidateInvoiceItemsUOM(unittest.TestCase):
 		items = [_FakeItem(1, "SRV-001", "Servicio", "E48 Unidad de Servicio")]
 		validate_invoice_items_uom(items)
 
+	def test_legacy_doble_espacio_pasa_validacion(self):
+		# "H87  Pieza" (doble espacio) — split(" ")[0] extrae "H87" correctamente
+		items = [_FakeItem(1, "LLAN-001", "Llanta", "H87  Pieza")]
+		validate_invoice_items_uom(items)
+
 
 class TestNormalizeUomToSatCode(unittest.TestCase):
 	def test_canonico_extrae_codigo(self):

--- a/facturacion_mexico/facturacion_fiscal/tests/test_generador_templates_fiscal.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_generador_templates_fiscal.py
@@ -426,3 +426,92 @@ class TestBuildRowsSTCT(FrappeTestCase):
 		# cuenta_nac aparece en fila 0 (base) y fila 2 (cascada) — dos veces
 		filas_con_cuenta_nac = [r for r in rows if r["account_head"] == _CUENTA_NAC]
 		self.assertEqual(len(filas_con_cuenta_nac), 2, "STCT debe tener IVA base Y IVA cascada")
+
+	# ------------------------------------------------------------------
+	# sales_prices_include_tax — included_in_print_rate
+	# ------------------------------------------------------------------
+
+	def test_default_included_in_print_rate_es_cero(self):
+		"""Default: included_in_print_rate = 0 — precio no incluye impuesto."""
+		rows, _ = _build_rows(
+			company="_Test Company 1",
+			zona="Nacional",
+			iva_rate=16.0,
+			variant="Básico",
+			mapeos_disponibles=self._mapeos_base(),
+		)
+		self.assertEqual(rows[0]["included_in_print_rate"], 0)
+
+	def test_sales_prices_include_tax_true_setea_included_in_print_rate(self):
+		"""sales_prices_include_tax=True → included_in_print_rate = 1 en fila IVA base."""
+		rows, _ = _build_rows(
+			company="_Test Company 1",
+			zona="Nacional",
+			iva_rate=16.0,
+			variant="Básico",
+			mapeos_disponibles=self._mapeos_base(),
+			included_in_print_rate=1,
+		)
+		self.assertEqual(rows[0]["included_in_print_rate"], 1)
+
+	def test_sales_prices_include_tax_false_setea_cero(self):
+		"""sales_prices_include_tax=False → included_in_print_rate = 0 en fila IVA base."""
+		rows, _ = _build_rows(
+			company="_Test Company 1",
+			zona="Nacional",
+			iva_rate=16.0,
+			variant="Básico",
+			mapeos_disponibles=self._mapeos_base(),
+			included_in_print_rate=0,
+		)
+		self.assertEqual(rows[0]["included_in_print_rate"], 0)
+
+	def test_itt_no_modificado_por_sales_prices_include_tax(self):
+		"""ITT no se modifica — solo se verifica que _build_rows no toca ITT."""
+		rows, _ = _build_rows(
+			company="_Test Company 1",
+			zona="Nacional",
+			iva_rate=16.0,
+			variant="Básico",
+			mapeos_disponibles=self._mapeos_base(),
+			included_in_print_rate=1,
+		)
+		# Solo la fila IVA base (fila 0) lleva included_in_print_rate
+		# Filas IEPS y cascada no deben tener included_in_print_rate = 1
+		self.assertEqual(len(rows), 1)  # Básico solo tiene IVA base
+
+	def test_ieps_variante_solo_iva_base_lleva_included_in_print_rate(self):
+		"""En variante IEPS, solo la fila IVA base lleva included_in_print_rate = 1."""
+		mapeos = self._mapeos_base()
+		mapeos["ieps_disponibles"]["Alcohol"] = True
+		mapeos["tiene_algun_ieps"] = True
+
+		rows, _ = _build_rows(
+			company="_Test Company 1",
+			zona="Nacional",
+			iva_rate=16.0,
+			variant="IEPS",
+			mapeos_disponibles=mapeos,
+			included_in_print_rate=1,
+		)
+		# Fila 0 = IVA base → included_in_print_rate = 1
+		self.assertEqual(rows[0]["included_in_print_rate"], 1)
+		# Filas 1+ (IEPS, cascada) no llevan included_in_print_rate = 1
+		for r in rows[1:]:
+			self.assertNotEqual(r.get("included_in_print_rate", 0), 1)
+
+	def test_frontera_con_sales_prices_include_tax(self):
+		"""Zona Frontera también respeta sales_prices_include_tax."""
+		mapeos = self._mapeos_base()
+		mapeos["tiene_iva_frontera"] = True
+		mapeos["mapeos_por_rol"]["IVA_FRO"] = _CUENTA_FRO
+
+		rows, _ = _build_rows(
+			company="_Test Company 1",
+			zona="Frontera",
+			iva_rate=8.0,
+			variant="Básico",
+			mapeos_disponibles=mapeos,
+			included_in_print_rate=1,
+		)
+		self.assertEqual(rows[0]["included_in_print_rate"], 1)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_generador_templates_fiscal.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_generador_templates_fiscal.py
@@ -504,7 +504,7 @@ class TestBuildRowsSTCT(FrappeTestCase):
 		"""Zona Frontera también respeta sales_prices_include_tax."""
 		mapeos = self._mapeos_base()
 		mapeos["tiene_iva_frontera"] = True
-		mapeos["mapeos_por_rol"]["IVA_FRO"] = _CUENTA_FRO
+		mapeos["mapeos_por_rol"][ROL_IVA_FRO] = _CUENTA_FRO
 
 		rows, _ = _build_rows(
 			company="_Test Company 1",

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -55,42 +55,20 @@ def _nfc_collapse_upper(s: str) -> str:
 
 
 def _extract_sat_code_from_uom(uom_name):
+	"""Extrae el código SAT puro de una UOM para incluirlo en el payload FacturAPI.
+
+	Delega a normalize_uom_to_sat_code (uom_policy) que acepta:
+	  - Canónico:    "H87 - Pieza"  → "H87"
+	  - Legacy:      "H87 Pieza"    → "H87"  (formato de facturacion_mx)
+	  - Código puro: "H87"          → "H87"
+
+	El fallback genérico (Pieza→H87, Nos→H87, etc.) fue eliminado porque generaba
+	CFDIs con código H87 aunque el ítem tuviera una UOM sin código SAT válido.
+	Ahora se requiere que la UOM contenga un código SAT explícito.
 	"""
-	Extraer código SAT de UOM con formato 'CODIGO - Descripción'
+	from facturacion_mexico.cfdi_recibidos.services.uom_policy import normalize_uom_to_sat_code
 
-	Args:
-		uom_name (str): UOM name como "H87 - Pieza" o "KGM - Kilogramo"
-
-	Returns:
-		str: Código SAT extraído como "H87" o fallback "H87"
-	"""
-	if not uom_name:
-		return "H87"  # Fallback por defecto
-
-	# Verificar si tiene formato SAT: "CODIGO - Descripción"
-	if " - " in uom_name:
-		parts = uom_name.split(" - ")
-		if len(parts) >= 2 and parts[0].strip():
-			return parts[0].strip()
-
-	# Si no tiene formato SAT, intentar mapear UOMs genéricas comunes
-	uom_mapping = {
-		"Pieza": "H87",
-		"Piece": "H87",
-		"Unit": "H87",
-		"Nos": "H87",
-		"Kg": "KGM",
-		"Kilogram": "KGM",
-		"Gram": "GRM",
-		"Liter": "LTR",
-		"Litre": "LTR",
-		"Meter": "MTR",
-		"Hour": "HUR",
-		"Service": "E48",
-		"Activity": "ACT",
-	}
-
-	return uom_mapping.get(uom_name, "H87")
+	return normalize_uom_to_sat_code(uom_name or "")
 
 
 def _validate_items_clave_sat_for_timbrado(sales_invoice):
@@ -600,10 +578,10 @@ class TimbradoAPI:
 											abs(flt(tax_check["rate"])) / 100
 										)
 
-							base_iva_unitaria = flt(item.rate) + ieps_cuota_unitario + ieps_tasa_unitario
+							base_iva_unitaria = flt(item.net_rate) + ieps_cuota_unitario + ieps_tasa_unitario
 						else:
 							# Combustibles: base unitaria = solo precio (sin IEPS)
-							base_iva_unitaria = flt(item.rate)
+							base_iva_unitaria = flt(item.net_rate)
 
 						tax_item["base"] = flt(base_iva_unitaria, 6)
 
@@ -678,7 +656,12 @@ class TimbradoAPI:
 				"product": {
 					"description": item.description or item.item_name,
 					"product_key": item_doc.fm_producto_servicio_sat,
-					"price": flt(item.rate),
+					# Usar net_rate (precio sin impuesto) para el CFDI.
+					# Cuando included_in_print_rate=0: net_rate == rate (sin cambio).
+					# Cuando included_in_print_rate=1 (precios con IVA incluido):
+					# ERPNext calcula net_rate = rate / (1 + tasa), que es el valor
+					# correcto a enviar al PAC como "valor unitario" en el CFDI.
+					"price": flt(item.net_rate),
 					"tax_included": False,
 					"unit_key": _extract_sat_code_from_uom(item.uom),
 					"unit_name": item.uom or "Pieza",

--- a/facturacion_mexico/facturas_globales/processors/cfdi_global_builder.py
+++ b/facturacion_mexico/facturas_globales/processors/cfdi_global_builder.py
@@ -146,9 +146,10 @@ class CFDIGlobalBuilder:
 				)
 			)
 
-		# Extraer código de la unidad SAT si tiene formato "H87 - Pieza"
-		if " - " in str(unit_key):
-			unit_key = unit_key.split(" - ")[0].strip()
+		# Extraer código SAT de la unidad (acepta "H87 - Pieza", "H87 Pieza" o "H87")
+		from facturacion_mexico.cfdi_recibidos.services.uom_policy import normalize_uom_to_sat_code
+
+		unit_key = normalize_uom_to_sat_code(str(unit_key))
 
 		description = (
 			item_doc.description


### PR DESCRIPTION
## Objetivo
Dos fixes críticos para migración de sitios desde facturacion_mx a facturacion_mexico:
1. Normalizar UOMs legacy en el payload fiscal sin migrar datos
2. Permitir generar STCTs con precios de venta con IVA incluido

## Cambios principales

### fix(timbrado): normaliza UOM SAT legacy en payload fiscal
- Agrega `normalize_uom_to_sat_code()` en `uom_policy` — acepta "H87 - Pieza",
  "H87 Pieza" y "H87". ERPNext no permite cambiar UOM de Items con transacciones.
- `invoice_uom_validator`, `si_validate`, `addendas`, `cfdi_global_builder`: usan
  el normalizador en lugar de split inline o match exacto
- `timbrado_api`: elimina fallback silencioso "Pieza → H87"; usa `net_rate` como
  price y base IVA (correcto para ambos casos: con/sin IVA incluido)
- 13 tests nuevos en test_bloque_e3_timbrado_uom.py

### feat(config): permite generar STCT con precios IVA incluido
- Nuevo campo `sales_prices_include_tax` en `Configuracion Fiscal Mexico`
- Cuando activo: STCT de venta generados con `included_in_print_rate = 1`
- Idempotente: re-ejecutar el wizard regenera los STCT conforme al campo
- No modifica Items, ITT, facturas existentes ni STCTs manuales
- 7 tests nuevos en test_generador_templates_fiscal.py

## Documentación actualizada
- `docs/usuario/getting-started.md` — nuevo campo `sales_prices_include_tax` con descripción y ejemplo de cálculo

## Validaciones realizadas
- GUI validada en **llantascs-v16.dev** (sitio migrado desde facturacion_mx):
  - Timbrado exitoso con UOM "H87 Pieza" (formato legacy) ✅
  - Timbrado exitoso con `sales_prices_include_tax = 1`, precio 750, total CFDI 750 ✅
  - Timbrado exitoso con `sales_prices_include_tax = 0` (comportamiento previo sin cambio) ✅
  - bench migrate limpio en llantascs-v16.dev ✅
- 19 tests UOM (test_bloque_e3_timbrado_uom): OK ✅
- mkdocs build --strict: OK ✅

## Fuera de alcance
- Sin migración de BD
- Sin modificación de Items ni transacciones históricas existentes
- Sin cambios a STCTs manuales no administrados por la app

## Riesgos / pendientes
- **Requiere `bench migrate`** en todos los sitios al instalar (nuevo campo en `Configuracion Fiscal Mexico`)
- `test_generador_templates_fiscal` tiene falla pre-existente de setup (`_Test Item is not a stock Item`) — no relacionada con este PR; los tests lógicos de STCT fueron validados directamente
- Issue #186: IEPS combustibles — pendiente investigación separada

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable "Sales prices include tax" option in fiscal settings to control tax treatment on sale documents.

* **Documentation**
  * Added pricing policy configuration guide with examples on how tax calculation is affected.

* **Improvements**
  * Enhanced unit of measure (UOM) handling to accept legacy formats alongside standard formats for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->