### PR TITLE
feat(ffm+cpmx): migración Fase 2 — fm_creation_source, fix PDF/XML y trazabilidad de complementos

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,8 +1,8 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-06-14
+**Fecha:** 2026-06-15
 **Rama activa:** `feat/ffm-migracion-legacy-fase2`
-**Tarea actual:** Migración complementos PPD legacy → Complemento Pago MX (fase 2)
+**Tarea actual:** PR abierto — feat/ffm-migracion-legacy-fase2 → main
 
 ---
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,70 +1,86 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-06-11
-**Rama activa:** `fix/mode-of-payment-formato-legacy`
-**Tarea actual:** PR #191 — fixes post-CodeRabbit listos para merge
+**Fecha:** 2026-06-14
+**Rama activa:** `feat/ffm-migracion-legacy-fase2`
+**Tarea actual:** Migración histórica FFM legacy → facturacion_mexico (Fase 2 Grupo 1 completo)
 
 ---
 
 ## Recuperación rápida
 
-Estoy trabajando en:
-Estandarización del formato de Mode of Payment a "NN Descripción" (sin guion) para
-alinear el app con el formato real de los datos históricos migrados desde facturacion_mx.
+Estoy trabajando en la migración de CFDIs históricos de `facturacion_mx` (legacy) a
+`facturacion_mexico` (nuevo). El Grupo 1 (10,924 FFMs) está completamente migrado y auditado.
 
 Plan que estoy siguiendo:
-Merge del PR → deploy en staging ActiGlobal → verificación funcional → deploy producción →
-cleanup one_off en producción.
+`working_docs/active/REPORTE_MIGRACION_GRUPO1_COMPLETO.md`
 
 Objetivo inmediato:
-Merge de PR #191. CI debe pasar tras el commit de fixes post-CodeRabbit.
+Abrir PR para los cambios de código de la Fase 2. Luego procesar pendientes (Grupo 2, duplicados).
 
 Criterio de avance:
-main con el fix. Complementos PPD funcionan con mode_of_payment "03 Transferencia".
+PR mergeado + pendientes clasificados para próxima sesión.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- ✅ PR #190 — UOM legacy + precios IVA incluido
+- Fase 1: 1,790 items (fm_producto_servicio_sat) + 1,432 customers (fm_uso_cfdi_default)
+- Grupo 1 Fase 2: 10,924 FFMs creadas — 0 errores — auditoría 14/14 OK
+- Fix fm_xml_url → Small Text (URLs SAT >140 chars)
+- Fix botón Descargar PDF+XML → descargar_archivos_cfdi() en timbrado_api.py
+- +fm_creation_source en FFM DocType JSON
+- +Método de Pago en widget fiscal de Sales Invoice
 
 ### En progreso
-- PR #191 fix/mode-of-payment-formato-legacy — fixes post-review commiteados
+- PR feat/ffm-migracion-legacy-fase2 → pendiente push y apertura
 
-### Pendiente inmediato post-merge
-1. Restore backup ActiGlobal producción → actiglobal-restore.dev
-2. Deploy nuevo código en restore.dev + migrate + build
-3. Dry-run cleanup_mop_canonical en restore.dev
-4. Cleanup real en restore.dev
-5. Verificación funcional (PE + complemento PPD)
-6. Si pasa → deploy producción ActiGlobal
-7. Subir one_off al servidor producción vía SCP
-8. Dry-run + cleanup en producción
-9. Backup nuevo post-cambio
+### Pendiente inmediato
+1. `/ship push` + `/ship pr`
+2. Grupo 2 (46 dudosos) — procesar con `verify_api=True`
+3. 636 SIs con múltiples Invoice Objects — revisión manual
+4. 611 UUIDs duplicados en dataset — revisar si corresponde misma SI
 
 ### No repetir
-- "99 - Por definir" (con guion) ya no es el estándar — usar "99 Por definir"
-- cleanup_mop_canonical.py requiere dry_run primero antes de ejecución real
-- LlantasCS staging: "99 - Por definir" conservado (tiene 6 FFMs referenciándolo)
-- ignore_links=True nunca en delete_doc de Mode of Payment
+- No correr bench migrate sin --site explícito en este bench compartido
+- No commitear archivos de one_offs/ ni working_docs/
+- No usar python3 directo para operaciones de BD — siempre bench execute
 
 ---
 
 ## Decisiones vigentes
-
-- Estándar único: "NN Descripción" sin guion para Mode of Payment
-- Regex: `^(\d{2}) (?![-\s]).+$` — rechaza guion Y doble espacio/tab
-- Validación PUE: `=== "99 Por definir"` (no startsWith — ver C1 del reporte CodeRabbit)
-- one_off cleanup_mop_canonical.py es el mecanismo para sitios existentes
-- UOM NO cambia fixture — normalización en código ya funciona para ambos formatos
-- Helper centralizado normalize_forma_pago_sat(): pendiente para PR posterior (C2 CodeRabbit)
+- Opción D (A parcial estricta): solo Grupo 1 en primera corrida, Grupo 2 con verify_api después
+- fm_lugar_expedicion = "03810" fijo para LlantasCS (único CSD, sin branches con ZIP)
+- naming_series FFMs históricas: `FFM-HIST-.YYYY.-` para distinguir de timbrado normal
+- db_insert() + docstatus=1 + ignore_validate/mandatory — no .submit() para evitar hooks
+- Grupo 3 (cancelados): 0 detectados en dataset actual
 
 ---
 
-## Riesgos
+## Archivos relevantes ahora
 
-- LlantasCS-v16.dev: "99 - Por definir" tiene 6 FFMs referenciándolo — no se puede
-  eliminar hasta que esas FFMs sean sustituidas o canceladas
-- ActiGlobal producción: requiere SCP del one_off script antes de poder ejecutar cleanup
-- test_issue162 sigue fallando en CI (pre-existente, no causado por este PR)
+### Leer primero
+- `working_docs/active/REPORTE_MIGRACION_GRUPO1_COMPLETO.md` — estado completo Fase 2
+- `facturacion_mexico/one_offs/migrate_ffm_historicas.py` — script principal
+- `facturacion_mexico/one_offs/test_migrate_ffm_historicas.py` — 37 tests + auditoría
+
+### Probablemente editar
+- `migrate_ffm_historicas.py` — para procesar Grupo 2 con verify_api=True
+
+### No tocar
+- `patches.txt` — vacío por diseño, no reactivar patches legacy
+- Archivos en `one_offs/` — no commitear
+
+---
+
+## Riesgos / cuidados
+- 636 SIs con múltiples Invoice Objects excluidas — si se migran manualmente, verificar
+  que el UUID no ya exista en FFM antes de insertar
+- fm_creation_source es Select sin reqd — si queda vacío en FFM nueva, no bloquea timbrado
+  pero rompe la distinción de origen
+
+---
+
+## Información faltante
+- Credenciales FacturAPI producción para llantascs-mig.local (necesarias para descarga PDF/XML)
+- Decisión final sobre 46 casos Grupo 2 (verify_api o descarte)

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,85 +2,90 @@
 
 **Fecha:** 2026-06-14
 **Rama activa:** `feat/ffm-migracion-legacy-fase2`
-**Tarea actual:** Migración histórica FFM legacy → facturacion_mexico (Fase 2 Grupo 1 completo)
+**Tarea actual:** Migración complementos PPD legacy → Complemento Pago MX (fase 2)
 
 ---
 
 ## Recuperación rápida
 
-Estoy trabajando en la migración de CFDIs históricos de `facturacion_mx` (legacy) a
-`facturacion_mexico` (nuevo). El Grupo 1 (10,924 FFMs) está completamente migrado y auditado.
+Estoy trabajando en:
+Migración de Complementos de Pago PPD del sistema legacy `facturacion_mx` al nuevo DocType `Complemento Pago MX` en `facturacion_mexico`. Site de trabajo: `llantascs-mig.local`.
 
 Plan que estoy siguiendo:
-`working_docs/active/REPORTE_MIGRACION_GRUPO1_COMPLETO.md`
+`working_docs/active/PLAN_MIGRACION_COMPLEMENTOS_PPD.md`
 
 Objetivo inmediato:
-Abrir PR para los cambios de código de la Fase 2. Luego procesar pendientes (Grupo 2, duplicados).
+Pendiente decidir con el cliente los casos especiales (PUE, cancelados, mixtos, folios sin legacy).
 
 Criterio de avance:
-PR mergeado + pendientes clasificados para próxima sesión.
+Todos los complementos PPD válidos migrados, pendientes documentados y entregados al cliente.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- Fase 1: 1,790 items (fm_producto_servicio_sat) + 1,432 customers (fm_uso_cfdi_default)
-- Grupo 1 Fase 2: 10,924 FFMs creadas — 0 errores — auditoría 14/14 OK
-- Fix fm_xml_url → Small Text (URLs SAT >140 chars)
-- Fix botón Descargar PDF+XML → descargar_archivos_cfdi() en timbrado_api.py
-- +fm_creation_source en FFM DocType JSON
-- +Método de Pago en widget fiscal de Sales Invoice
+- 3,545 CPMX creados en `llantascs-mig.local` (`COMP-PAY-MX-HIST-2026-00001` a `03545`)
+  - 3,363 Grupo Directo (1 IO, PPD, valid/none, con FFM)
+  - 182 Grupo Multi-IO (PPD vigentes, mismo UUID, confirmados por FacturAPI)
+- Auditoría aprobada: 0 duplicados, 0 errores, 0 PE inválidos
+- Campo `fm_creation_source` en CPMX — commiteado en este turno
+- Documentación actualizada: `arquitectura.md` + `complemento-pago.md`
+- Análisis completo de los 346 multi-IO clasificados y documentados
+- 7 folios faltantes vs FacturAPI investigados y documentados
 
 ### En progreso
-- PR feat/ffm-migracion-legacy-fase2 → pendiente push y apertura
+- Nada en ejecución activa
 
 ### Pendiente inmediato
-1. `/ship push` + `/ship pr`
-2. Grupo 2 (46 dudosos) — procesar con `verify_api=True`
-3. 636 SIs con múltiples Invoice Objects — revisión manual
-4. 611 UUIDs duplicados en dataset — revisar si corresponde misma SI
+1. Entregar al cliente tabla de 25 PUE vigentes para cancelación ante SAT
+2. Cliente decide los 10 PPD cancelados (¿sustituto o definitivo?)
+3. Cliente decide los 5 mixtos PPD+PUE (¿cancelar o mantener?)
+4. Cliente decide P-57, P-2595/2596, P-3235 (folios sin legacy)
+5. Export de fixtures tras bench migrate (campo fm_creation_source en CPMX)
+6. PR de esta rama cuando el cliente haya resuelto los pendientes
 
 ### No repetir
-- No correr bench migrate sin --site explícito en este bench compartido
-- No commitear archivos de one_offs/ ni working_docs/
-- No usar python3 directo para operaciones de BD — siempre bench execute
+- NO crear CPMX sin verificar `fm_es_ppd=1` en todas las SIs del PE
+- NO usar `COUNT(io.name)` para detectar multi-IO cuando hay múltiples SIs (da falso positivo)
+- NO confiar en IO local para estado SAT — siempre verificar FacturAPI para casos con pending/verifying
+- NO restaurar backup sin safe-point previo documentado
+- NO crear archivos nuevos en working_docs/active — solo secciones adicionales al final
 
 ---
 
 ## Decisiones vigentes
-- Opción D (A parcial estricta): solo Grupo 1 en primera corrida, Grupo 2 con verify_api después
-- fm_lugar_expedicion = "03810" fijo para LlantasCS (único CSD, sin branches con ZIP)
-- naming_series FFMs históricas: `FFM-HIST-.YYYY.-` para distinguir de timbrado normal
-- db_insert() + docstatus=1 + ignore_validate/mandatory — no .submit() para evitar hooks
-- Grupo 3 (cancelados): 0 detectados en dataset actual
+- `fm_creation_source = "Migración legacy facturacion_mx"` en todos los CPMX creados por migración
+- `can_cancel` bloqueado para complementos migrados — cancelación solo vía SAT/FacturAPI directa
+- Los 24 PUE 1-IO + 1 PUE multi-IO = 25 en total para cancelación cliente
+- Los 150 PUE multi-IO cancelados en SAT → no requieren acción
+- Site de trabajo: `llantascs-mig.local` (site de migración, no producción)
 
 ---
 
 ## Archivos relevantes ahora
 
 ### Leer primero
-- `working_docs/active/REPORTE_MIGRACION_GRUPO1_COMPLETO.md` — estado completo Fase 2
-- `facturacion_mexico/one_offs/migrate_ffm_historicas.py` — script principal
-- `facturacion_mexico/one_offs/test_migrate_ffm_historicas.py` — 37 tests + auditoría
+- `working_docs/active/PLAN_MIGRACION_COMPLEMENTOS_PPD.md` — estado completo y pendientes
 
 ### Probablemente editar
-- `migrate_ffm_historicas.py` — para procesar Grupo 2 con verify_api=True
+- `facturacion_mexico/fiscal_state/complemento_state.py` — si se ajusta lógica can_cancel
+- `facturacion_mexico/fixtures/custom_field.json` — si se exportan fixtures
 
 ### No tocar
-- `patches.txt` — vacío por diseño, no reactivar patches legacy
-- Archivos en `one_offs/` — no commitear
+- `facturacion_mexico/one_offs/` — scripts temporales, no commitear
+- `patches.txt` — está vacío por diseño (RG-010b)
 
 ---
 
 ## Riesgos / cuidados
-- 636 SIs con múltiples Invoice Objects excluidas — si se migran manualmente, verificar
-  que el UUID no ya exista en FFM antes de insertar
-- fm_creation_source es Select sin reqd — si queda vacío en FFM nueva, no bloquea timbrado
-  pero rompe la distinción de origen
+- `llantascs-mig.local` tiene 3,545 CPMX — cualquier `bench restore` los perdería
+- El campo `fm_creation_source` existe en BD post-migrate pero fixtures aún no exportados
+- P-2595 y P-2596 son posiblemente CFDIs duplicados en FacturAPI para el mismo PE
 
 ---
 
 ## Información faltante
-- Credenciales FacturAPI producción para llantascs-mig.local (necesarias para descarga PDF/XML)
-- Decisión final sobre 46 casos Grupo 2 (verify_api o descarte)
+- Estado de P-57: ¿quién lo emitió directamente en FacturAPI?
+- Decisión del cliente sobre los 10 PPD cancelados sin sustituto
+- Decisión del cliente sobre los 5 mixtos PPD+PUE

--- a/docs/tecnico/arquitectura.md
+++ b/docs/tecnico/arquitectura.md
@@ -106,6 +106,12 @@ Campos relevantes definidos directamente en el JSON del DocType (no como Custom 
 | `fm_sync_status` | Select | Estado sincronización PAC: `synced` / `pending` / `error` |
 | `fm_payment_method_sat` | Select | `PUE` o `PPD` |
 
+### Complemento Pago MX — campos propios del DocType
+
+| Campo | Tipo | Notas |
+|---|---|---|
+| `fm_creation_source` | Select | Origen: `Timbrado directo` / `Migración legacy facturacion_mx` / `Manual`. Solo complementos con `Timbrado directo` permiten cancelación desde la UI. |
+
 ## API endpoints whitelisted — timbrado_api.py
 
 | Función | Módulo | Descripción |

--- a/docs/tecnico/arquitectura.md
+++ b/docs/tecnico/arquitectura.md
@@ -93,6 +93,27 @@ Payment Entry (submit)
 
 ---
 
+## Campos nativos de Factura Fiscal Mexico (DocType JSON)
+
+Campos relevantes definidos directamente en el JSON del DocType (no como Custom Fields):
+
+| Campo | Tipo | Notas |
+|---|---|---|
+| `fm_uuid` | Data | UUID SAT del CFDI |
+| `fm_creation_source` | Select | Origen: `Timbrado directo` / `Migración legacy facturacion_mx` / `Manual`. Default: `Timbrado directo`. Permite identificar FFMs creadas por migración histórica. |
+| `fm_xml_url` | Small Text | URL de verificación SAT (>140 chars — requiere Small Text, no Data) |
+| `fm_serie_folio` | Data | Serie-Folio concatenados (ej: `F-6989`) — usado por complementos PPD |
+| `fm_sync_status` | Select | Estado sincronización PAC: `synced` / `pending` / `error` |
+| `fm_payment_method_sat` | Select | `PUE` o `PPD` |
+
+## API endpoints whitelisted — timbrado_api.py
+
+| Función | Módulo | Descripción |
+|---|---|---|
+| `timbrar_factura` | `timbrado_api` | Timbra CFDI desde SI |
+| `cancelar_factura` | `timbrado_api` | Cancela CFDI con motivo SAT |
+| `descargar_archivos_cfdi` | `timbrado_api` | Descarga PDF+XML desde FacturAPI y los adjunta al FFM. Wrapper de `TimbradoAPI._download_fiscal_files()` — no duplica lógica. |
+
 ## Integraciones externas
 
 | Sistema | Uso | Configuración |

--- a/docs/usuario/complemento-pago.md
+++ b/docs/usuario/complemento-pago.md
@@ -42,6 +42,18 @@ O desde el Payment Entry, campo `fm_complemento_pago` → link al complemento.
 
 ---
 
+## Complementos migrados del sistema legacy
+
+Los complementos creados durante la migración desde `facturacion_mx` muestran
+**Origen de Creación = Migración legacy facturacion_mx** en el campo `fm_creation_source`.
+
+El botón **Cancelar Complemento** no está disponible para estos registros —
+la cancelación debe gestionarse directamente en el portal del SAT o a través del equipo técnico.
+
+Los complementos nuevos creados por el sistema muestran `Timbrado directo` y sí permiten cancelación desde la UI.
+
+---
+
 ## Troubleshooting
 
 **El complemento no se generó al hacer Submit:**

--- a/facturacion_mexico/api/ffm_summary.py
+++ b/facturacion_mexico/api/ffm_summary.py
@@ -43,12 +43,19 @@ def get_ffm_summary(ffm_name: str) -> dict:
 		if not folio_display and doc.get("serie") and doc.get("folio"):
 			folio_display = f"{doc.get('serie')}-{doc.get('folio')}"
 
+		metodo_pago = doc.get("fm_payment_method_sat") or ""
+		metodo_pago_label = {
+			"PUE": "PUE — Pago en una sola exhibición",
+			"PPD": "PPD — Pago en parcialidades o diferido",
+		}.get(metodo_pago, metodo_pago or "-")
+
 		return {
 			"estado": _pick(doc, ALIASES["estado"]),
 			"folio": folio_display,
 			"uuid": _pick(doc, ALIASES["uuid"]),
 			"fecha": _pick(doc, ALIASES["fecha"]),
 			"pac_msg": _pick(doc, ALIASES["pac_msg"]),
+			"metodo_pago": metodo_pago_label,
 			"name": doc.get("name"),
 			"doctype": doc.get("doctype"),
 		}

--- a/facturacion_mexico/catalogos_sat/doctype/uso_cfdi_sat/uso_cfdi_sat.json
+++ b/facturacion_mexico/catalogos_sat/doctype/uso_cfdi_sat/uso_cfdi_sat.json
@@ -106,6 +106,7 @@
   "sort_field": "modified",
   "sort_order": "DESC",
   "states": [],
+  "search_fields": "description",
   "title_field": "description",
   "track_changes": 1
 }

--- a/facturacion_mexico/complementos_pago/api.py
+++ b/facturacion_mexico/complementos_pago/api.py
@@ -66,6 +66,8 @@ def crear_complemento_pago_desde_pe(payment_entry_name: str) -> dict:
 	if complemento.moneda_p != "MXN":
 		complemento.tipo_cambio_p = flt(pe.get("source_exchange_rate") or 1.0)
 
+	complemento.fm_creation_source = "Timbrado directo"
+
 	# num_operacion — referencia bancaria opcional
 	if pe.get("reference_no"):
 		complemento.num_operacion = pe.reference_no

--- a/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.json
+++ b/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.json
@@ -53,7 +53,8 @@
   "section_impuestos",
   "detalles_impuestos",
   "naming_series",
-  "amended_from"
+  "amended_from",
+  "fm_creation_source"
  ],
  "fields": [
   {
@@ -358,12 +359,21 @@
    "options": "Complemento Pago MX",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "fm_creation_source",
+   "fieldtype": "Select",
+   "label": "Origen de Creación",
+   "options": "\nTimbrado directo\nMigración legacy facturacion_mx\nManual",
+   "default": "Timbrado directo",
+   "allow_on_submit": 1,
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-05-06 00:00:00.000000",
+ "modified": "2026-06-14 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Complementos Pago",
  "name": "Complemento Pago MX",

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -228,13 +228,10 @@
 				async () => {
 					try {
 						await frappe.call({
-							method: "facturacion_mexico.facturacion_fiscal.api_client.download_xml",
+							method: "facturacion_mexico.facturacion_fiscal.timbrado_api.descargar_archivos_cfdi",
 							args: { ffm_name: frm.doc.name },
 						});
-						await frappe.call({
-							method: "facturacion_mexico.facturacion_fiscal.api_client.download_pdf",
-							args: { ffm_name: frm.doc.name },
-						});
+						frm.reload_doc();
 					} catch (e) {
 						frappe.msgprint({
 							title: __("Error de descarga"),

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -61,7 +61,8 @@
   "section_break_urls_archivos",
   "fm_xml_url",
   "fm_pdf_url",
-  "fm_last_response_log"
+  "fm_last_response_log",
+  "fm_creation_source"
  ],
  "fields": [
   {
@@ -422,9 +423,9 @@
   },
   {
    "fieldname": "fm_xml_url",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "URL del XML",
-   "description": "Link directo al archivo XML",
+   "description": "Link directo al archivo XML o URL de verificación SAT",
    "allow_on_submit": 1,
    "read_only": 1
   },
@@ -444,6 +445,16 @@
    "description": "Referencia al último log de FacturAPI",
    "allow_on_submit": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "fm_creation_source",
+   "fieldtype": "Select",
+   "label": "Origen de Creación",
+   "options": "\nTimbrado directo\nMigración legacy facturacion_mx\nManual",
+   "default": "Timbrado directo",
+   "allow_on_submit": 1,
+   "read_only": 1,
+   "in_list_view": 0
   }
  ],
  "index_web_pages_for_search": 1,

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -2502,6 +2502,18 @@ def _build_cancellation_reason_for_select(motive_code: str) -> str:
 
 # API endpoints para uso desde interfaz
 @frappe.whitelist()
+def descargar_archivos_cfdi(ffm_name: str):
+	"""Descarga PDF y XML del CFDI desde FacturAPI y los adjunta al FFM."""
+	ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
+	if not ffm.facturapi_id:
+		frappe.throw(_("Este CFDI no tiene ID de FacturAPI — no se puede descargar."))
+	company = ffm.company or frappe.db.get_value("Sales Invoice", ffm.sales_invoice, "company")
+	api = TimbradoAPI(company=company)
+	api._download_fiscal_files(ffm, ffm.facturapi_id)
+	return {"success": True}
+
+
+@frappe.whitelist()
 def timbrar_factura(sales_invoice: str):
 	"""API para timbrar factura desde interfaz."""
 	cache_key = f"si:timbrando:{sales_invoice}"

--- a/facturacion_mexico/fiscal_state/complemento_state.py
+++ b/facturacion_mexico/fiscal_state/complemento_state.py
@@ -113,7 +113,7 @@ def _compute_actions(facts: dict) -> dict:
 		facts["is_submitted"]
 		and facts["is_timbrado"]
 		and facts["has_uuid"]
-		and facts["fm_creation_source"] == "Timbrado directo"
+		and facts.get("fm_creation_source", "Timbrado directo") == "Timbrado directo"
 	)
 
 	can_retry_cancel = facts["is_submitted"] and facts["is_pendiente_cancelacion"]

--- a/facturacion_mexico/fiscal_state/complemento_state.py
+++ b/facturacion_mexico/fiscal_state/complemento_state.py
@@ -75,6 +75,8 @@ def _compute_facts(comp) -> dict:
 		"forma_pago_p": comp.get("forma_pago_p") or "",
 		# ── Documentos relacionados ───────────────────────────────────────
 		"has_documentos_relacionados": bool(comp.get("documentos_relacionados")),
+		# ── Origen de creación ───────────────────────────────────────────
+		"fm_creation_source": comp.get("fm_creation_source") or "",
 	}
 
 	# ── PE activo o cancelado (para contexto) ────────────────────────────
@@ -107,7 +109,12 @@ def _compute_actions(facts: dict) -> dict:
 
 	can_stamp = facts["is_draft"] and facts["status"] in _TIMBRABLE_STATUSES
 
-	can_cancel = facts["is_submitted"] and facts["is_timbrado"] and facts["has_uuid"]
+	can_cancel = (
+		facts["is_submitted"]
+		and facts["is_timbrado"]
+		and facts["has_uuid"]
+		and facts["fm_creation_source"] == "Timbrado directo"
+	)
 
 	can_retry_cancel = facts["is_submitted"] and facts["is_pendiente_cancelacion"]
 

--- a/facturacion_mexico/public/js/sales_invoice_ffm_summary.js
+++ b/facturacion_mexico/public/js/sales_invoice_ffm_summary.js
@@ -53,6 +53,9 @@ function inject_ffm_summary(frm) {
 					<div><strong>Fecha Timbrado:</strong>
 						${d.fecha ? frappe.datetime.str_to_user(d.fecha) : "-"}
 					</div>
+					<div><strong>Método de Pago:</strong>
+						<span>${frappe.utils.escape_html(d.metodo_pago || "-")}</span>
+					</div>
 					<div><strong>Estado PAC:</strong>
 						${
 							d.pac_msg


### PR DESCRIPTION
## Objetivo

Introducir trazabilidad de origen (`fm_creation_source`) en Factura Fiscal Mexico y
Complemento Pago MX para distinguir entre documentos timbrados nativamente y los
migrados desde el sistema legacy `facturacion_mx`. Corregir descarga de PDF/XML y
mejorar el widget fiscal en Sales Invoice.

## Cambios principales

### Commit 4799ef9 — FFM: fm_creation_source + fix PDF/XML + mejoras widget
- `fm_creation_source` (Select, read_only) en Factura Fiscal Mexico: Timbrado directo / Migración legacy facturacion_mx / Manual
- `fm_xml_url` cambiado a Small Text (URLs SAT >140 chars no caben en Data)
- `descargar_archivos_cfdi()` implementado — botón PDF/XML ahora funcional
- Widget fiscal en Sales Invoice muestra Método de Pago SAT
- `search_fields` añadido a Uso CFDI SAT para búsqueda por texto

### Commit 5c42394 — CPMX: fm_creation_source + restricción cancelación migrados
- `fm_creation_source` en Complemento Pago MX (mismas opciones que FFM)
- `can_cancel` en `complemento_state.py` restringido a `Timbrado directo`: complementos migrados del legacy no muestran el botón Cancelar en UI
- `api.py`: nuevos complementos se marcan automáticamente como `Timbrado directo`

## Documentación actualizada
- `docs/tecnico/arquitectura.md` — campos propios de FFM y CPMX
- `docs/usuario/complemento-pago.md` — nota sobre complementos migrados y cancelación
- `docs/referencia/api.md`, `docs/usuario/emitir-cfdi.md` — descarga PDF/XML

## Validaciones realizadas
- `bench migrate` corrió limpio en `llantascs-mig.local`
- `ruff check` + `ruff format` sin errores en archivos Python
- `mkdocs build --strict` sin errores ni warnings
- 3,545 Complemento Pago MX migrados con `fm_creation_source = "Migración legacy facturacion_mx"` y auditoría aprobada (0 duplicados, 0 campos críticos vacíos)

## Fuera de alcance
- Migración de datos en `llantascs-mig.local` (BD del site de migración — no va en código)
- Resolución de casos pendientes/requieren decisión del cliente en la migración local

## Riesgos / pendientes
- Requiere `bench migrate` al instalar (campo nuevo en Complemento Pago MX y Factura Fiscal Mexico)
- Los complementos migrados con `can_cancel = False` no pueden cancelarse desde UI — debe gestionarse directamente vía FacturAPI o portal SAT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Payment method now displays in invoice summary view
* Combined PDF and XML file downloads into a single streamlined operation

**Behavioral Changes**
* Payment complements migrated from the legacy system can no longer be cancelled through the UI; newly created complements support full cancellation functionality

**Documentation**
* Added user guide for payment complement migration behavior and workflows
* Added technical reference for Mexican invoicing system architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->