### PR TITLE
fix(prod): fixes post go-live LlantasCS — timbrado, CPMX email y cancelación

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,8 +1,8 @@
 # CONTINUITY.md — facturacion_mexico
 
 **Fecha:** 2026-06-15
-**Rama activa:** `feat/ffm-migracion-legacy-fase2`
-**Tarea actual:** PR abierto — feat/ffm-migracion-legacy-fase2 → main
+**Rama activa:** `fix/facturapi-response-log-permissions`
+**Tarea actual:** Fix urgente producción — PermissionError en insert de FacturAPI Response Log al timbrar FFM
 
 ---
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-06-15
 **Rama activa:** `fix/facturapi-response-log-permissions`
-**Tarea actual:** Fix urgente producción — PermissionError en insert de FacturAPI Response Log al timbrar FFM
+**Tarea actual:** Fixes producción post go-live + feat: email en Complemento Pago MX
 
 ---
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-06-15
 **Rama activa:** `fix/facturapi-response-log-permissions`
-**Tarea actual:** Fixes producción post go-live + feat: email en Complemento Pago MX
+**Tarea actual:** PR abierto — fix/facturapi-response-log-permissions → main (fixes post go-live LlantasCS)
 
 ---
 

--- a/docs/usuario/complemento-pago.md
+++ b/docs/usuario/complemento-pago.md
@@ -54,6 +54,22 @@ Los complementos nuevos creados por el sistema muestran `Timbrado directo` y sí
 
 ---
 
+## Enviar complemento por email
+
+Desde el Complemento Pago MX timbrado, el menú **Comprobantes** incluye el botón
+**Enviar por email**.
+
+El sistema envía el CFDI tipo P directamente al cliente vía FacturAPI. El destinatario
+se resuelve en este orden:
+
+1. Email del contacto en el Payment Entry
+2. Email del cliente (`Customer.email_id`)
+
+Si no hay destinatario, aparece un aviso naranja. En ese caso, configura el email
+en el cliente o el Payment Entry y vuelve a intentarlo.
+
+---
+
 ## Troubleshooting
 
 **El complemento no se generó al hacer Submit:**

--- a/facturacion_mexico/complementos_pago/api.py
+++ b/facturacion_mexico/complementos_pago/api.py
@@ -539,6 +539,12 @@ def action_send_email_complemento(complemento_name: str, to: str | None = None) 
 	comp = frappe.get_doc("Complemento Pago MX", complemento_name)
 	frappe.has_permission(doctype="Complemento Pago MX", ptype="write", doc=comp, throw=True)
 
+	if comp.status != "Timbrado":
+		frappe.throw(
+			_("Solo se puede enviar por email un complemento en estado Timbrado. Estado actual: {0}").format(
+				comp.status
+			)
+		)
 	if not comp.uuid_sat:
 		frappe.throw(_("El complemento no está timbrado (no tiene UUID)."))
 	if not comp.facturapi_id:

--- a/facturacion_mexico/complementos_pago/api.py
+++ b/facturacion_mexico/complementos_pago/api.py
@@ -534,6 +534,47 @@ def revisar_estatus_cancelacion_complemento(complemento_name: str) -> dict:
 
 
 @frappe.whitelist()
+def action_send_email_complemento(complemento_name: str, to: str | None = None) -> dict:
+	"""Envía el Complemento de Pago por email via FacturAPI. Equivalente al botón en FFM."""
+	comp = frappe.get_doc("Complemento Pago MX", complemento_name)
+	frappe.has_permission(doctype="Complemento Pago MX", ptype="write", doc=comp, throw=True)
+
+	if not comp.uuid_sat:
+		frappe.throw(_("El complemento no está timbrado (no tiene UUID)."))
+	if not comp.facturapi_id:
+		frappe.throw(_("El complemento no tiene ID de FacturAPI."))
+
+	to_email = to
+	if not to_email:
+		to_email = (
+			frappe.db.get_value("Payment Entry", comp.payment_entry, "contact_email")
+			if comp.payment_entry
+			else None
+		)
+	if not to_email:
+		customer = (
+			frappe.db.get_value("Payment Entry", comp.payment_entry, "party") if comp.payment_entry else None
+		)
+		if customer:
+			to_email = frappe.db.get_value("Customer", customer, "email_id")
+
+	if not to_email:
+		comp.add_comment("Comment", "No se envió complemento: no hay destinatario.")
+		return {"sent": False, "reason": "no-recipient"}
+
+	try:
+		from facturacion_mexico.facturacion_fiscal.api_client import get_facturapi_client
+
+		client = get_facturapi_client()
+		client.send_invoice_email(comp.facturapi_id, to_email)
+		comp.add_comment("Comment", f"Complemento enviado por email a: {to_email}")
+		return {"sent": True, "to": to_email}
+	except Exception as e:
+		comp.add_comment("Comment", f"Error al enviar complemento por email: {e}")
+		return {"sent": False, "error": str(e)}
+
+
+@frappe.whitelist()
 def descargar_archivos_complemento(complemento_name: str) -> dict:
 	"""Descarga manual de PDF/XML — equivalente al botón en FFM."""
 	comp = frappe.get_doc("Complemento Pago MX", complemento_name)

--- a/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
+++ b/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
@@ -79,17 +79,39 @@ function _setup_status_indicators(frm) {
 function _hide_standard_actions(frm) {
 	if (frm.page && frm.page.btn_primary) frm.page.btn_primary.addClass("hidden");
 	frm.page.wrapper.find('.btn[data-label="Submit"]').addClass("hidden");
-	if (frm.page && frm.page.btn_cancel) frm.page.btn_cancel.addClass("hidden");
-	frm.page.wrapper.find('.btn[data-label="Cancel"]').addClass("hidden");
-	frm.page.wrapper
-		.find('.btn[data-label="Amend"], .btn[data-label="Corregir"]')
-		.addClass("hidden");
-	frm.page.wrapper
-		.find(
-			'.menu-items .dropdown-item:contains("Amend"), .menu-items .dropdown-item:contains("Corregir")'
-		)
-		.addClass("disabled")
-		.css("pointer-events", "none");
+
+	// Eliminar botón nativo Cancel/Cancelar — la cancelación fiscal va por el botón custom.
+	// Frappe puede reinyectarlo tras renders asíncronos, por eso se ejecuta 3 veces.
+	const nukeCancel = () => {
+		try {
+			frm.perm ||= [];
+			frm.perm[0] ||= {};
+			frm.perm[0].cancel = 0;
+			frm.perm[0].amend = 0;
+			frm.toolbar && frm.toolbar.refresh && frm.toolbar.refresh();
+
+			frm.page.remove_menu_item && frm.page.remove_menu_item("Cancel");
+			frm.page.remove_menu_item && frm.page.remove_menu_item(__("Cancel"));
+			frm.page.remove_menu_item && frm.page.remove_menu_item("Cancelar");
+			frm.page.remove_menu_item && frm.page.remove_menu_item("Amend");
+			frm.page.remove_menu_item && frm.page.remove_menu_item(__("Amend"));
+			frm.page.remove_menu_item && frm.page.remove_menu_item(__("Corregir"));
+
+			const $menu = frm.page.menu || frm.page.actions_menu;
+			if ($menu && $menu.length) {
+				$menu.find("a, .dropdown-item, .menu-item").each(function () {
+					const t = (this.innerText || "").trim().toUpperCase();
+					if (["CANCEL", "CANCELAR", "AMEND", "CORREGIR"].includes(t)) this.remove();
+				});
+			}
+		} catch (e) {
+			/* ignorar */
+		}
+	};
+
+	nukeCancel();
+	setTimeout(nukeCancel, 0);
+	frappe.after_ajax && frappe.after_ajax(nukeCancel);
 }
 
 // ── Botones — callbacks sin cambio ─────────────────────────────────────────

--- a/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
+++ b/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
@@ -29,6 +29,7 @@ function _apply_buttons(frm, actions) {
 	if (actions.can_retry_cancel) _setup_revisar_estatus_btn(frm);
 	if (actions.can_cancel) _setup_cancelar_btn(frm);
 	if (actions.can_download_xml || actions.can_download_pdf) _setup_descargar_btn(frm);
+	if (actions.can_send_email) _setup_email_btn(frm);
 }
 
 // ── Aplicar mensajes desde fiscal_state ────────────────────────────────────
@@ -203,6 +204,42 @@ function _setup_cancelar_btn(frm) {
 			__("Solicitar")
 		);
 	}).addClass("btn-danger");
+}
+
+function _setup_email_btn(frm) {
+	frm.add_custom_button(
+		__("Enviar por email"),
+		async () => {
+			try {
+				const r = await frappe.call({
+					method: "facturacion_mexico.complementos_pago.api.action_send_email_complemento",
+					args: { complemento_name: frm.doc.name, to: null },
+				});
+				const res = r && r.message;
+				if (res && res.sent) {
+					frappe.msgprint({
+						message: __("Complemento enviado a: {0}", [res.to]),
+						indicator: "green",
+					});
+				} else if (res && res.reason === "no-recipient") {
+					frappe.msgprint({
+						message: __(
+							"No se envió: no hay destinatario en el Payment Entry ni en el cliente."
+						),
+						indicator: "orange",
+					});
+				} else {
+					frappe.msgprint({
+						message: __("No se pudo enviar: {0}", [(res && res.error) || ""]),
+						indicator: "red",
+					});
+				}
+			} catch (e) {
+				frappe.msgprint({ message: __(String(e)), indicator: "red" });
+			}
+		},
+		__("Comprobantes")
+	);
 }
 
 function _setup_descargar_btn(frm) {

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -307,7 +307,7 @@ class PACResponseWriter:
 			}
 		)
 
-		response_log.insert()
+		response_log.insert(ignore_permissions=True)
 
 		# Adjuntar JSON response como File para compatibilidad dfp_external_storage
 		try:

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -650,9 +650,7 @@ class FacturaFiscalMexico(Document):
 		try:
 			import json
 
-			from facturacion_mexico.facturacion_fiscal.doctype.facturapi_response_log.facturapi_response_log import (
-				write_pac_response,
-			)
+			from facturacion_mexico.facturacion_fiscal.api import write_pac_response
 
 			write_pac_response(
 				self.sales_invoice or self.name,

--- a/facturacion_mexico/fiscal_state/complemento_state.py
+++ b/facturacion_mexico/fiscal_state/complemento_state.py
@@ -125,6 +125,7 @@ def _compute_actions(facts: dict) -> dict:
 		# has_facturapi_id requerido: descargar_archivos_complemento lanza si falta
 		"can_download_xml": facts["has_uuid"] and facts["has_facturapi_id"],
 		"can_download_pdf": facts["has_uuid"] and facts["has_facturapi_id"],
+		"can_send_email": facts["has_uuid"] and facts["has_facturapi_id"],
 		"can_view_payment_entry": facts["has_payment_entry"],
 	}
 


### PR DESCRIPTION
## Objetivo

Corregir 3 defectos detectados en producción (erpstar.llantascs.com) durante la primera
semana de operación post go-live del 15 de junio de 2026, y agregar funcionalidad de
email en Complemento Pago MX equivalente a la existente en FFM.

## Cambios principales

### fix: PermissionError en FacturAPI Response Log al timbrar FFM (`fad249d`)
- `facturacion_fiscal/api/__init__.py`: `response_log.insert(ignore_permissions=True)`
- `factura_fiscal_mexico.py`: corrige import de `write_pac_response` (apuntaba al
  controlador del DocType en lugar de `facturacion_fiscal.api`)
- Causa raíz: FFM nunca tuvo `ignore_permissions=True` en el insert del log — los
  complementos sí lo tenían. Usuario no-Administrator (Karla) no tenía permiso de create
  en FacturAPI Response Log, bloqueando el registro del timbrado y dejando FFM en
  estado "Sincronizando con PAC".

### feat: botón "Enviar por email" en Complemento Pago MX (`2621279`)
- `complemento_state.py`: nueva acción `can_send_email`
- `complementos_pago/api.py`: `action_send_email_complemento()` whitelisted
- `complemento_pago_mx.js`: botón en grupo "Comprobantes"
- Reutiliza `FacturAPIClient.send_invoice_email()` — mismo endpoint que FFM

### fix: botón nativo Cancel de Frappe visible en CPMX timbrado (`696ec38`)
- `complemento_pago_mx.js`: adopta el mismo patrón agresivo de FFM para eliminar
  el botón nativo (frm.perm[0].cancel + remove_menu_item + setTimeout + after_ajax)
- El `addClass("hidden")` anterior no era suficiente — Frappe lo reinyecta tras
  renders asíncronos

## Documentación actualizada
- `docs/usuario/complemento-pago.md`: sección "Enviar complemento por email"

## Validaciones realizadas
- Revisión de código: diff verificado contra patrón FFM existente
- No ejecutado: tests unitarios (no aplica para estos cambios de permisos/UI)

## Fuera de alcance
- DocPerm formal de FacturAPI Response Log para Facturacion Mexico User
  (la solución con ignore_permissions es preferible — el log es interno del sistema)

## Riesgos / pendientes
- Ninguno. Los 3 fixes son conservadores y alineados con patrones existentes en FFM.
- Requiere `bench build --app facturacion_mexico` en producción para actualizar JS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to send Payment Complement (Complemento Pago MX) via email from stamped CFDI documents.
  * New "Send by Email" button in the user interface for Payment Complement records.

* **Documentation**
  * Added user guide section explaining how to send Payment Complement by email, including email recipient resolution and error handling.

* **Bug Fixes**
  * Improved permission handling for PAC response logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->