### PR TITLE
fix(mop): estándar "NN Descripción" sin guion para Mode of Payment SAT

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-06-11
 **Rama activa:** `fix/mode-of-payment-formato-legacy`
-**Tarea actual:** PR abierto — fix Mode of Payment formato legacy
+**Tarea actual:** PR #191 — fixes post-CodeRabbit listos para merge
 
 ---
 
@@ -17,7 +17,7 @@ Merge del PR → deploy en staging ActiGlobal → verificación funcional → de
 cleanup one_off en producción.
 
 Objetivo inmediato:
-Merge de este PR. Los cambios ya fueron limpiados en todos los sites de desarrollo.
+Merge de PR #191. CI debe pasar tras el commit de fixes post-CodeRabbit.
 
 Criterio de avance:
 main con el fix. Complementos PPD funcionan con mode_of_payment "03 Transferencia".
@@ -30,7 +30,7 @@ main con el fix. Complementos PPD funcionan con mode_of_payment "03 Transferenci
 - ✅ PR #190 — UOM legacy + precios IVA incluido
 
 ### En progreso
-- PR fix/mode-of-payment-formato-legacy — abierto
+- PR #191 fix/mode-of-payment-formato-legacy — fixes post-review commiteados
 
 ### Pendiente inmediato post-merge
 1. Restore backup ActiGlobal producción → actiglobal-restore.dev
@@ -54,9 +54,11 @@ main con el fix. Complementos PPD funcionan con mode_of_payment "03 Transferenci
 ## Decisiones vigentes
 
 - Estándar único: "NN Descripción" sin guion para Mode of Payment
-- Regex: `^(\d{2}) (?!-).+$` rechaza explícitamente el guion
+- Regex: `^(\d{2}) (?![-\s]).+$` — rechaza guion Y doble espacio/tab
+- Validación PUE: `=== "99 Por definir"` (no startsWith — ver C1 del reporte CodeRabbit)
 - one_off cleanup_mop_canonical.py es el mecanismo para sitios existentes
 - UOM NO cambia fixture — normalización en código ya funciona para ambos formatos
+- Helper centralizado normalize_forma_pago_sat(): pendiente para PR posterior (C2 CodeRabbit)
 
 ---
 
@@ -65,3 +67,4 @@ main con el fix. Complementos PPD funcionan con mode_of_payment "03 Transferenci
 - LlantasCS-v16.dev: "99 - Por definir" tiene 6 FFMs referenciándolo — no se puede
   eliminar hasta que esas FFMs sean sustituidas o canceladas
 - ActiGlobal producción: requiere SCP del one_off script antes de poder ejecutar cleanup
+- test_issue162 sigue fallando en CI (pre-existente, no causado por este PR)

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,61 +1,67 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-06-10
-**Rama activa:** `fix/uom-legacy-y-precios-iva-incluido`
-**Tarea actual:** PR abierto — UOM legacy + precios IVA incluido
+**Fecha:** 2026-06-11
+**Rama activa:** `fix/mode-of-payment-formato-legacy`
+**Tarea actual:** PR abierto — fix Mode of Payment formato legacy
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-PR con dos fixes críticos para migración de sitios desde facturacion_mx:
-1. Normalización de UOM legacy (H87 Pieza → H87) en payload fiscal
-2. Soporte configurable para precios de venta con IVA incluido
+Estandarización del formato de Mode of Payment a "NN Descripción" (sin guion) para
+alinear el app con el formato real de los datos históricos migrados desde facturacion_mx.
 
 Plan que estoy siguiendo:
-Merge del PR → sync-check → continuar con configuración LlantasCS.
+Merge del PR → deploy en staging ActiGlobal → verificación funcional → deploy producción →
+cleanup one_off en producción.
 
 Objetivo inmediato:
-Merge de este PR. Los dos cambios ya están probados en llantascs-v16.dev.
+Merge de este PR. Los cambios ya fueron limpiados en todos los sites de desarrollo.
 
 Criterio de avance:
-main con ambos fixes. Timbrado funciona en sitios legacy y con precios IVA incluido.
+main con el fix. Complementos PPD funcionan con mode_of_payment "03 Transferencia".
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- ✅ PR #185 — fix install + wizard + addendas
-- ✅ PR #187 — fix departamentos grupo CFDI Recibidos
-- ✅ PR #189 — fix workspace shortcuts + visual
+- ✅ PR #190 — UOM legacy + precios IVA incluido
 
 ### En progreso
-- PR fix/uom-legacy-y-precios-iva-incluido — abierto
+- PR fix/mode-of-payment-formato-legacy — abierto
 
-### Pendiente inmediato
-1. Merge este PR
-2. Configurar Cost Centers/Branches restantes en llantascs-v16.dev
-3. Restore ACG producción (pendiente)
-4. Issue #188 — Fase 2 workspace (KPIs, gráficas)
+### Pendiente inmediato post-merge
+1. Restore backup ActiGlobal producción → actiglobal-restore.dev
+2. Deploy nuevo código en restore.dev + migrate + build
+3. Dry-run cleanup_mop_canonical en restore.dev
+4. Cleanup real en restore.dev
+5. Verificación funcional (PE + complemento PPD)
+6. Si pasa → deploy producción ActiGlobal
+7. Subir one_off al servidor producción vía SCP
+8. Dry-run + cleanup en producción
+9. Backup nuevo post-cambio
 
 ### No repetir
-- UOM del payload usa net_rate (no rate) — correcto para ambos casos (con/sin IVA incluido)
-- base_iva_unitaria también debe usar net_rate
-- sales_prices_include_tax vive en Configuracion Fiscal Mexico, no en STCT directamente
+- "99 - Por definir" (con guion) ya no es el estándar — usar "99 Por definir"
+- cleanup_mop_canonical.py requiere dry_run primero antes de ejecución real
+- LlantasCS staging: "99 - Por definir" conservado (tiene 6 FFMs referenciándolo)
+- ignore_links=True nunca en delete_doc de Mode of Payment
 
 ---
 
 ## Decisiones vigentes
 
-- Normalización UOM: primera fila antes de " - " o antes de espacio → código SAT
-- "Pieza" sin prefijo código SAT falla (correcto — no es un código SAT válido)
-- net_rate es siempre el valor correcto para el CFDI independientemente de included_in_print_rate
+- Estándar único: "NN Descripción" sin guion para Mode of Payment
+- Regex: `^(\d{2}) (?!-).+$` rechaza explícitamente el guion
+- one_off cleanup_mop_canonical.py es el mecanismo para sitios existentes
+- UOM NO cambia fixture — normalización en código ya funciona para ambos formatos
 
 ---
 
 ## Riesgos
 
-- llantascs-v16.dev: Cost Centers sin Branch mapeado en otras sucursales (pendiente configurar)
-- Issue #186: IEPS combustibles — pendiente investigación
+- LlantasCS-v16.dev: "99 - Por definir" tiene 6 FFMs referenciándolo — no se puede
+  eliminar hasta que esas FFMs sean sustituidas o canceladas
+- ActiGlobal producción: requiere SCP del one_off script antes de poder ejecutar cleanup

--- a/facturacion_mexico/complementos_pago/api.py
+++ b/facturacion_mexico/complementos_pago/api.py
@@ -95,17 +95,20 @@ def crear_complemento_pago_desde_pe(payment_entry_name: str) -> dict:
 	return {"complemento_name": complemento.name}
 
 
-_PATRON_MOP_SAT = re.compile(r"^(\d{2}) - .+$")
+_PATRON_MOP_SAT = re.compile(r"^(\d{2}) (?!-).+$")
 
 
 def _resolver_forma_pago_sat(mode_of_payment: str | None) -> str:
 	"""Resuelve el código SAT de Forma de Pago desde un Mode of Payment del fixture del app.
 
+	Formato estándar del app: "NN Descripción" (sin guion).
+	Ejemplos: "03 Transferencia electrónica de fondos", "99 Por definir".
+
 	Validaciones en orden:
 	1. mode_of_payment no vacío
 	2. Mode of Payment existe en BD
 	3. Mode of Payment está habilitado
-	4. Nombre cumple patrón estricto ^(\\d{2}) - .+$
+	4. Nombre cumple patrón estricto ^(\\d{2})\\s+.+$ (dos dígitos + espacio + descripción)
 	5. Código extraído existe en DocType 'Forma Pago SAT'
 
 	Sin fallback. Sin inferencia. Falla explícitamente si el MoP no
@@ -140,7 +143,7 @@ def _resolver_forma_pago_sat(mode_of_payment: str | None) -> str:
 	if not match:
 		frappe.throw(
 			_(
-				"El modo de pago '{0}' no corresponde al catálogo SAT. Use un modo de pago con formato 'NN - Descripción' (ejemplo: '03 - Transferencia electrónica de fondos')."
+				"El modo de pago '{0}' no corresponde al catálogo SAT. Use un modo de pago con formato 'NN Descripción' (ejemplo: '03 Transferencia electrónica de fondos')."
 			).format(mode_of_payment),
 			frappe.ValidationError,
 			title=_("Modo de Pago No Compatible con SAT"),

--- a/facturacion_mexico/complementos_pago/api.py
+++ b/facturacion_mexico/complementos_pago/api.py
@@ -95,7 +95,7 @@ def crear_complemento_pago_desde_pe(payment_entry_name: str) -> dict:
 	return {"complemento_name": complemento.name}
 
 
-_PATRON_MOP_SAT = re.compile(r"^(\d{2}) (?!-).+$")
+_PATRON_MOP_SAT = re.compile(r"^(\d{2}) (?![-\s]).+$")
 
 
 def _resolver_forma_pago_sat(mode_of_payment: str | None) -> str:

--- a/facturacion_mexico/complementos_pago/tests/test_resolver_forma_pago_sat.py
+++ b/facturacion_mexico/complementos_pago/tests/test_resolver_forma_pago_sat.py
@@ -31,7 +31,7 @@ class TestResolverFormaPagoSAT(FrappeTestCase):
 		).insert(ignore_permissions=True)
 
 		# MoP con formato SAT pero código "55" que no existe en Forma Pago SAT
-		cls.mop_fake_sat = f"55 - TEST-{suffix}"
+		cls.mop_fake_sat = f"55 TEST-{suffix}"
 		frappe.get_doc(
 			{
 				"doctype": "Mode of Payment",
@@ -51,18 +51,18 @@ class TestResolverFormaPagoSAT(FrappeTestCase):
 	# -- Casos válidos con fixtures reales --
 
 	def test_resuelve_transferencia_electronica(self):
-		"""MoP SAT '03 - Transferencia...' del fixture → código '03'."""
-		result = _resolver_forma_pago_sat("03 - Transferencia electrónica de fondos")
+		"""MoP SAT '03 Transferencia...' del fixture → código '03'."""
+		result = _resolver_forma_pago_sat("03 Transferencia electrónica de fondos")
 		self.assertEqual(result, "03")
 
 	def test_resuelve_efectivo(self):
-		"""MoP SAT '01 - Efectivo' del fixture → código '01'."""
-		result = _resolver_forma_pago_sat("01 - Efectivo")
+		"""MoP SAT '01 Efectivo' del fixture → código '01'."""
+		result = _resolver_forma_pago_sat("01 Efectivo")
 		self.assertEqual(result, "01")
 
 	def test_resuelve_por_definir_99(self):
-		"""MoP SAT '99 - Por definir' del fixture → código '99'."""
-		result = _resolver_forma_pago_sat("99 - Por definir")
+		"""MoP SAT '99 Por definir' del fixture → código '99'."""
+		result = _resolver_forma_pago_sat("99 Por definir")
 		self.assertEqual(result, "99")
 
 	# -- Casos de bloqueo --
@@ -111,15 +111,26 @@ class TestResolverFormaPagoSAT(FrappeTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			_resolver_forma_pago_sat("Credit Card")
 
-	def test_bloquea_patron_sin_guion(self):
-		"""Nombre sin ' - ' no cumple patrón → ValidationError."""
+	def test_bloquea_patron_sin_espacio(self):
+		"""Nombre sin espacio separador no cumple patrón → ValidationError."""
 		with self.assertRaises(frappe.ValidationError):
 			_resolver_forma_pago_sat("01Efectivo")
 
+	def test_bloquea_formato_canonico_con_guion(self):
+		"""Formato canónico '01 - Efectivo' (con guion) no existe en BD → ValidationError.
+
+		El estándar del app es '01 Efectivo' (sin guion). El formato con guion
+		no corresponde a ningún registro del fixture y debe fallar.
+		"""
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			_resolver_forma_pago_sat("01 - Efectivo")
+		# Falla porque "01 - Efectivo" no existe en BD (fixture usa "01 Efectivo")
+		self.assertIn("no existe", str(ctx.exception))
+
 	def test_bloquea_letras_en_prefijo(self):
-		"""Prefijo con letras 'AB - Algo' → ValidationError."""
+		"""Prefijo con letras 'AB Algo' → ValidationError."""
 		with self.assertRaises(frappe.ValidationError):
-			_resolver_forma_pago_sat("AB - Algo")
+			_resolver_forma_pago_sat("AB Algo")
 
 	def test_bloquea_codigo_no_en_catalogo_sat(self):
 		"""MoP con formato correcto pero código '55' no en Forma Pago SAT → ValidationError."""
@@ -132,10 +143,10 @@ class TestResolverFormaPagoSAT(FrappeTestCase):
 	def test_patron_acepta_formatos_validos(self):
 		"""El patrón regex acepta nombres válidos del fixture."""
 		validos = [
-			"01 - Efectivo",
-			"03 - Transferencia electrónica de fondos",
-			"99 - Por definir",
-			"28 - Tarjeta de débito",
+			"01 Efectivo",
+			"03 Transferencia electrónica de fondos",
+			"99 Por definir",
+			"28 Tarjeta de débito",
 		]
 		for v in validos:
 			self.assertIsNotNone(_PATRON_MOP_SAT.match(v), f"Debería aceptar: {v}")
@@ -149,7 +160,8 @@ class TestResolverFormaPagoSAT(FrappeTestCase):
 			"Credit Card",
 			"Bank Draft",
 			"Cheque",
-			"1 - Solo un dígito",
+			"1 Solo un dígito",  # un solo dígito
+			"01 - Efectivo",  # formato con guion — no es el estándar del app
 		]
 		for v in invalidos:
 			self.assertIsNone(_PATRON_MOP_SAT.match(v), f"Debería rechazar: {v}")

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -798,7 +798,7 @@
 		if (!is_egreso && frm.doc.fm_payment_method_sat === "PUE") {
 			if (
 				!frm.doc.fm_forma_pago_timbrado ||
-				frm.doc.fm_forma_pago_timbrado.startsWith("99 -")
+				frm.doc.fm_forma_pago_timbrado === "99 Por definir"
 			) {
 				frappe.throw(__("Para método PUE debe especificar una forma de pago específica"));
 			}
@@ -1493,7 +1493,7 @@
 				frm.set_value("fm_forma_pago_timbrado", "99 Por definir");
 				frappe.show_alert(
 					{
-						message: __("Forma de pago asignada automáticamente: 99 - Por definir"),
+						message: __("Forma de pago asignada automáticamente: 99 Por definir"),
 						indicator: "orange",
 					},
 					ALERT_DURATION_DEFAULT
@@ -1531,10 +1531,10 @@
 		let color = "blue";
 
 		if (method === "PUE") {
-			message = "PUE: Requiere forma de pago específica (no '99 - Por definir')";
+			message = "PUE: Requiere forma de pago específica (no '99 Por definir')";
 			color = "green";
 		} else if (method === "PPD") {
-			message = "PPD: Automáticamente usará '99 - Por definir' como forma de pago";
+			message = "PPD: Automáticamente usará '99 Por definir' como forma de pago";
 			color = "orange";
 		}
 
@@ -2582,7 +2582,7 @@ function validate_billing_data_visual(frm) {
 				frm.doc.fm_forma_pago_timbrado !== "99 Por definir"
 			) {
 				frm.set_value("fm_forma_pago_timbrado", "99 Por definir");
-				console.log("✅ FASE 4: Auto-asignado PPD - 99 - Por definir");
+				console.log("✅ FASE 4: Auto-asignado PPD - 99 Por definir");
 			}
 			return;
 		}

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -1436,7 +1436,7 @@
 			title = "✅ Método cambiado a PPD";
 			message = `
 			<strong>Pago en Parcialidades o Diferido (PPD)</strong><br>
-			• Forma de pago se asignó automáticamente a "99 - Por definir"<br>
+			• Forma de pago se asignó automáticamente a "99 Por definir"<br>
 			• Campo "Forma de pago para Timbrado" se ocultó (no aplica para PPD)<br>
 			• Este método es para facturas con términos de pago diferido
 		`;
@@ -1447,7 +1447,7 @@
 			<strong>Pago en Una Exhibición (PUE)</strong><br>
 			• Debe especificar una forma de pago específica<br>
 			• Campo "Forma de pago para Timbrado" ahora es visible<br>
-			• NO puede usar "99 - Por definir" para PUE
+			• NO puede usar "99 Por definir" para PUE
 		`;
 			indicator = "green";
 		}
@@ -1479,7 +1479,7 @@
 		}
 
 		if (payment_method === "PPD") {
-			// Para PPD: Ocultar campo y asignar "99 - Por definir"
+			// Para PPD: Ocultar campo y asignar "99 Por definir"
 			frm.set_df_property("fm_forma_pago_timbrado", "hidden", 1);
 
 			// Remover filtros para PPD (todas las opciones disponibles)
@@ -1489,8 +1489,8 @@
 
 			// Only assign and alert if the value is not yet set.
 			// Prevents repeated notice on each refresh of an already stamped PPD.
-			if (frm.doc.fm_forma_pago_timbrado !== "99 - Por definir") {
-				frm.set_value("fm_forma_pago_timbrado", "99 - Por definir");
+			if (frm.doc.fm_forma_pago_timbrado !== "99 Por definir") {
+				frm.set_value("fm_forma_pago_timbrado", "99 Por definir");
 				frappe.show_alert(
 					{
 						message: __("Forma de pago asignada automáticamente: 99 - Por definir"),
@@ -1500,18 +1500,18 @@
 				);
 			}
 		} else if (payment_method === "PUE") {
-			// Para PUE: Mostrar campo y filtrar opciones (sin "99 - Por definir")
+			// Para PUE: Mostrar campo y filtrar opciones (sin "99 Por definir")
 			frm.set_df_property("fm_forma_pago_timbrado", "hidden", 0);
 
-			// Filtrar Mode of Payment para excluir "99 - Por definir"
+			// Filtrar Mode of Payment para excluir "99 Por definir"
 			frm.set_query("fm_forma_pago_timbrado", function () {
 				return {
-					filters: [["Mode of Payment", "name", "!=", "99 - Por definir"]],
+					filters: [["Mode of Payment", "name", "!=", "99 Por definir"]],
 				};
 			});
 
-			// Limpiar si tenía "99 - Por definir"
-			if (frm.doc.fm_forma_pago_timbrado === "99 - Por definir") {
+			// Limpiar si tenía "99 Por definir"
+			if (frm.doc.fm_forma_pago_timbrado === "99 Por definir") {
 				frm.set_value("fm_forma_pago_timbrado", "");
 
 				frappe.show_alert(
@@ -2427,7 +2427,7 @@ function validate_billing_data_visual(frm) {
 			`🔍 FASE 4: Verificando consistencia Payment Entry para documento existente ${frm.doc.name}`
 		);
 
-		// Solo verificar para PUE (PPD siempre usa "99 - Por definir")
+		// Solo verificar para PUE (PPD siempre usa "99 Por definir")
 		if (frm.doc.fm_payment_method_sat === "PUE") {
 			// Buscar Payment Entry relacionada
 			frappe.call({
@@ -2567,7 +2567,7 @@ function validate_billing_data_visual(frm) {
 		 *
 		 * Lógica según especificación:
 		 * - PUE: Buscar Payment Entry relacionada y auto-cargar mode_of_payment
-		 * - PPD: Siempre usar "99 - Por definir"
+		 * - PPD: Siempre usar "99 Por definir"
 		 * - Solo auto-cargar si campo está vacío (no sobrescribir selección manual)
 		 */
 		if (!frm.doc.sales_invoice || !frm.doc.fm_payment_method_sat) {
@@ -2575,13 +2575,13 @@ function validate_billing_data_visual(frm) {
 			return;
 		}
 
-		// Para PPD: Siempre asignar "99 - Por definir"
+		// Para PPD: Siempre asignar "99 Por definir"
 		if (frm.doc.fm_payment_method_sat === "PPD") {
 			if (
 				!frm.doc.fm_forma_pago_timbrado ||
-				frm.doc.fm_forma_pago_timbrado !== "99 - Por definir"
+				frm.doc.fm_forma_pago_timbrado !== "99 Por definir"
 			) {
-				frm.set_value("fm_forma_pago_timbrado", "99 - Por definir");
+				frm.set_value("fm_forma_pago_timbrado", "99 Por definir");
 				console.log("✅ FASE 4: Auto-asignado PPD - 99 - Por definir");
 			}
 			return;

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -370,7 +370,7 @@ class FacturaFiscalMexico(Document):
 
 		if nota_total <= origin_outstanding:
 			# Credit fully absorbed by pending debt — no real refund
-			self.fm_forma_pago_timbrado = "15 - Condonación"
+			self.fm_forma_pago_timbrado = "15 Condonación"
 
 		elif origin_outstanding == 0:
 			# Origin fully paid — inherit origin payment form as best available proxy.
@@ -382,7 +382,7 @@ class FacturaFiscalMexico(Document):
 		else:
 			# Mixed case: nota exceeds pending debt partially.
 			# Use 15 as safe default pending business policy definition.
-			self.fm_forma_pago_timbrado = "15 - Condonación"
+			self.fm_forma_pago_timbrado = "15 Condonación"
 
 	def _find_uuid_cfdi_origen(self) -> str | None:
 		"""Buscar el UUID del CFDI original para esta nota de crédito.
@@ -778,7 +778,7 @@ class FacturaFiscalMexico(Document):
 		- Si no existe: Dejar vacío para selección manual
 
 		Para método PPD:
-		- Siempre asignar "99 - Por definir"
+		- Siempre asignar "99 Por definir"
 		"""
 		if not self.sales_invoice or not self.fm_payment_method_sat:
 			return
@@ -790,10 +790,10 @@ class FacturaFiscalMexico(Document):
 				self._auto_populate_forma_pago_tipo_e()
 			return
 
-		# Para PPD: Siempre asignar "99 - Por definir"
+		# Para PPD: Siempre asignar "99 Por definir"
 		if self.fm_payment_method_sat == "PPD":
-			if not self.fm_forma_pago_timbrado or self.fm_forma_pago_timbrado != "99 - Por definir":
-				self.fm_forma_pago_timbrado = "99 - Por definir"
+			if not self.fm_forma_pago_timbrado or self.fm_forma_pago_timbrado != "99 Por definir":
+				self.fm_forma_pago_timbrado = "99 Por definir"
 				frappe.logger().info(f"Auto-asignado PPD: 99 - Por definir para {self.name}")
 			return
 
@@ -906,10 +906,10 @@ class FacturaFiscalMexico(Document):
 					payment_entry = frappe.get_doc("Payment Entry", payment_ref.parent)
 
 					if payment_entry.mode_of_payment:
-						# Extraer código SAT del Mode of Payment (formato: "01 - Efectivo")
-						mode_parts = payment_entry.mode_of_payment.split(" - ")
-						if len(mode_parts) >= 2 and mode_parts[0].isdigit():
-							forma_pago_sat = mode_parts[0]
+						# Extraer código SAT del Mode of Payment (formato: "01 Efectivo")
+						candidate = payment_entry.mode_of_payment[:2]
+						if candidate.isdigit():
+							forma_pago_sat = candidate
 							break
 
 		if not forma_pago_sat:
@@ -923,7 +923,7 @@ class FacturaFiscalMexico(Document):
 			if forma_pago_sat != "99":
 				frappe.throw(
 					_(
-						f"Para facturas PPD (Pago en Parcialidades) solo se permite '99 - Por definir'. "
+						f"Para facturas PPD (Pago en Parcialidades) solo se permite '99 Por definir'. "
 						f"Forma de pago detectada: {forma_pago_sat}"
 					),
 					title=_("Error Validación PPD"),
@@ -933,7 +933,7 @@ class FacturaFiscalMexico(Document):
 			if forma_pago_sat == "99":
 				frappe.throw(
 					_(
-						"Para facturas PUE (Pago Una Exhibición) no se permite '99 - Por definir'. "
+						"Para facturas PUE (Pago Una Exhibición) no se permite '99 Por definir'. "
 						"Debe seleccionar una forma de pago específica (01, 02, 03, etc.)"
 					),
 					title=_("Error Validación PUE"),

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -813,15 +813,15 @@ class TimbradoAPI:
 
 		# Prioridad 1: Campo fm_forma_pago_timbrado de Factura Fiscal Mexico
 		if fiscal_doc.get("fm_forma_pago_timbrado"):
-			# Extraer código SAT del formato "01 - Efectivo"
-			mode_parts = fiscal_doc.fm_forma_pago_timbrado.split(" - ")
-			if len(mode_parts) >= 2 and mode_parts[0].strip().isdigit():
-				return mode_parts[0].strip()
+			# Extraer código SAT — formato estándar: "01 Efectivo" (primeros 2 chars)
+			candidate = fiscal_doc.fm_forma_pago_timbrado[:2].strip()
+			if candidate.isdigit():
+				return candidate
 
 		# Prioridad 2: Lógica basada en método de pago SAT SOLO para PPD
 		if fiscal_doc.get("fm_payment_method_sat"):
 			if fiscal_doc.fm_payment_method_sat == "PPD":
-				# PPD siempre usa "99 - Por definir"
+				# PPD siempre usa "99 Por definir"
 				return "99"
 
 		# Si no hay forma de pago definida, lanzar error - NO usar defaults

--- a/facturacion_mexico/fixtures/mode_of_payment.json
+++ b/facturacion_mexico/fixtures/mode_of_payment.json
@@ -4,9 +4,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "01 - Efectivo",
+  "mode_of_payment": "01 Efectivo",
   "modified": "2025-08-01 02:19:40.072464",
-  "name": "01 - Efectivo",
+  "name": "01 Efectivo",
   "type": "General"
  },
  {
@@ -14,9 +14,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "02 - Cheque nominativo",
+  "mode_of_payment": "02 Cheque nominativo",
   "modified": "2025-08-01 02:19:40.218555",
-  "name": "02 - Cheque nominativo",
+  "name": "02 Cheque nominativo",
   "type": "General"
  },
  {
@@ -24,9 +24,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "04 - Tarjeta de crédito",
+  "mode_of_payment": "04 Tarjeta de crédito",
   "modified": "2025-08-01 02:19:40.226123",
-  "name": "04 - Tarjeta de crédito",
+  "name": "04 Tarjeta de crédito",
   "type": "General"
  },
  {
@@ -34,9 +34,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "05 - Monedero electrónico",
+  "mode_of_payment": "05 Monedero electrónico",
   "modified": "2025-08-01 02:19:40.229576",
-  "name": "05 - Monedero electrónico",
+  "name": "05 Monedero electrónico",
   "type": "General"
  },
  {
@@ -44,9 +44,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "06 - Dinero electrónico",
+  "mode_of_payment": "06 Dinero electrónico",
   "modified": "2025-08-01 02:19:40.232925",
-  "name": "06 - Dinero electrónico",
+  "name": "06 Dinero electrónico",
   "type": "General"
  },
  {
@@ -54,9 +54,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "08 - Vales de despensa",
+  "mode_of_payment": "08 Vales de despensa",
   "modified": "2025-08-01 02:19:40.235260",
-  "name": "08 - Vales de despensa",
+  "name": "08 Vales de despensa",
   "type": "General"
  },
  {
@@ -64,9 +64,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "12 - Dación en pago",
+  "mode_of_payment": "12 Dación en pago",
   "modified": "2025-08-01 02:19:40.237308",
-  "name": "12 - Dación en pago",
+  "name": "12 Dación en pago",
   "type": "General"
  },
  {
@@ -74,9 +74,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "13 - Pago por subrogación",
+  "mode_of_payment": "13 Pago por subrogación",
   "modified": "2025-08-01 02:19:40.239330",
-  "name": "13 - Pago por subrogación",
+  "name": "13 Pago por subrogación",
   "type": "General"
  },
  {
@@ -84,9 +84,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "14 - Pago por consignación",
+  "mode_of_payment": "14 Pago por consignación",
   "modified": "2025-08-01 02:19:40.241149",
-  "name": "14 - Pago por consignación",
+  "name": "14 Pago por consignación",
   "type": "General"
  },
  {
@@ -94,9 +94,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "15 - Condonación",
+  "mode_of_payment": "15 Condonación",
   "modified": "2025-08-01 02:19:40.243078",
-  "name": "15 - Condonación",
+  "name": "15 Condonación",
   "type": "General"
  },
  {
@@ -104,9 +104,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "17 - Compensación",
+  "mode_of_payment": "17 Compensación",
   "modified": "2025-08-01 02:19:40.244811",
-  "name": "17 - Compensación",
+  "name": "17 Compensación",
   "type": "General"
  },
  {
@@ -114,9 +114,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "23 - Novación",
+  "mode_of_payment": "23 Novación",
   "modified": "2025-08-01 02:19:40.246807",
-  "name": "23 - Novación",
+  "name": "23 Novación",
   "type": "General"
  },
  {
@@ -124,9 +124,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "24 - Confusión",
+  "mode_of_payment": "24 Confusión",
   "modified": "2025-08-01 02:19:40.251324",
-  "name": "24 - Confusión",
+  "name": "24 Confusión",
   "type": "General"
  },
  {
@@ -134,9 +134,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "25 - Remisión de deuda",
+  "mode_of_payment": "25 Remisión de deuda",
   "modified": "2025-08-01 02:19:40.256698",
-  "name": "25 - Remisión de deuda",
+  "name": "25 Remisión de deuda",
   "type": "General"
  },
  {
@@ -144,9 +144,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "26 - Prescripción o caducidad",
+  "mode_of_payment": "26 Prescripción o caducidad",
   "modified": "2025-08-01 02:19:40.262354",
-  "name": "26 - Prescripción o caducidad",
+  "name": "26 Prescripción o caducidad",
   "type": "General"
  },
  {
@@ -154,9 +154,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "27 - A satisfacción del acreedor",
+  "mode_of_payment": "27 A satisfacción del acreedor",
   "modified": "2025-08-01 02:19:40.268078",
-  "name": "27 - A satisfacción del acreedor",
+  "name": "27 A satisfacción del acreedor",
   "type": "General"
  },
  {
@@ -164,9 +164,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "28 - Tarjeta de débito",
+  "mode_of_payment": "28 Tarjeta de débito",
   "modified": "2025-08-01 02:19:40.274263",
-  "name": "28 - Tarjeta de débito",
+  "name": "28 Tarjeta de débito",
   "type": "General"
  },
  {
@@ -174,9 +174,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "29 - Tarjeta de servicios",
+  "mode_of_payment": "29 Tarjeta de servicios",
   "modified": "2025-08-01 02:19:40.278991",
-  "name": "29 - Tarjeta de servicios",
+  "name": "29 Tarjeta de servicios",
   "type": "General"
  },
  {
@@ -184,9 +184,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "30 - Aplicación de anticipos",
+  "mode_of_payment": "30 Aplicación de anticipos",
   "modified": "2025-08-01 02:19:40.284201",
-  "name": "30 - Aplicación de anticipos",
+  "name": "30 Aplicación de anticipos",
   "type": "General"
  },
  {
@@ -194,9 +194,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "31 - Intermediario pagos",
+  "mode_of_payment": "31 Intermediario pagos",
   "modified": "2025-08-01 02:19:40.288160",
-  "name": "31 - Intermediario pagos",
+  "name": "31 Intermediario pagos",
   "type": "General"
  },
  {
@@ -204,9 +204,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "99 - Por definir",
+  "mode_of_payment": "99 Por definir",
   "modified": "2025-08-01 02:19:40.291445",
-  "name": "99 - Por definir",
+  "name": "99 Por definir",
   "type": "General"
  },
  {
@@ -214,9 +214,9 @@
   "docstatus": 0,
   "doctype": "Mode of Payment",
   "enabled": 1,
-  "mode_of_payment": "03 - Transferencia electrónica de fondos",
+  "mode_of_payment": "03 Transferencia electrónica de fondos",
   "modified": "2025-08-01 02:19:40.223135",
-  "name": "03 - Transferencia electrónica de fondos",
+  "name": "03 Transferencia electrónica de fondos",
   "type": "General"
  },
  {

--- a/facturacion_mexico/one_offs/cleanup_mop_canonical.py
+++ b/facturacion_mexico/one_offs/cleanup_mop_canonical.py
@@ -1,0 +1,115 @@
+"""
+one_off: cleanup_mop_canonical
+
+Elimina registros Mode of Payment con formato canónico "NN - Descripción"
+dejados por fixtures anteriores de facturacion_mexico.
+
+El estándar actual del app es "NN Descripción" (sin guion). Los registros
+canónicos con guion ya no corresponden a ningún fixture activo y no deben
+estar disponibles en selectores.
+
+Uso (siempre dry_run primero):
+    bench --site <site> execute facturacion_mexico.one_offs.cleanup_mop_canonical.run
+    bench --site <site> execute facturacion_mexico.one_offs.cleanup_mop_canonical.run --kwargs "{'dry_run': False}"
+
+IMPORTANTE: No ejecutar dry_run=False hasta revisar el reporte completo.
+"""
+
+import frappe
+
+# DocTypes que tienen Link a Mode of Payment en facturacion_mexico.
+# Actualizar si se agregan nuevos Link fields al app.
+_LINK_FIELDS = [
+    ("Payment Entry", "mode_of_payment"),
+    ("Factura Fiscal Mexico", "fm_forma_pago_timbrado"),
+]
+
+
+def run(dry_run: bool = True) -> None:
+    modo = "DRY RUN" if dry_run else "EJECUCIÓN REAL"
+    print(f"\n{'='*60}")
+    print(f"  cleanup_mop_canonical — {modo}")
+    print(f"{'='*60}\n")
+
+    # 1. Detectar registros canónicos con guion
+    canonical = frappe.db.sql(
+        "SELECT name FROM `tabMode of Payment` WHERE name REGEXP %s ORDER BY name",
+        (r"^[0-9]{2} - ",),
+        as_dict=True,
+    )
+
+    if not canonical:
+        print("✅ No hay registros Mode of Payment con formato canónico (NN - Descripción).")
+        print("   Nada que limpiar.\n")
+        return
+
+    print(f"Encontrados {len(canonical)} registros con formato canónico:\n")
+
+    can_delete = []
+    cannot_delete = []
+
+    for mop in canonical:
+        name = mop.name
+        # Equivalente sin guion (para verificar que ya existe la versión correcta)
+        legacy_name = name.replace(" - ", " ", 1)
+        legacy_exists = frappe.db.exists("Mode of Payment", legacy_name)
+
+        # 2. Revisar todas las referencias Link
+        refs = {}
+        for doctype, fieldname in _LINK_FIELDS:
+            count = frappe.db.count(doctype, {fieldname: name})
+            if count:
+                refs[f"{doctype}.{fieldname}"] = count
+
+        if refs:
+            cannot_delete.append({"name": name, "legacy": legacy_name, "refs": refs})
+        else:
+            can_delete.append({"name": name, "legacy": legacy_name, "legacy_exists": bool(legacy_exists)})
+
+    # 3. Reporte — pueden borrarse
+    print(f"{'─'*60}")
+    print(f"✅ SIN REFERENCIAS — pueden eliminarse: {len(can_delete)}\n")
+    for r in can_delete:
+        legacy_status = "✅ existe" if r["legacy_exists"] else "⚠️  NO existe"
+        print(f"   • {r['name']}")
+        print(f"     Equivalente legacy: {r['legacy']} → {legacy_status}")
+
+    # 4. Reporte — no pueden borrarse
+    print(f"\n{'─'*60}")
+    print(f"⛔ CON REFERENCIAS — no se borrarán: {len(cannot_delete)}\n")
+    for r in cannot_delete:
+        print(f"   • {r['name']}")
+        for ref_field, count in r["refs"].items():
+            print(f"     └─ {ref_field}: {count} documento(s)")
+
+    print(f"\n{'─'*60}")
+
+    if dry_run:
+        print("ℹ️  MODO DRY RUN — no se eliminó nada.")
+        print(f"   Para ejecutar: --kwargs \"{{\"dry_run\": False}}\"\n")
+        return
+
+    # 5. Ejecución real — solo registros sin referencias
+    if not can_delete:
+        print("⚠️  No hay registros elegibles para borrar. Nada que hacer.\n")
+        return
+
+    print(f"\n🗑️  Eliminando {len(can_delete)} registros...\n")
+    deleted = []
+    errors = []
+
+    for r in can_delete:
+        try:
+            # Sin ignore_links — Frappe verifica referencias adicionales en FK de BD
+            frappe.delete_doc("Mode of Payment", r["name"], ignore_permissions=True)
+            deleted.append(r["name"])
+            print(f"   ✅ Eliminado: {r['name']}")
+        except Exception as e:
+            errors.append({"name": r["name"], "error": str(e)})
+            print(f"   ❌ Error al eliminar {r['name']}: {e}")
+
+    frappe.db.commit()
+
+    print(f"\n{'='*60}")
+    print(f"  Resultado: {len(deleted)} eliminados, {len(errors)} errores, {len(cannot_delete)} conservados")
+    print(f"{'='*60}\n")

--- a/facturacion_mexico/one_offs/cleanup_mop_canonical.py
+++ b/facturacion_mexico/one_offs/cleanup_mop_canonical.py
@@ -20,96 +20,96 @@ import frappe
 # DocTypes que tienen Link a Mode of Payment en facturacion_mexico.
 # Actualizar si se agregan nuevos Link fields al app.
 _LINK_FIELDS = [
-    ("Payment Entry", "mode_of_payment"),
-    ("Factura Fiscal Mexico", "fm_forma_pago_timbrado"),
+	("Payment Entry", "mode_of_payment"),
+	("Factura Fiscal Mexico", "fm_forma_pago_timbrado"),
 ]
 
 
 def run(dry_run: bool = True) -> None:
-    modo = "DRY RUN" if dry_run else "EJECUCIÓN REAL"
-    print(f"\n{'='*60}")
-    print(f"  cleanup_mop_canonical — {modo}")
-    print(f"{'='*60}\n")
+	modo = "DRY RUN" if dry_run else "EJECUCIÓN REAL"
+	print(f"\n{'=' * 60}")
+	print(f"  cleanup_mop_canonical — {modo}")
+	print(f"{'=' * 60}\n")
 
-    # 1. Detectar registros canónicos con guion
-    canonical = frappe.db.sql(
-        "SELECT name FROM `tabMode of Payment` WHERE name REGEXP %s ORDER BY name",
-        (r"^[0-9]{2} - ",),
-        as_dict=True,
-    )
+	# 1. Detectar registros canónicos con guion
+	canonical = frappe.db.sql(
+		"SELECT name FROM `tabMode of Payment` WHERE name REGEXP %s ORDER BY name",
+		(r"^[0-9]{2} - ",),
+		as_dict=True,
+	)
 
-    if not canonical:
-        print("✅ No hay registros Mode of Payment con formato canónico (NN - Descripción).")
-        print("   Nada que limpiar.\n")
-        return
+	if not canonical:
+		print("✅ No hay registros Mode of Payment con formato canónico (NN - Descripción).")
+		print("   Nada que limpiar.\n")
+		return
 
-    print(f"Encontrados {len(canonical)} registros con formato canónico:\n")
+	print(f"Encontrados {len(canonical)} registros con formato canónico:\n")
 
-    can_delete = []
-    cannot_delete = []
+	can_delete = []
+	cannot_delete = []
 
-    for mop in canonical:
-        name = mop.name
-        # Equivalente sin guion (para verificar que ya existe la versión correcta)
-        legacy_name = name.replace(" - ", " ", 1)
-        legacy_exists = frappe.db.exists("Mode of Payment", legacy_name)
+	for mop in canonical:
+		name = mop.name
+		# Equivalente sin guion (para verificar que ya existe la versión correcta)
+		legacy_name = name.replace(" - ", " ", 1)
+		legacy_exists = frappe.db.exists("Mode of Payment", legacy_name)
 
-        # 2. Revisar todas las referencias Link
-        refs = {}
-        for doctype, fieldname in _LINK_FIELDS:
-            count = frappe.db.count(doctype, {fieldname: name})
-            if count:
-                refs[f"{doctype}.{fieldname}"] = count
+		# 2. Revisar todas las referencias Link
+		refs = {}
+		for doctype, fieldname in _LINK_FIELDS:
+			count = frappe.db.count(doctype, {fieldname: name})
+			if count:
+				refs[f"{doctype}.{fieldname}"] = count
 
-        if refs:
-            cannot_delete.append({"name": name, "legacy": legacy_name, "refs": refs})
-        else:
-            can_delete.append({"name": name, "legacy": legacy_name, "legacy_exists": bool(legacy_exists)})
+		if refs:
+			cannot_delete.append({"name": name, "legacy": legacy_name, "refs": refs})
+		else:
+			can_delete.append({"name": name, "legacy": legacy_name, "legacy_exists": bool(legacy_exists)})
 
-    # 3. Reporte — pueden borrarse
-    print(f"{'─'*60}")
-    print(f"✅ SIN REFERENCIAS — pueden eliminarse: {len(can_delete)}\n")
-    for r in can_delete:
-        legacy_status = "✅ existe" if r["legacy_exists"] else "⚠️  NO existe"
-        print(f"   • {r['name']}")
-        print(f"     Equivalente legacy: {r['legacy']} → {legacy_status}")
+	# 3. Reporte — pueden borrarse
+	print(f"{'─' * 60}")
+	print(f"✅ SIN REFERENCIAS — pueden eliminarse: {len(can_delete)}\n")
+	for r in can_delete:
+		legacy_status = "✅ existe" if r["legacy_exists"] else "⚠️  NO existe"
+		print(f"   • {r['name']}")
+		print(f"     Equivalente legacy: {r['legacy']} → {legacy_status}")
 
-    # 4. Reporte — no pueden borrarse
-    print(f"\n{'─'*60}")
-    print(f"⛔ CON REFERENCIAS — no se borrarán: {len(cannot_delete)}\n")
-    for r in cannot_delete:
-        print(f"   • {r['name']}")
-        for ref_field, count in r["refs"].items():
-            print(f"     └─ {ref_field}: {count} documento(s)")
+	# 4. Reporte — no pueden borrarse
+	print(f"\n{'─' * 60}")
+	print(f"⛔ CON REFERENCIAS — no se borrarán: {len(cannot_delete)}\n")
+	for r in cannot_delete:
+		print(f"   • {r['name']}")
+		for ref_field, count in r["refs"].items():
+			print(f"     └─ {ref_field}: {count} documento(s)")
 
-    print(f"\n{'─'*60}")
+	print(f"\n{'─' * 60}")
 
-    if dry_run:
-        print("ℹ️  MODO DRY RUN — no se eliminó nada.")
-        print(f"   Para ejecutar: --kwargs \"{{\"dry_run\": False}}\"\n")
-        return
+	if dry_run:
+		print("INFO: MODO DRY RUN — no se eliminó nada.")
+		print("   Para ejecutar: --kwargs '{\"dry_run\": False}'\n")
+		return
 
-    # 5. Ejecución real — solo registros sin referencias
-    if not can_delete:
-        print("⚠️  No hay registros elegibles para borrar. Nada que hacer.\n")
-        return
+	# 5. Ejecución real — solo registros sin referencias
+	if not can_delete:
+		print("⚠️  No hay registros elegibles para borrar. Nada que hacer.\n")
+		return
 
-    print(f"\n🗑️  Eliminando {len(can_delete)} registros...\n")
-    deleted = []
-    errors = []
+	print(f"\n🗑️  Eliminando {len(can_delete)} registros...\n")
+	deleted = []
+	errors = []
 
-    for r in can_delete:
-        try:
-            # Sin ignore_links — Frappe verifica referencias adicionales en FK de BD
-            frappe.delete_doc("Mode of Payment", r["name"], ignore_permissions=True)
-            deleted.append(r["name"])
-            print(f"   ✅ Eliminado: {r['name']}")
-        except Exception as e:
-            errors.append({"name": r["name"], "error": str(e)})
-            print(f"   ❌ Error al eliminar {r['name']}: {e}")
+	for r in can_delete:
+		try:
+			# Sin ignore_links — Frappe verifica referencias adicionales en FK de BD
+			frappe.delete_doc("Mode of Payment", r["name"], ignore_permissions=True)
+			deleted.append(r["name"])
+			print(f"   ✅ Eliminado: {r['name']}")
+		except Exception as e:
+			errors.append({"name": r["name"], "error": str(e)})
+			print(f"   ❌ Error al eliminar {r['name']}: {e}")
 
-    frappe.db.commit()
+	frappe.db.commit()
 
-    print(f"\n{'='*60}")
-    print(f"  Resultado: {len(deleted)} eliminados, {len(errors)} errores, {len(cannot_delete)} conservados")
-    print(f"{'='*60}\n")
+	print(f"\n{'=' * 60}")
+	print(f"  Resultado: {len(deleted)} eliminados, {len(errors)} errores, {len(cannot_delete)} conservados")
+	print(f"{'=' * 60}\n")

--- a/facturacion_mexico/one_offs/cleanup_mop_canonical.py
+++ b/facturacion_mexico/one_offs/cleanup_mop_canonical.py
@@ -108,7 +108,7 @@ def run(dry_run: bool = True) -> None:
 			errors.append({"name": r["name"], "error": str(e)})
 			print(f"   ❌ Error al eliminar {r['name']}: {e}")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit — one_off script, commit intencional tras bulk delete
 
 	print(f"\n{'=' * 60}")
 	print(f"  Resultado: {len(deleted)} eliminados, {len(errors)} errores, {len(cannot_delete)} conservados")

--- a/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
+++ b/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
@@ -45,7 +45,7 @@ class TestValidateItemsClavesSATTimbrado(FrappeTestCase):
 				"stock_uom": "Nos",
 				"fm_producto_servicio_sat": "84111506",
 			}
-		).insert(ignore_permissions=True)
+		).insert(ignore_permissions=True, ignore_links=True)
 
 		cls.item_sin_clave = f"TEST-NOSAT-A-{suffix}"
 		frappe.get_doc(
@@ -160,7 +160,7 @@ class TestFFMValidateClavesSAT(FrappeTestCase):
 				"stock_uom": "Nos",
 				"fm_producto_servicio_sat": "84111506",
 			}
-		).insert(ignore_permissions=True)
+		).insert(ignore_permissions=True, ignore_links=True)
 
 		# Item para el caso malo: se crea con clave para poder insertar el SI;
 		# la clave se elimina DESPUÉS de crear el SI para simular dato corrupto.
@@ -174,7 +174,7 @@ class TestFFMValidateClavesSAT(FrappeTestCase):
 				"stock_uom": "Nos",
 				"fm_producto_servicio_sat": "84111506",
 			}
-		).insert(ignore_permissions=True)
+		).insert(ignore_permissions=True, ignore_links=True)
 
 		# Company, Customer y Cost Center mínimos para crear SI
 		cls.company = frappe.db.get_value("Company", {}, "name") or "_Test Company"

--- a/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
+++ b/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
@@ -212,7 +212,11 @@ class TestFFMValidateClavesSAT(FrappeTestCase):
 				],
 			}
 		)
-		si_ok.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
+		frappe.flags.in_import = True
+		try:
+			si_ok.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
+		finally:
+			frappe.flags.in_import = False
 		cls.si_con_clave = si_ok.name
 
 		# SI para caso malo: se inserta mientras el item tiene clave SAT,
@@ -234,7 +238,11 @@ class TestFFMValidateClavesSAT(FrappeTestCase):
 				],
 			}
 		)
-		si_fail.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
+		frappe.flags.in_import = True
+		try:
+			si_fail.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
+		finally:
+			frappe.flags.in_import = False
 		cls.si_sin_clave = si_fail.name
 
 		# Ahora eliminar la clave SAT del item — FFM.validate() leerá estado actual del Item

--- a/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
+++ b/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
@@ -212,7 +212,7 @@ class TestFFMValidateClavesSAT(FrappeTestCase):
 				],
 			}
 		)
-		si_ok.insert(ignore_permissions=True, ignore_mandatory=True)
+		si_ok.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
 		cls.si_con_clave = si_ok.name
 
 		# SI para caso malo: se inserta mientras el item tiene clave SAT,
@@ -234,7 +234,7 @@ class TestFFMValidateClavesSAT(FrappeTestCase):
 				],
 			}
 		)
-		si_fail.insert(ignore_permissions=True, ignore_mandatory=True)
+		si_fail.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
 		cls.si_sin_clave = si_fail.name
 
 		# Ahora eliminar la clave SAT del item — FFM.validate() leerá estado actual del Item

--- a/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
+++ b/facturacion_mexico/tests/test_issue162_clave_sat_obligatoria.py
@@ -212,11 +212,8 @@ class TestFFMValidateClavesSAT(FrappeTestCase):
 				],
 			}
 		)
-		frappe.flags.in_import = True
-		try:
-			si_ok.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
-		finally:
-			frappe.flags.in_import = False
+		si_ok.flags.ignore_validate = True
+		si_ok.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
 		cls.si_con_clave = si_ok.name
 
 		# SI para caso malo: se inserta mientras el item tiene clave SAT,
@@ -238,11 +235,8 @@ class TestFFMValidateClavesSAT(FrappeTestCase):
 				],
 			}
 		)
-		frappe.flags.in_import = True
-		try:
-			si_fail.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
-		finally:
-			frappe.flags.in_import = False
+		si_fail.flags.ignore_validate = True
+		si_fail.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
 		cls.si_sin_clave = si_fail.name
 
 		# Ahora eliminar la clave SAT del item — FFM.validate() leerá estado actual del Item

--- a/facturacion_mexico/tests/test_layer2_cross_module_validation.py
+++ b/facturacion_mexico/tests/test_layer2_cross_module_validation.py
@@ -9,69 +9,81 @@ Tests de validación cruzada entre módulos Multi-Sucursal y Addendas Sprint 6
 import unittest
 
 import frappe
-from facturacion_mexico.config.fiscal_states_config import FiscalStates, SyncStates, OperationTypes
+
+from facturacion_mexico.config.fiscal_states_config import FiscalStates, OperationTypes, SyncStates
 from facturacion_mexico.tests.legacy_allowlist import LEGACY_CF_ALLOWLIST
 
 
 class TestLayer2CrossModuleValidation(unittest.TestCase):
-    """Tests de validación Cross-Module - Layer 2"""
+	"""Tests de validación Cross-Module - Layer 2"""
 
-    def setUp(self):
-        """Crea prerequisitos por test — autocontenido, sin depender del estado del site."""
-        frappe.clear_cache()
+	def setUp(self):
+		"""Crea prerequisitos por test — autocontenido, sin depender del estado del site."""
+		frappe.clear_cache()
 
-        # Grupos raíz de ERPNext — no existen en site de tests limpio (Setup Wizard no corrió)
-        if not frappe.db.exists("Customer Group", "All Customer Groups"):
-            frappe.get_doc({
-                "doctype": "Customer Group",
-                "customer_group_name": "All Customer Groups",
-                "parent_customer_group": "",
-                "is_group": 1,
-            }).insert(ignore_permissions=True)
+		# Grupos raíz de ERPNext — no existen en site de tests limpio (Setup Wizard no corrió)
+		if not frappe.db.exists("Customer Group", "All Customer Groups"):
+			frappe.get_doc(
+				{
+					"doctype": "Customer Group",
+					"customer_group_name": "All Customer Groups",
+					"parent_customer_group": "",
+					"is_group": 1,
+				}
+			).insert(ignore_permissions=True)
 
-        # ERPNext no permite usar grupos raíz (is_group=1) como customer_group — necesita un hijo
-        if not frappe.db.exists("Customer Group", "_Test Customer Group"):
-            frappe.get_doc({
-                "doctype": "Customer Group",
-                "customer_group_name": "_Test Customer Group",
-                "parent_customer_group": "All Customer Groups",
-                "is_group": 0,
-            }).insert(ignore_permissions=True)
+		# ERPNext no permite usar grupos raíz (is_group=1) como customer_group — necesita un hijo
+		if not frappe.db.exists("Customer Group", "_Test Customer Group"):
+			frappe.get_doc(
+				{
+					"doctype": "Customer Group",
+					"customer_group_name": "_Test Customer Group",
+					"parent_customer_group": "All Customer Groups",
+					"is_group": 0,
+				}
+			).insert(ignore_permissions=True)
 
-        if not frappe.db.exists("Territory", "All Territories"):
-            frappe.get_doc({
-                "doctype": "Territory",
-                "territory_name": "All Territories",
-                "parent_territory": "",
-                "is_group": 1,
-            }).insert(ignore_permissions=True)
+		if not frappe.db.exists("Territory", "All Territories"):
+			frappe.get_doc(
+				{
+					"doctype": "Territory",
+					"territory_name": "All Territories",
+					"parent_territory": "",
+					"is_group": 1,
+				}
+			).insert(ignore_permissions=True)
 
-        # Customer y Item de test
-        if not frappe.db.exists("Customer", "_Test Customer"):
-            frappe.get_doc({
-                "doctype": "Customer",
-                "customer_name": "_Test Customer",
-                "customer_type": "Individual",
-                "territory": "All Territories",
-                "customer_group": "_Test Customer Group",
-                "tax_id": "LOMS800101AB1",  # RFC ficticio con formato válido (13 chars, no genérico)
-            }).insert(ignore_permissions=True)
+		# Customer y Item de test
+		if not frappe.db.exists("Customer", "_Test Customer"):
+			frappe.get_doc(
+				{
+					"doctype": "Customer",
+					"customer_name": "_Test Customer",
+					"customer_type": "Individual",
+					"territory": "All Territories",
+					"customer_group": "_Test Customer Group",
+					"tax_id": "LOMS800101AB1",  # RFC ficticio con formato válido (13 chars, no genérico)
+				}
+			).insert(ignore_permissions=True)
 
-        if not frappe.db.exists("Item", "_Test Item"):
-            frappe.get_doc({
-                "doctype": "Item",
-                "item_code": "_Test Item",
-                "item_name": "_Test Item",
-                "item_group": "All Item Groups",
-                "is_stock_item": 0,
-                "stock_uom": "H87 - Pieza",
-            }).insert(ignore_permissions=True)
+		if not frappe.db.exists("Item", "_Test Item"):
+			frappe.get_doc(
+				{
+					"doctype": "Item",
+					"item_code": "_Test Item",
+					"item_name": "_Test Item",
+					"item_group": "All Item Groups",
+					"is_stock_item": 0,
+					"stock_uom": "H87 - Pieza",
+				}
+			).insert(ignore_permissions=True)
 
-    def test_custom_fields_naming_consistency(self):
-        """Test: Consistencia en nomenclatura de custom fields entre módulos"""
-        # Verificar que todos los custom fields siguen el patrón fm_*
+	def test_custom_fields_naming_consistency(self):
+		"""Test: Consistencia en nomenclatura de custom fields entre módulos"""
+		# Verificar que todos los custom fields siguen el patrón fm_*
 
-        inconsistent_fields = frappe.db.sql("""
+		inconsistent_fields = frappe.db.sql(
+			"""
             SELECT dt, fieldname, label
             FROM `tabCustom Field`
             WHERE fieldname NOT LIKE 'fm_%'
@@ -79,816 +91,880 @@ class TestLayer2CrossModuleValidation(unittest.TestCase):
             AND fieldname NOT IN ('customer', 'company', 'branch')
             AND fieldname NOT LIKE 'column_%'
             AND fieldname NOT LIKE 'section_%'
-        """, as_dict=True)
+        """,
+			as_dict=True,
+		)
 
-        # Filtrar campos del sistema base ERPNext y legados autorizados
-        system_fields = [
-            'informacion_fiscal_mx_section', 'cfdi_use', 'payment_method_sat',
-            'column_break_fiscal_mx', 'fiscal_status', 'uuid_fiscal',
-            'fm_factura_fiscal_mx', 'rfc', 'column_break_fiscal_customer',
-            'regimen_fiscal', 'uso_cfdi_default', 'clasificacion_sat_section',
-            'producto_servicio_sat', 'column_break_item_sat', 'fm_unidad_sat',
-            # Secciones legacy sin prefijo (grandfathered)
-            'certificate_management_section', 'fiscal_configuration_section',
-            'folio_management_section', 'statistics_section', 'exempt_from_sales_tax',
-            'branch'  # Campo nativo ERPNext
-        ]
+		# Filtrar campos del sistema base ERPNext y legados autorizados
+		system_fields = [
+			"informacion_fiscal_mx_section",
+			"cfdi_use",
+			"payment_method_sat",
+			"column_break_fiscal_mx",
+			"fiscal_status",
+			"uuid_fiscal",
+			"fm_factura_fiscal_mx",
+			"rfc",
+			"column_break_fiscal_customer",
+			"regimen_fiscal",
+			"uso_cfdi_default",
+			"clasificacion_sat_section",
+			"producto_servicio_sat",
+			"column_break_item_sat",
+			"fm_unidad_sat",
+			# Secciones legacy sin prefijo (grandfathered)
+			"certificate_management_section",
+			"fiscal_configuration_section",
+			"folio_management_section",
+			"statistics_section",
+			"exempt_from_sales_tax",
+			"branch",  # Campo nativo ERPNext
+		]
 
-        # Combinar system_fields con allowlist centralizada
-        allowed_fields = system_fields + list(LEGACY_CF_ALLOWLIST)
+		# Combinar system_fields con allowlist centralizada
+		allowed_fields = system_fields + list(LEGACY_CF_ALLOWLIST)
 
-        real_inconsistent = [f for f in inconsistent_fields
-                           if f.fieldname not in allowed_fields]
+		real_inconsistent = [f for f in inconsistent_fields if f.fieldname not in allowed_fields]
 
-        if real_inconsistent:
-            print(f"⚠ Campos sin prefijo fm_: {[(f.dt, f.fieldname) for f in real_inconsistent[:5]]}")
-        else:
-            print("✓ Todos los custom fields nuevos siguen nomenclatura fm_*")
+		if real_inconsistent:
+			print(f"⚠ Campos sin prefijo fm_: {[(f.dt, f.fieldname) for f in real_inconsistent[:5]]}")
+		else:
+			print("✓ Todos los custom fields nuevos siguen nomenclatura fm_*")
 
-        self.assertEqual(len(real_inconsistent), 0,
-            f"Custom Fields sin prefijo 'fm_': {[(f.dt, f.fieldname) for f in real_inconsistent]}. "
-            "Los campos nuevos deben iniciar con 'fm_'. "
-            "Si un campo es realmente legado, agréguelo a LEGACY_CF_ALLOWLIST.")
+		self.assertEqual(
+			len(real_inconsistent),
+			0,
+			f"Custom Fields sin prefijo 'fm_': {[(f.dt, f.fieldname) for f in real_inconsistent]}. "
+			"Los campos nuevos deben iniciar con 'fm_'. "
+			"Si un campo es realmente legado, agréguelo a LEGACY_CF_ALLOWLIST.",
+		)
 
-    def test_sales_invoice_filters_implementation(self):
-        """
-        Test: Verificar implementación de filtros Sales Invoice en Factura Fiscal Mexico
+	def test_sales_invoice_filters_implementation(self):
+		"""
+		Test: Verificar implementación de filtros Sales Invoice en Factura Fiscal Mexico
 
-        FASE 3: Validaciones de filtros dinámicos
-        - Función setup_sales_invoice_filters existe
-        - Filtros configuran criterios correctos
-        - Validación de disponibilidad funciona
-        """
-        # Leer archivo JavaScript de Factura Fiscal Mexico
-        # Usar path relativo desde frappe-bench para compatibilidad CI
-        js_file_path = frappe.get_app_path("facturacion_mexico", "facturacion_fiscal", "doctype", "factura_fiscal_mexico", "factura_fiscal_mexico.js")
+		FASE 3: Validaciones de filtros dinámicos
+		- Función setup_sales_invoice_filters existe
+		- Filtros configuran criterios correctos
+		- Validación de disponibilidad funciona
+		"""
+		# Leer archivo JavaScript de Factura Fiscal Mexico
+		# Usar path relativo desde frappe-bench para compatibilidad CI
+		js_file_path = frappe.get_app_path(
+			"facturacion_mexico",
+			"facturacion_fiscal",
+			"doctype",
+			"factura_fiscal_mexico",
+			"factura_fiscal_mexico.js",
+		)
 
-        js_content = ""
-        try:
-            with open(js_file_path, 'r', encoding='utf-8') as f:
-                js_content = f.read()
-        except FileNotFoundError:
-            self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
+		js_content = ""
+		try:
+			with open(js_file_path, encoding="utf-8") as f:
+				js_content = f.read()
+		except FileNotFoundError:
+			self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
 
-        # Verificar que función setup_sales_invoice_filters existe
-        self.assertIn(
-            "function setup_sales_invoice_filters",
-            js_content,
-            "Función setup_sales_invoice_filters debe existir"
-        )
+		# Verificar que función setup_sales_invoice_filters existe
+		self.assertIn(
+			"function setup_sales_invoice_filters",
+			js_content,
+			"Función setup_sales_invoice_filters debe existir",
+		)
 
-        # Verificar que se configura frm.set_query para sales_invoice
-        self.assertIn(
-            'frm.set_query("sales_invoice"',
-            js_content,
-            "Debe configurar filtros dinámicos para campo sales_invoice"
-        )
+		# Verificar que se configura frm.set_query para sales_invoice
+		self.assertIn(
+			'frm.set_query("sales_invoice"',
+			js_content,
+			"Debe configurar filtros dinámicos para campo sales_invoice",
+		)
 
-        # Verificar que usa query personalizada (implementación actual más robusta)
-        self.assertIn(
-            "get_sales_invoice_for_ffm",
-            js_content,
-            "Debe usar query personalizada get_sales_invoice_for_ffm para filtros avanzados"
-        )
+		# Verificar que usa query personalizada (implementación actual más robusta)
+		self.assertIn(
+			"get_sales_invoice_for_ffm",
+			js_content,
+			"Debe usar query personalizada get_sales_invoice_for_ffm para filtros avanzados",
+		)
 
-        # Verificar que la query personalizada maneja company filter
-        self.assertIn(
-            'filters: { company: frm.doc.company || null }',
-            js_content,
-            "Query debe incluir filtro de company"
-        )
+		# Verificar que la query personalizada maneja company filter
+		self.assertIn(
+			"filters: { company: frm.doc.company || null }",
+			js_content,
+			"Query debe incluir filtro de company",
+		)
 
-        # Verificar que la función Python correspondiente existe y maneja los criterios correctos
-        from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import get_sales_invoice_for_ffm
+		# Verificar que la función Python correspondiente existe y maneja los criterios correctos
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			get_sales_invoice_for_ffm,
+		)
 
-        # Verificar que la función existe (importación exitosa)
-        self.assertTrue(
-            callable(get_sales_invoice_for_ffm),
-            "Función get_sales_invoice_for_ffm debe existir y ser callable"
-        )
+		# Verificar que la función existe (importación exitosa)
+		self.assertTrue(
+			callable(get_sales_invoice_for_ffm),
+			"Función get_sales_invoice_for_ffm debe existir y ser callable",
+		)
 
-        # Verificar función de validación de disponibilidad
-        self.assertIn(
-            "function validate_sales_invoice_availability",
-            js_content,
-            "Función validate_sales_invoice_availability debe existir"
-        )
+		# Verificar función de validación de disponibilidad
+		self.assertIn(
+			"function validate_sales_invoice_availability",
+			js_content,
+			"Función validate_sales_invoice_availability debe existir",
+		)
 
-        # Verificar que se llama en el evento sales_invoice
-        self.assertIn(
-            "validate_sales_invoice_availability(frm)",
-            js_content,
-            "Validación debe ejecutarse cuando se selecciona Sales Invoice"
-        )
+		# Verificar que se llama en el evento sales_invoice
+		self.assertIn(
+			"validate_sales_invoice_availability(frm)",
+			js_content,
+			"Validación debe ejecutarse cuando se selecciona Sales Invoice",
+		)
 
-        # Verificar comentarios de documentación FASE 3
-        self.assertIn(
-            "FASE 3: FILTROS SALES INVOICE DISPONIBLES",
-            js_content,
-            "Código debe estar documentado como FASE 3"
-        )
+		# Verificar comentarios de documentación FASE 3
+		self.assertIn(
+			"FASE 3: FILTROS SALES INVOICE DISPONIBLES",
+			js_content,
+			"Código debe estar documentado como FASE 3",
+		)
 
-        print("✅ Filtros Sales Invoice correctamente implementados")
+		print("✅ Filtros Sales Invoice correctamente implementados")
 
-    def test_sales_invoice_availability_validation_logic(self):
-        """
-        Test: Verificar lógica de validación de disponibilidad de Sales Invoice
+	def test_sales_invoice_availability_validation_logic(self):
+		"""
+		Test: Verificar lógica de validación de disponibilidad de Sales Invoice
 
-        Validaciones:
-        - Detecta Sales Invoice ya timbradas
-        - Valida docstatus = 1
-        - Verifica RFC presente
-        - Maneja casos edge apropiadamente
-        """
-        # Leer archivo JavaScript - usar path relativo para compatibilidad CI
-        js_file_path = frappe.get_app_path("facturacion_mexico", "facturacion_fiscal", "doctype", "factura_fiscal_mexico", "factura_fiscal_mexico.js")
+		Validaciones:
+		- Detecta Sales Invoice ya timbradas
+		- Valida docstatus = 1
+		- Verifica RFC presente
+		- Maneja casos edge apropiadamente
+		"""
+		# Leer archivo JavaScript - usar path relativo para compatibilidad CI
+		js_file_path = frappe.get_app_path(
+			"facturacion_mexico",
+			"facturacion_fiscal",
+			"doctype",
+			"factura_fiscal_mexico",
+			"factura_fiscal_mexico.js",
+		)
 
-        js_content = ""
-        try:
-            with open(js_file_path, 'r', encoding='utf-8') as f:
-                js_content = f.read()
-        except FileNotFoundError:
-            self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
+		js_content = ""
+		try:
+			with open(js_file_path, encoding="utf-8") as f:
+				js_content = f.read()
+		except FileNotFoundError:
+			self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
 
-        # Verificar validación de estado timbrado (usando arquitectura resiliente)
-        self.assertIn(
-            "states.cancelable_states.includes",
-            js_content,
-            "Debe validar si Sales Invoice ya está timbrada usando estados resilientes"
-        )
+		# Verificar validación de estado timbrado (usando arquitectura resiliente)
+		self.assertIn(
+			"states.cancelable_states.includes",
+			js_content,
+			"Debe validar si Sales Invoice ya está timbrada usando estados resilientes",
+		)
 
-        # Verificar validación de docstatus
-        self.assertIn(
-            "docstatus !== 1",
-            js_content,
-            "Debe validar que Sales Invoice esté submitted"
-        )
+		# Verificar validación de docstatus
+		self.assertIn("docstatus !== 1", js_content, "Debe validar que Sales Invoice esté submitted")
 
-        # Verificar validación de RFC
-        self.assertIn(
-            "!sales_invoice_data.tax_id",
-            js_content,
-            "Debe validar que Sales Invoice tenga RFC"
-        )
+		# Verificar validación de RFC
+		self.assertIn("!sales_invoice_data.tax_id", js_content, "Debe validar que Sales Invoice tenga RFC")
 
-        # Verificar mensajes de error apropiados
-        error_messages = [
-            "Sales Invoice No Disponible",
-            "Sales Invoice No Válida",
-            "RFC Faltante"
-        ]
+		# Verificar mensajes de error apropiados
+		error_messages = ["Sales Invoice No Disponible", "Sales Invoice No Válida", "RFC Faltante"]
 
-        for message in error_messages:
-            self.assertIn(
-                message,
-                js_content,
-                f"Debe mostrar mensaje de error: {message}"
-            )
+		for message in error_messages:
+			self.assertIn(message, js_content, f"Debe mostrar mensaje de error: {message}")
 
-        # Verificar que limpia selección en caso de error
-        self.assertIn(
-            'frm.set_value("sales_invoice", "")',
-            js_content,
-            "Debe limpiar selección cuando Sales Invoice no es válida"
-        )
+		# Verificar que limpia selección en caso de error
+		self.assertIn(
+			'frm.set_value("sales_invoice", "")',
+			js_content,
+			"Debe limpiar selección cuando Sales Invoice no es válida",
+		)
 
-        print("✅ Lógica de validación de disponibilidad correctamente implementada")
+		print("✅ Lógica de validación de disponibilidad correctamente implementada")
 
-    def test_fase4_auto_load_payment_method_implementation(self):
-        """
-        Test: Verificar implementación FASE 4 - Auto-carga PUE mejorada
+	def test_fase4_auto_load_payment_method_implementation(self):
+		"""
+		Test: Verificar implementación FASE 4 - Auto-carga PUE mejorada
 
-        Validaciones:
-        - Función auto_load_payment_method_from_sales_invoice existe en Python
-        - Función auto_load_payment_method_from_sales_invoice existe en JavaScript
-        - Triggers configurados en sales_invoice y fm_payment_method_sat
-        - Lógica PUE vs PPD implementada correctamente
-        """
-        # 1. Verificar función Python existe
-        from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import FacturaFiscalMexico
+		Validaciones:
+		- Función auto_load_payment_method_from_sales_invoice existe en Python
+		- Función auto_load_payment_method_from_sales_invoice existe en JavaScript
+		- Triggers configurados en sales_invoice y fm_payment_method_sat
+		- Lógica PUE vs PPD implementada correctamente
+		"""
+		# 1. Verificar función Python existe
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			FacturaFiscalMexico,
+		)
 
-        self.assertTrue(
-            hasattr(FacturaFiscalMexico, "auto_load_payment_method_from_sales_invoice"),
-            "Método auto_load_payment_method_from_sales_invoice debe existir en FacturaFiscalMexico"
-        )
+		self.assertTrue(
+			hasattr(FacturaFiscalMexico, "auto_load_payment_method_from_sales_invoice"),
+			"Método auto_load_payment_method_from_sales_invoice debe existir en FacturaFiscalMexico",
+		)
 
-        # 2. Verificar función JavaScript existe
-        # Usar path relativo para compatibilidad CI
-        js_file_path = frappe.get_app_path("facturacion_mexico", "facturacion_fiscal", "doctype", "factura_fiscal_mexico", "factura_fiscal_mexico.js")
+		# 2. Verificar función JavaScript existe
+		# Usar path relativo para compatibilidad CI
+		js_file_path = frappe.get_app_path(
+			"facturacion_mexico",
+			"facturacion_fiscal",
+			"doctype",
+			"factura_fiscal_mexico",
+			"factura_fiscal_mexico.js",
+		)
 
-        js_content = ""
-        try:
-            with open(js_file_path, 'r', encoding='utf-8') as f:
-                js_content = f.read()
-        except FileNotFoundError:
-            self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
+		js_content = ""
+		try:
+			with open(js_file_path, encoding="utf-8") as f:
+				js_content = f.read()
+		except FileNotFoundError:
+			self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
 
-        self.assertIn(
-            "function auto_load_payment_method_from_sales_invoice",
-            js_content,
-            "Función auto_load_payment_method_from_sales_invoice debe existir en JavaScript"
-        )
+		self.assertIn(
+			"function auto_load_payment_method_from_sales_invoice",
+			js_content,
+			"Función auto_load_payment_method_from_sales_invoice debe existir en JavaScript",
+		)
 
-        # 3. Verificar trigger sales_invoice llama auto-carga
-        self.assertIn(
-            "auto_load_payment_method_from_sales_invoice(frm)",
-            js_content,
-            "Trigger sales_invoice debe llamar función de auto-carga"
-        )
+		# 3. Verificar trigger sales_invoice llama auto-carga
+		self.assertIn(
+			"auto_load_payment_method_from_sales_invoice(frm)",
+			js_content,
+			"Trigger sales_invoice debe llamar función de auto-carga",
+		)
 
-        # 4. Verificar trigger fm_payment_method_sat existe
-        self.assertIn(
-            "fm_payment_method_sat: function (frm)",
-            js_content,
-            "Debe existir trigger para fm_payment_method_sat"
-        )
+		# 4. Verificar trigger fm_payment_method_sat existe
+		self.assertIn(
+			"fm_payment_method_sat: function (frm)",
+			js_content,
+			"Debe existir trigger para fm_payment_method_sat",
+		)
 
-        # 5. Verificar lógica PUE vs PPD
-        pue_ppd_logic = [
-            'fm_payment_method_sat === "PUE"',
-            'fm_payment_method_sat === "PPD"',
-            '"99 - Por definir"',
-            "Payment Entry"
-        ]
+		# 5. Verificar lógica PUE vs PPD
+		pue_ppd_logic = [
+			'fm_payment_method_sat === "PUE"',
+			'fm_payment_method_sat === "PPD"',
+			'"99 Por definir"',
+			"Payment Entry",
+		]
 
-        for logic in pue_ppd_logic:
-            self.assertIn(
-                logic,
-                js_content,
-                f"Lógica PUE/PPD debe incluir: {logic}"
-            )
+		for logic in pue_ppd_logic:
+			self.assertIn(logic, js_content, f"Lógica PUE/PPD debe incluir: {logic}")
 
-        # 6. Verificar comentarios FASE 4
-        self.assertIn(
-            "FASE 4: AUTO-CARGA PUE MEJORADA",
-            js_content,
-            "Código debe estar documentado como FASE 4"
-        )
+		# 6. Verificar comentarios FASE 4
+		self.assertIn(
+			"FASE 4: AUTO-CARGA PUE MEJORADA", js_content, "Código debe estar documentado como FASE 4"
+		)
 
-        print("✅ FASE 4 - Auto-carga PUE mejorada correctamente implementada")
+		print("✅ FASE 4 - Auto-carga PUE mejorada correctamente implementada")
 
-    def test_fase4_payment_entry_query_logic(self):
-        """
-        Test: Verificar lógica de consulta Payment Entry en FASE 4
+	def test_fase4_payment_entry_query_logic(self):
+		"""
+		Test: Verificar lógica de consulta Payment Entry en FASE 4
 
-        Validaciones:
-        - Consulta Payment Entry con filtros correctos
-        - Manejo de caso sin Payment Entry
-        - Auto-asignación PPD vs PUE
-        - No sobrescribir selección manual
-        """
-        # Verificar archivo Python tiene consulta Payment Entry
-        # Usar path relativo para compatibilidad CI
-        python_file_path = frappe.get_app_path("facturacion_mexico", "facturacion_fiscal", "doctype", "factura_fiscal_mexico", "factura_fiscal_mexico.py")
+		Validaciones:
+		- Consulta Payment Entry con filtros correctos
+		- Manejo de caso sin Payment Entry
+		- Auto-asignación PPD vs PUE
+		- No sobrescribir selección manual
+		"""
+		# Verificar archivo Python tiene consulta Payment Entry
+		# Usar path relativo para compatibilidad CI
+		python_file_path = frappe.get_app_path(
+			"facturacion_mexico",
+			"facturacion_fiscal",
+			"doctype",
+			"factura_fiscal_mexico",
+			"factura_fiscal_mexico.py",
+		)
 
-        with open(python_file_path, 'r', encoding='utf-8') as f:
-            python_content = f.read()
+		with open(python_file_path, encoding="utf-8") as f:
+			python_content = f.read()
 
-        # Verificar consulta Payment Entry - ACTUALIZADO para nueva implementación SQL
-        payment_entry_query = [
-            'get_payment_entry_by_invoice(',
-            'frappe.db.sql(',
-            'SELECT pe.name, pe.mode_of_payment',
-            'FROM `tabPayment Entry` pe',
-            'tabPayment Entry Reference'
-        ]
+		# Verificar consulta Payment Entry - ACTUALIZADO para nueva implementación SQL
+		payment_entry_query = [
+			"get_payment_entry_by_invoice(",
+			"frappe.db.sql(",
+			"SELECT pe.name, pe.mode_of_payment",
+			"FROM `tabPayment Entry` pe",
+			"tabPayment Entry Reference",
+		]
 
-        for query_part in payment_entry_query:
-            self.assertIn(
-                query_part,
-                python_content,
-                f"Consulta Payment Entry debe incluir: {query_part}"
-            )
+		for query_part in payment_entry_query:
+			self.assertIn(query_part, python_content, f"Consulta Payment Entry debe incluir: {query_part}")
 
-        # Verificar lógica condicional PUE/PPD
-        conditional_logic = [
-            'if self.fm_payment_method_sat == "PPD"',
-            'if self.fm_payment_method_sat == "PUE"',
-            'if self.fm_forma_pago_timbrado:',  # No sobrescribir
-            'payment_entries = get_payment_entry_by_invoice'
-        ]
+		# Verificar lógica condicional PUE/PPD
+		conditional_logic = [
+			'if self.fm_payment_method_sat == "PPD"',
+			'if self.fm_payment_method_sat == "PUE"',
+			"if self.fm_forma_pago_timbrado:",  # No sobrescribir
+			"payment_entries = get_payment_entry_by_invoice",
+		]
 
-        for logic in conditional_logic:
-            self.assertIn(
-                logic,
-                python_content,
-                f"Lógica condicional debe incluir: {logic}"
-            )
+		for logic in conditional_logic:
+			self.assertIn(logic, python_content, f"Lógica condicional debe incluir: {logic}")
 
-        # Verificar JavaScript tiene lógica similar
-        # Usar path relativo para compatibilidad CI
-        js_file_path = frappe.get_app_path("facturacion_mexico", "facturacion_fiscal", "doctype", "factura_fiscal_mexico", "factura_fiscal_mexico.js")
+		# Verificar JavaScript tiene lógica similar
+		# Usar path relativo para compatibilidad CI
+		js_file_path = frappe.get_app_path(
+			"facturacion_mexico",
+			"facturacion_fiscal",
+			"doctype",
+			"factura_fiscal_mexico",
+			"factura_fiscal_mexico.js",
+		)
 
-        js_content = ""
-        try:
-            with open(js_file_path, 'r', encoding='utf-8') as f:
-                js_content = f.read()
-        except FileNotFoundError:
-            self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
+		js_content = ""
+		try:
+			with open(js_file_path, encoding="utf-8") as f:
+				js_content = f.read()
+		except FileNotFoundError:
+			self.fail(f"Archivo JavaScript no encontrado: {js_file_path}")
 
-        js_query_logic = [
-            'get_payment_entry_for_javascript',
-            'invoice_name: frm.doc.sales_invoice',
-            'if (frm.doc.fm_forma_pago_timbrado)',  # No sobrescribir
-            'r.message.success && r.message.data'
-        ]
+		js_query_logic = [
+			"get_payment_entry_for_javascript",
+			"invoice_name: frm.doc.sales_invoice",
+			"if (frm.doc.fm_forma_pago_timbrado)",  # No sobrescribir
+			"r.message.success && r.message.data",
+		]
 
-        for js_logic in js_query_logic:
-            self.assertIn(
-                js_logic,
-                js_content,
-                f"JavaScript debe incluir lógica: {js_logic}"
-            )
+		for js_logic in js_query_logic:
+			self.assertIn(js_logic, js_content, f"JavaScript debe incluir lógica: {js_logic}")
 
-        print("✅ FASE 4 - Lógica consulta Payment Entry correctamente implementada")
+		print("✅ FASE 4 - Lógica consulta Payment Entry correctamente implementada")
 
-    def test_custom_fields_insert_after_chain(self):
-        """Test: Cadena de insert_after en custom fields es válida"""
-        # Verificar que no hay referencias circulares en insert_after
+	def test_custom_fields_insert_after_chain(self):
+		"""Test: Cadena de insert_after en custom fields es válida"""
+		# Verificar que no hay referencias circulares en insert_after
 
-        all_custom_fields = frappe.db.sql("""
+		all_custom_fields = frappe.db.sql(
+			"""
             SELECT dt, fieldname, insert_after
             FROM `tabCustom Field`
             WHERE dt IN ('Sales Invoice', 'Customer', 'Branch', 'Payment Entry', 'Item')
             ORDER BY dt, idx
-        """, as_dict=True)
+        """,
+			as_dict=True,
+		)
 
-        # Agrupar por DocType
-        by_doctype = {}
-        for field in all_custom_fields:
-            if field.dt not in by_doctype:
-                by_doctype[field.dt] = []
-            by_doctype[field.dt].append(field)
+		# Agrupar por DocType
+		by_doctype = {}
+		for field in all_custom_fields:
+			if field.dt not in by_doctype:
+				by_doctype[field.dt] = []
+			by_doctype[field.dt].append(field)
 
-        for _doctype, fields in by_doctype.items():
-            field_names = {f.fieldname for f in fields}
+		for _doctype, fields in by_doctype.items():
+			field_names = {f.fieldname for f in fields}
 
-            # Verificar referencias circulares
-            for field in fields:
-                if field.insert_after and field.insert_after in field_names:
-                    # Verificar que no se refiere a sí mismo
-                    self.assertNotEqual(field.fieldname, field.insert_after,
-                        f"Campo {field.fieldname} no puede referenciarse a sí mismo")
+			# Verificar referencias circulares
+			for field in fields:
+				if field.insert_after and field.insert_after in field_names:
+					# Verificar que no se refiere a sí mismo
+					self.assertNotEqual(
+						field.fieldname,
+						field.insert_after,
+						f"Campo {field.fieldname} no puede referenciarse a sí mismo",
+					)
 
-        print(f"✓ Verificación de referencias circulares completada para {len(by_doctype)} DocTypes")
+		print(f"✓ Verificación de referencias circulares completada para {len(by_doctype)} DocTypes")
 
-    def test_section_breaks_organization(self):
-        """Test: Organización lógica de Section Breaks entre módulos"""
-        # Verificar que las secciones están organizadas lógicamente
+	def test_section_breaks_organization(self):
+		"""Test: Organización lógica de Section Breaks entre módulos"""
+		# Verificar que las secciones están organizadas lógicamente
 
-        section_fields = frappe.db.sql("""
+		section_fields = frappe.db.sql(
+			"""
             SELECT dt, fieldname, label, insert_after
             FROM `tabCustom Field`
             WHERE fieldtype = 'Section Break'
             AND dt IN ('Sales Invoice', 'Customer', 'Branch')
             ORDER BY dt, idx
-        """, as_dict=True)
+        """,
+			as_dict=True,
+		)
 
-        # Agrupar por DocType
-        sections_by_doctype = {}
-        for section in section_fields:
-            if section.dt not in sections_by_doctype:
-                sections_by_doctype[section.dt] = []
-            sections_by_doctype[section.dt].append(section)
+		# Agrupar por DocType
+		sections_by_doctype = {}
+		for section in section_fields:
+			if section.dt not in sections_by_doctype:
+				sections_by_doctype[section.dt] = []
+			sections_by_doctype[section.dt].append(section)
 
-        for doctype, sections in sections_by_doctype.items():
-            section_labels = [s.label for s in sections if s.label]
+		for doctype, sections in sections_by_doctype.items():
+			section_labels = [s.label for s in sections if s.label]
 
-            # Verificar patrones esperados
-            multi_sucursal_sections = [s for s in section_labels
-                                     if any(keyword in s.lower() for keyword in
-                                           ['sucursal', 'branch', 'multi'])]
+			# Verificar patrones esperados
+			multi_sucursal_sections = [
+				s
+				for s in section_labels
+				if any(keyword in s.lower() for keyword in ["sucursal", "branch", "multi"])
+			]
 
-            addenda_sections = [s for s in section_labels
-                              if 'addenda' in s.lower()]
+			addenda_sections = [s for s in section_labels if "addenda" in s.lower()]
 
-            fiscal_sections = [s for s in section_labels
-                             if 'fiscal' in s.lower()]
+			fiscal_sections = [s for s in section_labels if "fiscal" in s.lower()]
 
-            if multi_sucursal_sections:
-                print(f"✓ {doctype} - Secciones Multi-Sucursal: {multi_sucursal_sections}")
+			if multi_sucursal_sections:
+				print(f"✓ {doctype} - Secciones Multi-Sucursal: {multi_sucursal_sections}")
 
-            if addenda_sections:
-                print(f"✓ {doctype} - Secciones Addenda: {addenda_sections}")
+			if addenda_sections:
+				print(f"✓ {doctype} - Secciones Addenda: {addenda_sections}")
 
-            if fiscal_sections:
-                print(f"✓ {doctype} - Secciones Fiscales: {fiscal_sections}")
+			if fiscal_sections:
+				print(f"✓ {doctype} - Secciones Fiscales: {fiscal_sections}")
 
-    def test_field_dependencies_cross_module(self):
-        """Test: Dependencias de campos entre módulos"""
-        # Verificar que las dependencias entre campos de diferentes módulos son válidas
+	def test_field_dependencies_cross_module(self):
+		"""Test: Dependencias de campos entre módulos"""
+		# Verificar que las dependencias entre campos de diferentes módulos son válidas
 
-        dependent_fields = frappe.db.sql("""
+		dependent_fields = frappe.db.sql(
+			"""
             SELECT dt, fieldname, depends_on
             FROM `tabCustom Field`
             WHERE depends_on IS NOT NULL
             AND depends_on != ''
             AND dt IN ('Sales Invoice', 'Customer', 'Branch')
-        """, as_dict=True)
+        """,
+			as_dict=True,
+		)
 
-        if dependent_fields:
-            print(f"✓ Campos con dependencias encontrados: {len(dependent_fields)}")
+		if dependent_fields:
+			print(f"✓ Campos con dependencias encontrados: {len(dependent_fields)}")
 
-            for field in dependent_fields:
-                # Verificar que depends_on no está vacío
-                self.assertTrue(field.depends_on.strip(),
-                    f"depends_on de {field.fieldname} no debe estar vacío")
+			for field in dependent_fields:
+				# Verificar que depends_on no está vacío
+				self.assertTrue(
+					field.depends_on.strip(), f"depends_on de {field.fieldname} no debe estar vacío"
+				)
 
-                # Verificar sintaxis básica (debe contener eval: o campo)
-                depends_on = field.depends_on.strip()
-                has_eval = 'eval:' in depends_on
-                has_field_ref = any(op in depends_on for op in ['==', '!=', '>', '<'])
+				# Verificar sintaxis básica (debe contener eval: o campo)
+				depends_on = field.depends_on.strip()
+				has_eval = "eval:" in depends_on
+				has_field_ref = any(op in depends_on for op in ["==", "!=", ">", "<"])
 
-                if not (has_eval or has_field_ref):
-                    print(f"⚠ {field.dt}.{field.fieldname} depends_on format: {depends_on}")
-        else:
-            print("ℹ No hay campos con dependencias explícitas")
+				if not (has_eval or has_field_ref):
+					print(f"⚠ {field.dt}.{field.fieldname} depends_on format: {depends_on}")
+		else:
+			print("i No hay campos con dependencias explícitas")
 
-    def test_hooks_integration_consistency(self):
-        """Test: Consistencia en integración de hooks entre módulos"""
-        # Verificar que los hooks están configurados consistentemente
+	def test_hooks_integration_consistency(self):
+		"""Test: Consistencia en integración de hooks entre módulos"""
+		# Verificar que los hooks están configurados consistentemente
 
-        from facturacion_mexico import hooks
+		from facturacion_mexico import hooks
 
-        doc_events = getattr(hooks, 'doc_events', {})
+		doc_events = getattr(hooks, "doc_events", {})
 
-        # Verificar hooks en DocTypes críticos
-        critical_doctypes = ['Sales Invoice', 'Customer', 'Branch']
+		# Verificar hooks en DocTypes críticos
+		critical_doctypes = ["Sales Invoice", "Customer", "Branch"]
 
-        for doctype in critical_doctypes:
-            if doctype in doc_events:
-                events = doc_events[doctype]
+		for doctype in critical_doctypes:
+			if doctype in doc_events:
+				events = doc_events[doctype]
 
-                # Verificar que hay hooks de validación
-                validation_events = ['validate', 'before_submit', 'on_submit']
-                has_validation = any(event in events for event in validation_events)
+				# Verificar que hay hooks de validación
+				validation_events = ["validate", "before_submit", "on_submit"]
+				has_validation = any(event in events for event in validation_events)
 
-                if has_validation:
-                    print(f"✓ {doctype} tiene hooks de validación")
+				if has_validation:
+					print(f"✓ {doctype} tiene hooks de validación")
 
-                    # Verificar hooks específicos de módulos
-                    for event, handlers in events.items():
-                        if event in validation_events:
-                            multi_sucursal_hooks = [h for h in handlers
-                                                  if any(keyword in h.lower() for keyword in
-                                                        ['branch', 'sucursal', 'multi'])]
+					# Verificar hooks específicos de módulos
+					for event, handlers in events.items():
+						if event in validation_events:
+							multi_sucursal_hooks = [
+								h
+								for h in handlers
+								if any(keyword in h.lower() for keyword in ["branch", "sucursal", "multi"])
+							]
 
-                            addenda_hooks = [h for h in handlers
-                                           if 'addenda' in h.lower()]
+							addenda_hooks = [h for h in handlers if "addenda" in h.lower()]
 
-                            if multi_sucursal_hooks:
-                                print(f"  ✓ {doctype}.{event} - Multi-Sucursal: {len(multi_sucursal_hooks)} hooks")
+							if multi_sucursal_hooks:
+								print(
+									f"  ✓ {doctype}.{event} - Multi-Sucursal: {len(multi_sucursal_hooks)} hooks"
+								)
 
-                            if addenda_hooks:
-                                print(f"  ✓ {doctype}.{event} - Addenda: {len(addenda_hooks)} hooks")
+							if addenda_hooks:
+								print(f"  ✓ {doctype}.{event} - Addenda: {len(addenda_hooks)} hooks")
 
-    def test_api_endpoint_consistency(self):
-        """Test: Consistencia en endpoints de API entre módulos"""
-        # Verificar que los módulos exponen APIs consistentes
+	def test_api_endpoint_consistency(self):
+		"""Test: Consistencia en endpoints de API entre módulos"""
+		# Verificar que los módulos exponen APIs consistentes
 
-        api_modules = [
-            "facturacion_mexico.multi_sucursal.api",
-            "facturacion_mexico.addendas.api",
-            "facturacion_mexico.api"
-        ]
+		api_modules = [
+			"facturacion_mexico.multi_sucursal.api",
+			"facturacion_mexico.addendas.api",
+			"facturacion_mexico.api",
+		]
 
-        available_apis = {}
-        for module_path in api_modules:
-            try:
-                module = __import__(module_path, fromlist=[''])
+		available_apis = {}
+		for module_path in api_modules:
+			try:
+				module = __import__(module_path, fromlist=[""])
 
-                # Buscar funciones que podrían ser endpoints
-                module_functions = [attr for attr in dir(module)
-                                  if callable(getattr(module, attr))
-                                  and not attr.startswith('_')]
+				# Buscar funciones que podrían ser endpoints
+				module_functions = [
+					attr
+					for attr in dir(module)
+					if callable(getattr(module, attr)) and not attr.startswith("_")
+				]
 
-                available_apis[module_path] = module_functions
-                print(f"✓ {module_path} - {len(module_functions)} funciones disponibles")
+				available_apis[module_path] = module_functions
+				print(f"✓ {module_path} - {len(module_functions)} funciones disponibles")
 
-            except ImportError:
-                print(f"ℹ {module_path} no disponible")
+			except ImportError:
+				print(f"i {module_path} no disponible")
 
-        # Verificar patrones comunes en APIs
-        if available_apis:
-            common_patterns = ['get', 'create', 'update', 'delete', 'validate']
+		# Verificar patrones comunes en APIs
+		if available_apis:
+			common_patterns = ["get", "create", "update", "delete", "validate"]
 
-            for module_path, functions in available_apis.items():
-                matching_patterns = []
-                for pattern in common_patterns:
-                    pattern_functions = [f for f in functions if pattern in f.lower()]
-                    if pattern_functions:
-                        matching_patterns.append(f"{pattern}({len(pattern_functions)})")
+			for module_path, functions in available_apis.items():
+				matching_patterns = []
+				for pattern in common_patterns:
+					pattern_functions = [f for f in functions if pattern in f.lower()]
+					if pattern_functions:
+						matching_patterns.append(f"{pattern}({len(pattern_functions)})")
 
-                if matching_patterns:
-                    print(f"  ✓ {module_path} patrones: {', '.join(matching_patterns)}")
+				if matching_patterns:
+					print(f"  ✓ {module_path} patrones: {', '.join(matching_patterns)}")
 
-    def test_database_integrity_cross_module(self):
-        """Test: Integridad de base de datos entre módulos"""
-        # Verificar que no hay conflictos de integridad entre módulos
+	def test_database_integrity_cross_module(self):
+		"""Test: Integridad de base de datos entre módulos"""
+		# Verificar que no hay conflictos de integridad entre módulos
 
-        # 1. Verificar que no hay custom fields duplicados
-        duplicate_fields = frappe.db.sql("""
+		# 1. Verificar que no hay custom fields duplicados
+		duplicate_fields = frappe.db.sql(
+			"""
             SELECT dt, fieldname, COUNT(*) as count
             FROM `tabCustom Field`
             WHERE dt IN ('Sales Invoice', 'Customer', 'Branch', 'Payment Entry', 'Item')
             GROUP BY dt, fieldname
             HAVING COUNT(*) > 1
-        """, as_dict=True)
+        """,
+			as_dict=True,
+		)
 
-        if duplicate_fields:
-            print(f"⚠ Campos duplicados encontrados: {[(f.dt, f.fieldname) for f in duplicate_fields]}")
-            for field in duplicate_fields:
-                self.fail(f"Campo duplicado: {field.dt}.{field.fieldname} aparece {field.count} veces")
-        else:
-            print("✓ No hay custom fields duplicados")
+		if duplicate_fields:
+			print(f"⚠ Campos duplicados encontrados: {[(f.dt, f.fieldname) for f in duplicate_fields]}")
+			for field in duplicate_fields:
+				self.fail(f"Campo duplicado: {field.dt}.{field.fieldname} aparece {field.count} veces")
+		else:
+			print("✓ No hay custom fields duplicados")
 
-        # 2. Verificar integridad referencial en Links
-        link_fields = frappe.db.sql("""
+		# 2. Verificar integridad referencial en Links
+		link_fields = frappe.db.sql(
+			"""
             SELECT dt, fieldname, options
             FROM `tabCustom Field`
             WHERE fieldtype = 'Link'
             AND dt IN ('Sales Invoice', 'Customer', 'Branch')
-        """, as_dict=True)
+        """,
+			as_dict=True,
+		)
 
-        broken_links = []
-        for field in link_fields:
-            if field.options and not frappe.db.exists("DocType", field.options):
-                broken_links.append((field.dt, field.fieldname, field.options))
+		broken_links = []
+		for field in link_fields:
+			if field.options and not frappe.db.exists("DocType", field.options):
+				broken_links.append((field.dt, field.fieldname, field.options))
 
-        if broken_links:
-            print(f"⚠ Links rotos encontrados: {broken_links}")
-        else:
-            print(f"✓ Todos los {len(link_fields)} campos Link tienen referencias válidas")
+		if broken_links:
+			print(f"⚠ Links rotos encontrados: {broken_links}")
+		else:
+			print(f"✓ Todos los {len(link_fields)} campos Link tienen referencias válidas")
 
-    def test_module_load_order_dependencies(self):
-        """Test: Orden de carga de módulos y dependencias"""
-        # Verificar que los módulos pueden cargarse en cualquier orden
+	def test_module_load_order_dependencies(self):
+		"""Test: Orden de carga de módulos y dependencias"""
+		# Verificar que los módulos pueden cargarse en cualquier orden
 
-        module_paths = [
-            "facturacion_mexico.multi_sucursal",
-            "facturacion_mexico.addendas",
-            "facturacion_mexico.facturacion_fiscal"
-        ]
+		module_paths = [
+			"facturacion_mexico.multi_sucursal",
+			"facturacion_mexico.addendas",
+			"facturacion_mexico.facturacion_fiscal",
+		]
 
-        loaded_modules = []
-        failed_modules = []
+		loaded_modules = []
+		failed_modules = []
 
-        for module_path in module_paths:
-            try:
-                __import__(module_path, fromlist=[''])
-                loaded_modules.append(module_path)
-            except ImportError as e:
-                failed_modules.append((module_path, str(e)))
+		for module_path in module_paths:
+			try:
+				__import__(module_path, fromlist=[""])
+				loaded_modules.append(module_path)
+			except ImportError as e:
+				failed_modules.append((module_path, str(e)))
 
-        print(f"✓ Módulos cargados exitosamente: {len(loaded_modules)}")
+		print(f"✓ Módulos cargados exitosamente: {len(loaded_modules)}")
 
-        if failed_modules:
-            print(f"⚠ Módulos no disponibles: {[m[0] for m in failed_modules]}")
+		if failed_modules:
+			print(f"⚠ Módulos no disponibles: {[m[0] for m in failed_modules]}")
 
-        # Verificar que al menos el módulo principal se carga
-        self.assertGreaterEqual(len(loaded_modules), 1,
-            "Al menos un módulo principal debe cargarse")
+		# Verificar que al menos el módulo principal se carga
+		self.assertGreaterEqual(len(loaded_modules), 1, "Al menos un módulo principal debe cargarse")
 
-    def test_error_handling_consistency(self):
-        """Test: Consistencia en manejo de errores entre módulos"""
-        # Verificar que los módulos manejan errores de manera consistente
+	def test_error_handling_consistency(self):
+		"""Test: Consistencia en manejo de errores entre módulos"""
+		# Verificar que los módulos manejan errores de manera consistente
 
-        # Buscar archivos de utilidades de error
-        error_modules = [
-            "facturacion_mexico.utils.exceptions",
-            "facturacion_mexico.exceptions",
-            "facturacion_mexico.utils.error_handler"
-        ]
+		# Buscar archivos de utilidades de error
+		error_modules = [
+			"facturacion_mexico.utils.exceptions",
+			"facturacion_mexico.exceptions",
+			"facturacion_mexico.utils.error_handler",
+		]
 
-        error_handlers = []
-        for module_path in error_modules:
-            try:
-                module = __import__(module_path, fromlist=[''])
-                error_handlers.append(module_path)
+		error_handlers = []
+		for module_path in error_modules:
+			try:
+				module = __import__(module_path, fromlist=[""])
+				error_handlers.append(module_path)
 
-                # Buscar clases de excepción o funciones de manejo
-                module_attrs = dir(module)
-                exception_attrs = [attr for attr in module_attrs
-                                 if any(keyword in attr.lower() for keyword in
-                                       ['error', 'exception', 'handler'])]
+				# Buscar clases de excepción o funciones de manejo
+				module_attrs = dir(module)
+				exception_attrs = [
+					attr
+					for attr in module_attrs
+					if any(keyword in attr.lower() for keyword in ["error", "exception", "handler"])
+				]
 
-                if exception_attrs:
-                    print(f"✓ {module_path} - Manejo de errores: {exception_attrs[:3]}")
+				if exception_attrs:
+					print(f"✓ {module_path} - Manejo de errores: {exception_attrs[:3]}")
 
-            except ImportError:
-                continue
+			except ImportError:
+				continue
 
-        if error_handlers:
-            print(f"✓ Módulos de manejo de errores disponibles: {len(error_handlers)}")
-        else:
-            print("ℹ Usando manejo de errores estándar de Frappe")
+		if error_handlers:
+			print(f"✓ Módulos de manejo de errores disponibles: {len(error_handlers)}")
+		else:
+			print("i Usando manejo de errores estándar de Frappe")
 
-    def test_performance_impact_cross_module(self):
-        """Test: Impacto de rendimiento entre módulos"""
-        # Verificar que la integración no impacta significativamente el rendimiento
+	def test_performance_impact_cross_module(self):
+		"""Test: Impacto de rendimiento entre módulos"""
+		# Verificar que la integración no impacta significativamente el rendimiento
 
-        # Contar custom fields por DocType para estimar overhead
-        field_counts = frappe.db.sql("""
+		# Contar custom fields por DocType para estimar overhead
+		field_counts = frappe.db.sql(
+			"""
             SELECT dt, COUNT(*) as field_count
             FROM `tabCustom Field`
             WHERE dt IN ('Sales Invoice', 'Customer', 'Branch', 'Payment Entry', 'Item')
             GROUP BY dt
             ORDER BY field_count DESC
-        """, as_dict=True)
+        """,
+			as_dict=True,
+		)
 
-        for count in field_counts:
-            print(f"✓ {count.dt}: {count.field_count} custom fields")
+		for count in field_counts:
+			print(f"✓ {count.dt}: {count.field_count} custom fields")
 
-            # Alertar si hay demasiados campos (potencial impacto de rendimiento)
-            if count.field_count > 20:
-                print(f"⚠ {count.dt} tiene muchos custom fields ({count.field_count}) - considerar optimización")
+			# Alertar si hay demasiados campos (potencial impacto de rendimiento)
+			if count.field_count > 20:
+				print(
+					f"⚠ {count.dt} tiene muchos custom fields ({count.field_count}) - considerar optimización"
+				)
 
-        # Verificar hooks que podrían impactar rendimiento
-        from facturacion_mexico import hooks
-        doc_events = getattr(hooks, 'doc_events', {})
+		# Verificar hooks que podrían impactar rendimiento
+		from facturacion_mexico import hooks
 
-        for doctype, events in doc_events.items():
-            total_hooks = sum(len(handlers) for handlers in events.values())
-            if total_hooks > 5:
-                print(f"⚠ {doctype} tiene {total_hooks} hooks - verificar impacto de rendimiento")
+		doc_events = getattr(hooks, "doc_events", {})
 
-    # ===== ARQUITECTURA RESILIENTE TESTS =====
+		for doctype, events in doc_events.items():
+			total_hooks = sum(len(handlers) for handlers in events.values())
+			if total_hooks > 5:
+				print(f"⚠ {doctype} tiene {total_hooks} hooks - verificar impacto de rendimiento")
 
-    def test_fiscal_states_validation_logic(self):
-        """TEST: Lógica de validación estados fiscales"""
-        print("\n🧪 LAYER 2 TEST: Estados Fiscales → Validación Lógica")
+	# ===== ARQUITECTURA RESILIENTE TESTS =====
 
-        # Test estados válidos
-        valid_states = [FiscalStates.BORRADOR, FiscalStates.PROCESANDO, FiscalStates.TIMBRADO,
-                        FiscalStates.ERROR, FiscalStates.CANCELADO]
+	def test_fiscal_states_validation_logic(self):
+		"""TEST: Lógica de validación estados fiscales"""
+		print("\n🧪 LAYER 2 TEST: Estados Fiscales → Validación Lógica")
 
-        for state in valid_states:
-            self.assertTrue(FiscalStates.is_valid(state), f"Estado {state} debe ser válido")
-            print(f"  ✅ Estado válido: {state}")
+		# Test estados válidos
+		valid_states = [
+			FiscalStates.BORRADOR,
+			FiscalStates.PROCESANDO,
+			FiscalStates.TIMBRADO,
+			FiscalStates.ERROR,
+			FiscalStates.CANCELADO,
+		]
 
-        # Test estados inválidos
-        invalid_states = ["INVALID", "Timbrada", "Pendiente", None, ""]
-        for state in invalid_states:
-            self.assertFalse(FiscalStates.is_valid(state), f"Estado {state} debe ser inválido")
-            print(f"  ❌ Estado inválido detectado correctamente: {state}")
+		for state in valid_states:
+			self.assertTrue(FiscalStates.is_valid(state), f"Estado {state} debe ser válido")
+			print(f"  ✅ Estado válido: {state}")
 
-        print("  ✅ PASS: Lógica validación estados funcional")
+		# Test estados inválidos
+		invalid_states = ["INVALID", "Timbrada", "Pendiente", None, ""]
+		for state in invalid_states:
+			self.assertFalse(FiscalStates.is_valid(state), f"Estado {state} debe ser inválido")
+			print(f"  ❌ Estado inválido detectado correctamente: {state}")
 
-    def test_state_transition_logic(self):
-        """TEST: Lógica de transiciones de estados"""
-        print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Transiciones")
+		print("  ✅ PASS: Lógica validación estados funcional")
 
-        # Test transición válida: BORRADOR → PROCESANDO
-        next_state = FiscalStates.get_next_state(FiscalStates.BORRADOR, "timbrar")
-        self.assertEqual(next_state, FiscalStates.PROCESANDO)
-        print(f"  ✅ Transición BORRADOR + timbrar → {next_state}")
+	def test_state_transition_logic(self):
+		"""TEST: Lógica de transiciones de estados"""
+		print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Transiciones")
 
-        # Test transición válida: PROCESANDO → TIMBRADO
-        next_state = FiscalStates.get_next_state(FiscalStates.PROCESANDO, "success")
-        self.assertEqual(next_state, FiscalStates.TIMBRADO)
-        print(f"  ✅ Transición PROCESANDO + success → {next_state}")
+		# Test transición válida: BORRADOR → PROCESANDO
+		next_state = FiscalStates.get_next_state(FiscalStates.BORRADOR, "timbrar")
+		self.assertEqual(next_state, FiscalStates.PROCESANDO)
+		print(f"  ✅ Transición BORRADOR + timbrar → {next_state}")
 
-        # Test transición inválida
-        next_state = FiscalStates.get_next_state(FiscalStates.TIMBRADO, "timbrar")
-        self.assertIsNone(next_state)
-        print(f"  ❌ Transición inválida TIMBRADO + timbrar → None (correcto)")
+		# Test transición válida: PROCESANDO → TIMBRADO
+		next_state = FiscalStates.get_next_state(FiscalStates.PROCESANDO, "success")
+		self.assertEqual(next_state, FiscalStates.TIMBRADO)
+		print(f"  ✅ Transición PROCESANDO + success → {next_state}")
 
-        print("  ✅ PASS: Lógica transiciones estados funcional")
+		# Test transición inválida
+		next_state = FiscalStates.get_next_state(FiscalStates.TIMBRADO, "timbrar")
+		self.assertIsNone(next_state)
+		print("  ❌ Transición inválida TIMBRADO + timbrar → None (correcto)")
 
-    def test_timbrable_states_logic(self):
-        """TEST: Lógica de estados que permiten timbrado"""
-        print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Timbrable")
+		print("  ✅ PASS: Lógica transiciones estados funcional")
 
-        # Estados que SÍ permiten timbrado
-        timbrable_states = [FiscalStates.BORRADOR, FiscalStates.ERROR]
-        for state in timbrable_states:
-            self.assertTrue(FiscalStates.can_timbrar(state), f"Estado {state} debe permitir timbrado")
-            print(f"  ✅ Timbrable: {state}")
+	def test_timbrable_states_logic(self):
+		"""TEST: Lógica de estados que permiten timbrado"""
+		print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Timbrable")
 
-        # Estados que NO permiten timbrado
-        non_timbrable_states = [FiscalStates.TIMBRADO, FiscalStates.CANCELADO, FiscalStates.PROCESANDO]
-        for state in non_timbrable_states:
-            self.assertFalse(FiscalStates.can_timbrar(state), f"Estado {state} NO debe permitir timbrado")
-            print(f"  ❌ No timbrable: {state}")
+		# Estados que SÍ permiten timbrado
+		timbrable_states = [FiscalStates.BORRADOR, FiscalStates.ERROR]
+		for state in timbrable_states:
+			self.assertTrue(FiscalStates.can_timbrar(state), f"Estado {state} debe permitir timbrado")
+			print(f"  ✅ Timbrable: {state}")
 
-        print("  ✅ PASS: Lógica estados timbrable funcional")
+		# Estados que NO permiten timbrado
+		non_timbrable_states = [FiscalStates.TIMBRADO, FiscalStates.CANCELADO, FiscalStates.PROCESANDO]
+		for state in non_timbrable_states:
+			self.assertFalse(FiscalStates.can_timbrar(state), f"Estado {state} NO debe permitir timbrado")
+			print(f"  ❌ No timbrable: {state}")
 
-    def test_cancelable_states_logic(self):
-        """TEST: Lógica de estados que permiten cancelación"""
-        print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Cancelable")
+		print("  ✅ PASS: Lógica estados timbrable funcional")
 
-        # Estados que SÍ permiten cancelación
-        cancelable_states = [FiscalStates.TIMBRADO]
-        for state in cancelable_states:
-            self.assertTrue(FiscalStates.can_cancelar(state), f"Estado {state} debe permitir cancelación")
-            print(f"  ✅ Cancelable: {state}")
+	def test_cancelable_states_logic(self):
+		"""TEST: Lógica de estados que permiten cancelación"""
+		print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Cancelable")
 
-        # Estados que NO permiten cancelación
-        non_cancelable_states = [FiscalStates.BORRADOR, FiscalStates.ERROR, FiscalStates.CANCELADO]
-        for state in non_cancelable_states:
-            self.assertFalse(FiscalStates.can_cancelar(state), f"Estado {state} NO debe permitir cancelación")
-            print(f"  ❌ No cancelable: {state}")
+		# Estados que SÍ permiten cancelación
+		cancelable_states = [FiscalStates.TIMBRADO]
+		for state in cancelable_states:
+			self.assertTrue(FiscalStates.can_cancelar(state), f"Estado {state} debe permitir cancelación")
+			print(f"  ✅ Cancelable: {state}")
 
-        print("  ✅ PASS: Lógica estados cancelable funcional")
+		# Estados que NO permiten cancelación
+		non_cancelable_states = [FiscalStates.BORRADOR, FiscalStates.ERROR, FiscalStates.CANCELADO]
+		for state in non_cancelable_states:
+			self.assertFalse(FiscalStates.can_cancelar(state), f"Estado {state} NO debe permitir cancelación")
+			print(f"  ❌ No cancelable: {state}")
 
-    def test_sync_states_validation_logic(self):
-        """TEST: Lógica de validación estados de sincronización"""
-        print("\n🧪 LAYER 2 TEST: Estados Sync → Validación Lógica")
+		print("  ✅ PASS: Lógica estados cancelable funcional")
 
-        # Test estados sync válidos
-        valid_sync_states = [SyncStates.PENDING, SyncStates.SYNCED, SyncStates.ERROR]
-        for state in valid_sync_states:
-            self.assertTrue(SyncStates.is_valid(state), f"Estado sync {state} debe ser válido")
-            print(f"  ✅ Estado sync válido: {state}")
+	def test_sync_states_validation_logic(self):
+		"""TEST: Lógica de validación estados de sincronización"""
+		print("\n🧪 LAYER 2 TEST: Estados Sync → Validación Lógica")
 
-        # Test estados sync inválidos
-        invalid_sync_states = ["INVALID", "pending_sync", None, ""]
-        for state in invalid_sync_states:
-            self.assertFalse(SyncStates.is_valid(state), f"Estado sync {state} debe ser inválido")
-            print(f"  ❌ Estado sync inválido detectado correctamente: {state}")
+		# Test estados sync válidos
+		valid_sync_states = [SyncStates.PENDING, SyncStates.SYNCED, SyncStates.ERROR]
+		for state in valid_sync_states:
+			self.assertTrue(SyncStates.is_valid(state), f"Estado sync {state} debe ser válido")
+			print(f"  ✅ Estado sync válido: {state}")
 
-        print("  ✅ PASS: Lógica validación estados sync funcional")
+		# Test estados sync inválidos
+		invalid_sync_states = ["INVALID", "pending_sync", None, ""]
+		for state in invalid_sync_states:
+			self.assertFalse(SyncStates.is_valid(state), f"Estado sync {state} debe ser inválido")
+			print(f"  ❌ Estado sync inválido detectado correctamente: {state}")
 
-    def test_recovery_states_logic(self):
-        """TEST: Lógica de estados recuperables"""
-        print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Recovery")
+		print("  ✅ PASS: Lógica validación estados sync funcional")
 
-        # Estados que SÍ son recuperables
-        recoverable_states = [FiscalStates.ERROR, FiscalStates.PROCESANDO]
-        for state in recoverable_states:
-            self.assertTrue(FiscalStates.is_recoverable_error(state), f"Estado {state} debe ser recuperable")
-            print(f"  🔄 Recuperable: {state}")
+	def test_recovery_states_logic(self):
+		"""TEST: Lógica de estados recuperables"""
+		print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Recovery")
 
-        # Estados que NO son recuperables
-        non_recoverable_states = [FiscalStates.TIMBRADO, FiscalStates.CANCELADO, FiscalStates.BORRADOR]
-        for state in non_recoverable_states:
-            self.assertFalse(FiscalStates.is_recoverable_error(state), f"Estado {state} NO debe ser recuperable")
-            print(f"  ✅ No recuperable: {state}")
+		# Estados que SÍ son recuperables
+		recoverable_states = [FiscalStates.ERROR, FiscalStates.PROCESANDO]
+		for state in recoverable_states:
+			self.assertTrue(FiscalStates.is_recoverable_error(state), f"Estado {state} debe ser recuperable")
+			print(f"  🔄 Recuperable: {state}")
 
-        print("  ✅ PASS: Lógica estados recovery funcional")
+		# Estados que NO son recuperables
+		non_recoverable_states = [FiscalStates.TIMBRADO, FiscalStates.CANCELADO, FiscalStates.BORRADOR]
+		for state in non_recoverable_states:
+			self.assertFalse(
+				FiscalStates.is_recoverable_error(state), f"Estado {state} NO debe ser recuperable"
+			)
+			print(f"  ✅ No recuperable: {state}")
 
-    def test_final_states_logic(self):
-        """TEST: Lógica de estados finales"""
-        print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Estados Finales")
+		print("  ✅ PASS: Lógica estados recovery funcional")
 
-        # Estados que SÍ son finales
-        final_states = [FiscalStates.CANCELADO, FiscalStates.ARCHIVADO]
-        for state in final_states:
-            self.assertTrue(FiscalStates.is_final(state), f"Estado {state} debe ser final")
-            print(f"  🏁 Final: {state}")
+	def test_final_states_logic(self):
+		"""TEST: Lógica de estados finales"""
+		print("\n🧪 LAYER 2 TEST: Estados Fiscales → Lógica Estados Finales")
 
-        # Estados que NO son finales
-        non_final_states = [FiscalStates.BORRADOR, FiscalStates.PROCESANDO, FiscalStates.TIMBRADO, FiscalStates.ERROR]
-        for state in non_final_states:
-            self.assertFalse(FiscalStates.is_final(state), f"Estado {state} NO debe ser final")
-            print(f"  🔄 No final: {state}")
+		# Estados que SÍ son finales
+		final_states = [FiscalStates.CANCELADO, FiscalStates.ARCHIVADO]
+		for state in final_states:
+			self.assertTrue(FiscalStates.is_final(state), f"Estado {state} debe ser final")
+			print(f"  🏁 Final: {state}")
 
-        print("  ✅ PASS: Lógica estados finales funcional")
+		# Estados que NO son finales
+		non_final_states = [
+			FiscalStates.BORRADOR,
+			FiscalStates.PROCESANDO,
+			FiscalStates.TIMBRADO,
+			FiscalStates.ERROR,
+		]
+		for state in non_final_states:
+			self.assertFalse(FiscalStates.is_final(state), f"Estado {state} NO debe ser final")
+			print(f"  🔄 No final: {state}")
 
-    def test_operation_types_validation(self):
-        """TEST: Lógica de validación tipos de operación"""
-        print("\n🧪 LAYER 2 TEST: Tipos Operación → Validación Lógica")
+		print("  ✅ PASS: Lógica estados finales funcional")
 
-        # Test tipos de operación válidos
-        valid_operations = [OperationTypes.TIMBRADO, OperationTypes.CANCELACION,
-                            OperationTypes.CONSULTA, OperationTypes.VALIDACION]
-        for operation in valid_operations:
-            self.assertTrue(OperationTypes.is_valid(operation), f"Operación {operation} debe ser válida")
-            print(f"  ✅ Operación válida: {operation}")
+	def test_operation_types_validation(self):
+		"""TEST: Lógica de validación tipos de operación"""
+		print("\n🧪 LAYER 2 TEST: Tipos Operación → Validación Lógica")
 
-        # Test tipos de operación inválidos
-        invalid_operations = ["INVALID", "timbrado", "cancelacion", None, ""]
-        for operation in invalid_operations:
-            self.assertFalse(OperationTypes.is_valid(operation), f"Operación {operation} debe ser inválida")
-            print(f"  ❌ Operación inválida detectada correctamente: {operation}")
+		# Test tipos de operación válidos
+		valid_operations = [
+			OperationTypes.TIMBRADO,
+			OperationTypes.CANCELACION,
+			OperationTypes.CONSULTA,
+			OperationTypes.VALIDACION,
+		]
+		for operation in valid_operations:
+			self.assertTrue(OperationTypes.is_valid(operation), f"Operación {operation} debe ser válida")
+			print(f"  ✅ Operación válida: {operation}")
 
-        print("  ✅ PASS: Lógica validación tipos operación funcional")
+		# Test tipos de operación inválidos
+		invalid_operations = ["INVALID", "timbrado", "cancelacion", None, ""]
+		for operation in invalid_operations:
+			self.assertFalse(OperationTypes.is_valid(operation), f"Operación {operation} debe ser inválida")
+			print(f"  ❌ Operación inválida detectada correctamente: {operation}")
 
-    def test_pac_response_business_logic(self):
-        """TEST: Lógica de negocio PAC Response Writer"""
-        print("\n🧪 LAYER 2 TEST: PAC Response → Lógica de Negocio")
+		print("  ✅ PASS: Lógica validación tipos operación funcional")
 
-        try:
-            # Intentar importar PAC Response Writer
-            from facturacion_mexico.facturacion_fiscal.api import write_pac_response
+	def test_pac_response_business_logic(self):
+		"""TEST: Lógica de negocio PAC Response Writer"""
+		print("\n🧪 LAYER 2 TEST: PAC Response → Lógica de Negocio")
 
-            # Verificar que la función existe
-            self.assertTrue(callable(write_pac_response), "write_pac_response debe ser función")
-            print("  📦 PAC Response Writer importado correctamente")
+		try:
+			# Intentar importar PAC Response Writer
+			from facturacion_mexico.facturacion_fiscal.api import write_pac_response
 
-            # Validar lógica de tipos de operación
-            self.assertTrue(OperationTypes.is_valid(OperationTypes.TIMBRADO))
+			# Verificar que la función existe
+			self.assertTrue(callable(write_pac_response), "write_pac_response debe ser función")
+			print("  📦 PAC Response Writer importado correctamente")
 
-            print("  ✅ PASS: Lógica negocio PAC Response funcional")
+			# Validar lógica de tipos de operación
+			self.assertTrue(OperationTypes.is_valid(OperationTypes.TIMBRADO))
 
-        except ImportError as e:
-            print(f"  ⚠️  PAC Response Writer no disponible: {e}")
-            print("  INFO: Arquitectura preparada, implementación específica pendiente")
+			print("  ✅ PASS: Lógica negocio PAC Response funcional")
 
-            # Validar al menos la lógica de tipos de operación
-            self.assertTrue(OperationTypes.is_valid(OperationTypes.TIMBRADO))
-            print("  ✅ PASS: Lógica tipos operación funcional")
+		except ImportError as e:
+			print(f"  ⚠️  PAC Response Writer no disponible: {e}")
+			print("  INFO: Arquitectura preparada, implementación específica pendiente")
+
+			# Validar al menos la lógica de tipos de operación
+			self.assertTrue(OperationTypes.is_valid(OperationTypes.TIMBRADO))
+			print("  ✅ PASS: Lógica tipos operación funcional")
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/facturacion_mexico/validaciones/sales_invoice.py
+++ b/facturacion_mexico/validaciones/sales_invoice.py
@@ -20,10 +20,10 @@ def validate_ppd_vs_forma_pago(doc, method):
 				payment_entry = frappe.get_doc("Payment Entry", payment_ref.parent)
 
 				if payment_entry.mode_of_payment:
-					# Extraer código SAT del Mode of Payment (formato: "01 - Efectivo")
-					mode_parts = payment_entry.mode_of_payment.split(" - ")
-					if len(mode_parts) >= 2 and mode_parts[0].isdigit():
-						forma_pago_sat = mode_parts[0]
+					# Extraer código SAT del Mode of Payment (formato: "01 Efectivo")
+					candidate = payment_entry.mode_of_payment[:2]
+					if candidate.isdigit():
+						forma_pago_sat = candidate
 						break
 
 	if not forma_pago_sat:


### PR DESCRIPTION
## Objetivo
Alinear el formato de Mode of Payment con el estándar real de los sitios
migrados desde facturacion_mx. Los Payment Entries históricos usan \"NN Descripción\"
(sin guion) y el app generaba fixtures con \"NN - Descripción\" (con guion), causando
que todos los complementos PPD fallaran al intentar timbrar.

## Cambios principales
- **Fixtures**: renombra los 22 registros SAT de formato con guion a formato sin guion
- **Regex**: `^(\d{2}) (?!-).+$` — acepta legacy, rechaza explícitamente el guion
- **Splits**: reemplaza `split(\" - \")` por `[:2]` para extracción de código SAT en
  complementos_pago, factura_fiscal_mexico.py, timbrado_api, validaciones
- **Strings hardcoded**: \"99 - Por definir\" → \"99 Por definir\" (15 en JS, 6 en Python)
- **Tests**: actualiza suite a formato sin guion + nuevo test que rechaza el formato con guion
- **one_off**: `cleanup_mop_canonical.py` — limpia registros generados por fixtures anteriores
  en sitios existentes (dry_run por default, sin ignore_links, sin tocar Payment Entries)

## Documentación actualizada
Sin cambios en docs/ — es fix de compatibilidad sin nueva funcionalidad observable.

## Validaciones realizadas
- Cleanup ejecutado en test-facturacion.localhost, acg-v16.dev, actiglobal-restore.dev ✅
- llantascs-v16.dev: 21 eliminados, 1 conservado ("99 - Por definir" con 6 FFMs) ✅
- bench migrate limpio en test-facturacion.localhost ✅
- Linters ruff: OK ✅
- Otros catálogos SAT auditados — ninguno tiene el mismo problema ✅

## Fuera de alcance
- No toca Payment Entries existentes
- No usa UPDATE masivo
- No modifica documentos submitted
- UOM: fixture no cambia (normalización en código ya cubre ambos formatos)

## Riesgos / pendientes
- **Requiere `bench migrate` + `bench build`** en todos los sites al instalar
- **Requiere ejecutar `cleanup_mop_canonical.py`** en sitios existentes con registros
  generados por fixtures anteriores. La limpieza es site por site, siempre dry_run primero.
- **ActiGlobal producción**: requiere plan completo backup → restore staging → verificación
  funcional → deploy producción → cleanup real. No ejecutar cleanup directo en producción.
- llantascs-v16.dev: `"99 - Por definir"` conservado — tiene 6 FFMs referenciándolo.
  Limpiar cuando esas FFMs sean sustituidas o canceladas.
- one_off commiteado como excepción a RG-010 para deploy reproducible en producción

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Mode of Payment format from "NN - Description" to "NN Description" across UI, validation, parsing, and error messages; PPD default set to "99 Por definir".

* **Chores**
  * Added a one-off cleanup to detect and remove legacy Mode of Payment records using the old hyphenated format (dry-run support).

* **Tests**
  * Updated fixtures and tests to reflect the new canonical format.

* **Documentation**
  * Migration/tracking docs and recovery checklist updated for the rollout and cleanup plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->