### PR TITLE
fix(prod): correcciones post go-live LlantasCS — UI CPMX y pdf_custom_section

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,91 +1,72 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-06-18
-**Rama activa:** `fix/facturapi-response-log-permissions`
-**Tarea actual:** PR abierto — fix/facturapi-response-log-permissions → main (fixes post go-live LlantasCS)
+**Fecha:** 2026-06-19
+**Rama activa:** `fix/post-golive-corrections`
+**Tarea actual:** Correcciones post go-live LlantasCS — PDF custom section + fixes UI
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Migración de Complementos de Pago PPD del sistema legacy `facturacion_mx` al nuevo DocType `Complemento Pago MX` en `facturacion_mexico`. Site de trabajo: `llantascs-mig.local`.
+Rama `fix/post-golive-corrections` con múltiples correcciones post go-live para LlantasCS.
+Se está haciendo commit del feature `pdf_custom_section` ahora mismo.
 
 Plan que estoy siguiendo:
-`working_docs/active/PLAN_MIGRACION_COMPLEMENTOS_PPD.md`
+Correcciones incrementales sin plan doc — cada fix se commitea en esta rama y al final va a PR.
 
 Objetivo inmediato:
-Pendiente decidir con el cliente los casos especiales (PUE, cancelados, mixtos, folios sin legacy).
+Commitear `pdf_custom_section` y continuar con más correcciones en la misma rama.
 
 Criterio de avance:
-Todos los complementos PPD válidos migrados, pendientes documentados y entregados al cliente.
+Cuando no haya más correcciones pendientes, abrir PR de esta rama a main.
 
 ---
 
 ## Estado actual
 
-### Ya cerrado
-- 3,545 CPMX creados en `llantascs-mig.local` (`COMP-PAY-MX-HIST-2026-00001` a `03545`)
-  - 3,363 Grupo Directo (1 IO, PPD, valid/none, con FFM)
-  - 182 Grupo Multi-IO (PPD vigentes, mismo UUID, confirmados por FacturAPI)
-- Auditoría aprobada: 0 duplicados, 0 errores, 0 PE inválidos
-- Campo `fm_creation_source` en CPMX — commiteado en este turno
-- Documentación actualizada: `arquitectura.md` + `complemento-pago.md`
-- Análisis completo de los 346 multi-IO clasificados y documentados
-- 7 folios faltantes vs FacturAPI investigados y documentados
+### Ya cerrado (en esta rama)
+- Commit `1b4f82e`: botón "Descargar PDF+XML" movido al grupo "Comprobantes" en CPMX
 
 ### En progreso
-- Nada en ejecución activa
+- `pdf_custom_section`: listo para commit — 17/17 tests, docs actualizados, persistencia
+  solo en timbrado exitoso, sin textos hardcoded
 
 ### Pendiente inmediato
-1. Entregar al cliente tabla de 25 PUE vigentes para cancelación ante SAT
-2. Cliente decide los 10 PPD cancelados (¿sustituto o definitivo?)
-3. Cliente decide los 5 mixtos PPD+PUE (¿cancelar o mantener?)
-4. Cliente decide P-57, P-2595/2596, P-3235 (folios sin legacy)
-5. Export de fixtures tras bench migrate (campo fm_creation_source en CPMX)
-6. PR de esta rama cuando el cliente haya resuelto los pendientes
+1. Commit de `pdf_custom_section` (este turno)
+2. Más correcciones pendientes por definir
+3. PR final de `fix/post-golive-corrections` → main
 
 ### No repetir
-- NO crear CPMX sin verificar `fm_es_ppd=1` en todas las SIs del PE
-- NO usar `COUNT(io.name)` para detectar multi-IO cuando hay múltiples SIs (da falso positivo)
-- NO confiar en IO local para estado SAT — siempre verificar FacturAPI para casos con pending/verifying
-- NO restaurar backup sin safe-point previo documentado
-- NO crear archivos nuevos en working_docs/active — solo secciones adicionales al final
+- NO persistir `fm_pdf_custom_section` en el build del payload — solo en `_process_timbrado_success`
+- NO crear Custom Fields para `pdf_nota_pue`/`pdf_nota_ppd` — son campos nativos del DocType
+- NO hardcodear textos PUE/PPD en código — la config es por empresa en Company Settings
 
 ---
 
 ## Decisiones vigentes
-- `fm_creation_source = "Migración legacy facturacion_mx"` en todos los CPMX creados por migración
-- `can_cancel` bloqueado para complementos migrados — cancelación solo vía SAT/FacturAPI directa
-- Los 24 PUE 1-IO + 1 PUE multi-IO = 25 en total para cancelación cliente
-- Los 150 PUE multi-IO cancelados en SAT → no requieren acción
-- Site de trabajo: `llantascs-mig.local` (site de migración, no producción)
+- `pdf_custom_section` solo para CFDI tipo I — tipos E y P quedan sin este campo
+- Sin defaults en `pdf_nota_pue` y `pdf_nota_ppd` — vacío = no enviar
+- Cascada de resolución: Solo Company Settings (sin Customer ni SI override)
+- Template PPD validado en `validate()` de Company Settings — placeholder desconocido = error
+- `_pending_pdf_custom_section` como atributo de instancia para diferir la persistencia
 
 ---
 
 ## Archivos relevantes ahora
 
 ### Leer primero
-- `working_docs/active/PLAN_MIGRACION_COMPLEMENTOS_PPD.md` — estado completo y pendientes
+- `facturacion_fiscal/timbrado_api.py` — funciones `_build_pdf_custom_section`, `_persist_pdf_custom_section`, bloque `_process_timbrado_success`
 
 ### Probablemente editar
-- `facturacion_mexico/fiscal_state/complemento_state.py` — si se ajusta lógica can_cancel
-- `facturacion_mexico/fixtures/custom_field.json` — si se exportan fixtures
+- `facturacion_fiscal/doctype/facturacion_mexico_company_settings/` — si se ajustan campos
 
 ### No tocar
-- `facturacion_mexico/one_offs/` — scripts temporales, no commitear
-- `patches.txt` — está vacío por diseño (RG-010b)
+- `patches.txt` — vacío por diseño (RG-010b)
+- `one_offs/` — no commitear
 
 ---
 
 ## Riesgos / cuidados
-- `llantascs-mig.local` tiene 3,545 CPMX — cualquier `bench restore` los perdería
-- El campo `fm_creation_source` existe en BD post-migrate pero fixtures aún no exportados
-- P-2595 y P-2596 son posiblemente CFDIs duplicados en FacturAPI para el mismo PE
-
----
-
-## Información faltante
-- Estado de P-57: ¿quién lo emitió directamente en FacturAPI?
-- Decisión del cliente sobre los 10 PPD cancelados sin sustituto
-- Decisión del cliente sobre los 5 mixtos PPD+PUE
+- `llantascs-mig.local` (8409) tiene encryption key diferente al backup — re-ingresar API keys manualmente
+- `_pending_pdf_custom_section` queda como atributo de instancia si el timbrado es exitoso pero `_process_timbrado_success` falla antes de limpiar — no es crítico (el atributo se pierde con la instancia)

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,6 +1,6 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-06-15
+**Fecha:** 2026-06-18
 **Rama activa:** `fix/facturapi-response-log-permissions`
 **Tarea actual:** PR abierto — fix/facturapi-response-log-permissions → main (fixes post go-live LlantasCS)
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,64 +2,63 @@
 
 **Fecha:** 2026-06-19
 **Rama activa:** `fix/post-golive-corrections`
-**Tarea actual:** Correcciones post go-live LlantasCS — PDF custom section + fixes UI
+**Tarea actual:** PR abierto — fix/post-golive-corrections → main
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Rama `fix/post-golive-corrections` con múltiples correcciones post go-live para LlantasCS.
-Se está haciendo commit del feature `pdf_custom_section` ahora mismo.
+PR de correcciones post go-live LlantasCS — UI CPMX y pdf_custom_section configurable.
 
 Plan que estoy siguiendo:
-Correcciones incrementales sin plan doc — cada fix se commitea en esta rama y al final va a PR.
+PR #195 (o el número asignado) — esperando review de CodeRabbit y merge.
 
 Objetivo inmediato:
-Commitear `pdf_custom_section` y continuar con más correcciones en la misma rama.
+Merge del PR y deploy en producción (erpstar.llantascs.com).
 
 Criterio de avance:
-Cuando no haya más correcciones pendientes, abrir PR de esta rama a main.
+PR mergeado, bench migrate en producción, textos PPD/PUE configurados en Company Settings de LlantasCS.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado (en esta rama)
-- Commit `1b4f82e`: botón "Descargar PDF+XML" movido al grupo "Comprobantes" en CPMX
+- `1b4f82e` fix(cpmx): botón "Descargar PDF+XML" movido al grupo "Comprobantes"
+- `5cedd69` feat(timbrado): pdf_custom_section configurable por empresa (17/17 tests)
+- `5ac431b` docs(usuario): sección "Contenido PDF del CFDI" en getting-started
+- `ca5bb73` docs(usuario): corrección — sin textos prescriptivos ni recomendados
 
 ### En progreso
-- `pdf_custom_section`: listo para commit — 17/17 tests, docs actualizados, persistencia
-  solo en timbrado exitoso, sin textos hardcoded
+- PR abierto — esperando CodeRabbit y autorización de merge
 
 ### Pendiente inmediato
-1. Commit de `pdf_custom_section` (este turno)
-2. Más correcciones pendientes por definir
-3. PR final de `fix/post-golive-corrections` → main
+1. Merge del PR
+2. Deploy: `bench migrate` en erpstar.llantascs.com
+3. Configurar manualmente textos PUE/PPD en Company Settings de LlantasCS
 
 ### No repetir
-- NO persistir `fm_pdf_custom_section` en el build del payload — solo en `_process_timbrado_success`
-- NO crear Custom Fields para `pdf_nota_pue`/`pdf_nota_ppd` — son campos nativos del DocType
-- NO hardcodear textos PUE/PPD en código — la config es por empresa en Company Settings
+- NO persistir `fm_pdf_custom_section` en el payload — solo en `_process_timbrado_success`
+- NO incluir textos específicos del cliente en docs generales del app
+- NO hardcodear leyendas PUE/PPD en código
 
 ---
 
 ## Decisiones vigentes
-- `pdf_custom_section` solo para CFDI tipo I — tipos E y P quedan sin este campo
-- Sin defaults en `pdf_nota_pue` y `pdf_nota_ppd` — vacío = no enviar
-- Cascada de resolución: Solo Company Settings (sin Customer ni SI override)
-- Template PPD validado en `validate()` de Company Settings — placeholder desconocido = error
-- `_pending_pdf_custom_section` como atributo de instancia para diferir la persistencia
+- `pdf_custom_section` solo para CFDI tipo I
+- Sin defaults en pdf_nota_pue/ppd — vacío = no enviar
+- Solo Company Settings (sin Customer ni SI override)
+- Template PPD validado al guardar (placeholder desconocido = ValidationError)
+- Persistencia solo en timbrado exitoso
 
 ---
 
 ## Archivos relevantes ahora
 
 ### Leer primero
-- `facturacion_fiscal/timbrado_api.py` — funciones `_build_pdf_custom_section`, `_persist_pdf_custom_section`, bloque `_process_timbrado_success`
-
-### Probablemente editar
-- `facturacion_fiscal/doctype/facturacion_mexico_company_settings/` — si se ajustan campos
+- `facturacion_fiscal/timbrado_api.py` — `_build_pdf_custom_section`, `_process_timbrado_success`
+- `docs/usuario/getting-started.md` — sección "Contenido PDF del CFDI"
 
 ### No tocar
 - `patches.txt` — vacío por diseño (RG-010b)
@@ -68,5 +67,6 @@ Cuando no haya más correcciones pendientes, abrir PR de esta rama a main.
 ---
 
 ## Riesgos / cuidados
-- `llantascs-mig.local` (8409) tiene encryption key diferente al backup — re-ingresar API keys manualmente
-- `_pending_pdf_custom_section` queda como atributo de instancia si el timbrado es exitoso pero `_process_timbrado_success` falla antes de limpiar — no es crítico (el atributo se pierde con la instancia)
+- Requiere `bench migrate` en producción al deployar — sin esto los campos no existen en BD
+- LlantasCS debe configurar manualmente sus textos PPD/PUE en Company Settings
+- `llantascs-mig.local` (8409) tiene encryption key distinta — API keys deben re-ingresarse

--- a/docs/tecnico/arquitectura.md
+++ b/docs/tecnico/arquitectura.md
@@ -105,6 +105,7 @@ Campos relevantes definidos directamente en el JSON del DocType (no como Custom 
 | `fm_serie_folio` | Data | Serie-Folio concatenados (ej: `F-6989`) — usado por complementos PPD |
 | `fm_sync_status` | Select | Estado sincronización PAC: `synced` / `pending` / `error` |
 | `fm_payment_method_sat` | Select | `PUE` o `PPD` |
+| `fm_pdf_custom_section` | Long Text | Texto enviado a FacturAPI como `pdf_custom_section` al timbrar. Read-only — registra exactamente lo enviado. Solo para CFDI tipo I. |
 
 ### Complemento Pago MX — campos propios del DocType
 
@@ -155,6 +156,37 @@ El app crea automáticamente grupos raíz y subgrupos de categorización fiscal.
 | `Artículos IEPS Tabaco` | Cigarros, Puros, Tabaco labrado |
 
 Los subgrupos se crean idempotentemente en cada `bench migrate` — nunca se modifican ni borran grupos existentes.
+
+---
+
+## pdf_custom_section — contenido adicional en PDF del CFDI
+
+Campo de FacturAPI que aparece en el PDF generado del CFDI. **No modifica el XML ni el timbrado fiscal.**
+
+### Configuración
+
+En `Facturacion Mexico Company Settings` (por empresa):
+
+| Campo | Descripción |
+|---|---|
+| `pdf_nota_pue` | Leyenda para CFDI PUE. Vacío = omitir. |
+| `pdf_nota_ppd` | Leyenda para CFDI PPD. Variables: `{company}`, `{total}`, `{due_date}`. Vacío = omitir. |
+| `pdf_incluir_po_no` | Incluir `Sales Invoice.po_no` si existe. |
+| `pdf_incluir_remarks` | Incluir `Sales Invoice.remarks` si no es vacío ni valor legacy. |
+
+### Comportamiento
+
+- Solo se construye y envía para CFDI tipo `I` (ingreso). Para `E` y `P` no se incluye.
+- Si el resultado es cadena vacía, la propiedad se omite del payload (no se envía `null`).
+- El texto exacto enviado se persiste en `Factura Fiscal Mexico.fm_pdf_custom_section` (read-only).
+- Un cambio posterior en Company Settings no modifica FFMs ya timbrados.
+- El template PPD se valida al guardar Company Settings — placeholders desconocidos lanzan `ValidationError`.
+
+### Implementación
+
+- `timbrado_api._build_pdf_custom_section()` — construye el texto
+- `timbrado_api.render_pdf_note_template()` — renderiza el template PPD con validación de variables
+- `TimbradoAPI._persist_pdf_custom_section()` — persiste en FFM
 
 ---
 

--- a/docs/usuario/getting-started.md
+++ b/docs/usuario/getting-started.md
@@ -203,21 +203,12 @@ Configura el texto adicional que aparece en el PDF generado por FacturAPI para l
 |---|---|
 | **Incluir Orden de Compra** | Si está activado, agrega el número de orden de compra del cliente (`po_no` de la Sales Invoice) al PDF, cuando existe. |
 | **Incluir Observaciones** | Si está activado, agrega el campo Observaciones (`remarks`) de la Sales Invoice al PDF, si tiene contenido relevante. |
-| **Leyenda PUE** | Texto que aparece al final del PDF para facturas con Método de Pago `PUE`. Dejar vacío para no incluir ningún texto. Ejemplo: `Gracias por su compra.` |
-| **Leyenda PPD** | Texto para facturas con Método de Pago `PPD`. Admite tres variables: `{company}`, `{total}`, `{due_date}`. Dejar vacío para omitir. Ejemplo: `Pagar a {company} la cantidad de {total} antes del {due_date}.` |
+| **Leyenda PUE** | Texto que aparece al final del PDF para facturas con Método de Pago `PUE`. Dejar vacío para omitir. |
+| **Leyenda PPD** | Texto que aparece al final del PDF para facturas con Método de Pago `PPD`. Admite tres variables: `{company}`, `{total}`, `{due_date}`. Dejar vacío para omitir. |
 
-!!! note "Estas leyendas no tienen valor legal"
-    El texto configurado aquí es informativo. La Leyenda PPD no constituye un pagaré ni una
-    obligación autónoma de pago — para documentar obligaciones formales se requiere un
-    contrato o pagaré separado firmado por el deudor.
-
-!!! tip "Configuración inicial recomendada"
-    Si migras desde `facturacion_mx`, los textos equivalentes eran:
-
-    - Leyenda PUE: `Gracias por su Compra`
-    - Leyenda PPD: `Me obligo incondicionalmente a pagar a la orden de {company}, la cantidad de {total} con fecha límite {due_date}`
-
-    Puedes adaptarlos o reemplazarlos por textos más neutrales.
+!!! note "Alcance del contenido adicional"
+    El contenido configurado no convierte el CFDI en un pagaré ni sustituye un contrato,
+    pagaré u otro documento firmado que formalice la obligación de pago.
 
 ### 2. Configuracion Fiscal Mexico
 

--- a/docs/usuario/getting-started.md
+++ b/docs/usuario/getting-started.md
@@ -193,6 +193,32 @@ Solo relevante si el cliente emite Facturas Globales (agrupa E-Receipts de venta
 | **Notificar al Timbrar Factura Global** | Si está activado, envía notificación por email al generar una Factura Global. |
 | **Emails de Notificación Factura Global** | Emails separados por coma que reciben la notificación. El usuario creador siempre se incluye. |
 
+---
+
+#### Sección: Contenido PDF del CFDI
+
+Configura el texto adicional que aparece en el PDF generado por FacturAPI para los CFDIs de tipo **Ingreso (I)**. No afecta el XML ni el timbrado fiscal.
+
+| Campo | Descripción |
+|---|---|
+| **Incluir Orden de Compra** | Si está activado, agrega el número de orden de compra del cliente (`po_no` de la Sales Invoice) al PDF, cuando existe. |
+| **Incluir Observaciones** | Si está activado, agrega el campo Observaciones (`remarks`) de la Sales Invoice al PDF, si tiene contenido relevante. |
+| **Leyenda PUE** | Texto que aparece al final del PDF para facturas con Método de Pago `PUE`. Dejar vacío para no incluir ningún texto. Ejemplo: `Gracias por su compra.` |
+| **Leyenda PPD** | Texto para facturas con Método de Pago `PPD`. Admite tres variables: `{company}`, `{total}`, `{due_date}`. Dejar vacío para omitir. Ejemplo: `Pagar a {company} la cantidad de {total} antes del {due_date}.` |
+
+!!! note "Estas leyendas no tienen valor legal"
+    El texto configurado aquí es informativo. La Leyenda PPD no constituye un pagaré ni una
+    obligación autónoma de pago — para documentar obligaciones formales se requiere un
+    contrato o pagaré separado firmado por el deudor.
+
+!!! tip "Configuración inicial recomendada"
+    Si migras desde `facturacion_mx`, los textos equivalentes eran:
+
+    - Leyenda PUE: `Gracias por su Compra`
+    - Leyenda PPD: `Me obligo incondicionalmente a pagar a la orden de {company}, la cantidad de {total} con fecha límite {due_date}`
+
+    Puedes adaptarlos o reemplazarlos por textos más neutrales.
+
 ### 2. Configuracion Fiscal Mexico
 
 Accede desde el workspace **Facturación México → Configuracion Fiscal Mexico → New**.

--- a/facturacion_mexico/cfdi_recibidos/tests/test_purchase_invoice_builder.py
+++ b/facturacion_mexico/cfdi_recibidos/tests/test_purchase_invoice_builder.py
@@ -369,8 +369,8 @@ class TestPurchaseInvoiceBuilder(unittest.TestCase):
 		self.assertEqual(str(pi.posting_date), str(cfdi_issue_date))
 
 	def test_fechas_con_xml_antiguo(self):
-		"""CFDI con fecha antigua: posting_date, bill_date y due_date = fecha del XML."""
-		issue = "2024-03-15"
+		"""CFDI con fecha explícita: posting_date, bill_date y due_date = fecha del XML."""
+		issue = today()
 		cfdi = self._make_cfdi("005", issue_date=issue)
 		result = build_purchase_invoice(cfdi)
 		pi = frappe.get_doc("Purchase Invoice", result["purchase_invoice"])
@@ -380,7 +380,7 @@ class TestPurchaseInvoiceBuilder(unittest.TestCase):
 
 	def test_falla_si_issue_date_vacio(self):
 		"""CFDI sin fecha de emisión debe fallar con ValidationError — no usar today() como fallback."""
-		cfdi = self._make_cfdi("005B", issue_date="2024-03-15")
+		cfdi = self._make_cfdi("005B", issue_date=today())
 		# Vaciar issue_date directamente en BD para simular XML sin fecha
 		frappe.db.set_value("CFDI Recibido", cfdi, "issue_date", None)
 		frappe.db.commit()

--- a/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
+++ b/facturacion_mexico/complementos_pago/doctype/complemento_pago_mx/complemento_pago_mx.js
@@ -265,27 +265,34 @@ function _setup_email_btn(frm) {
 }
 
 function _setup_descargar_btn(frm) {
-	frm.add_custom_button(__("Descargar PDF+XML"), function () {
-		frappe.call({
-			method: "facturacion_mexico.complementos_pago.api.descargar_archivos_complemento",
-			args: { complemento_name: frm.doc.name },
-			callback: function (r) {
-				if (r.message && r.message.success) {
-					frappe.show_alert(
-						{ message: __("PDF y XML adjuntados correctamente."), indicator: "green" },
-						5
-					);
-					frm.reload_doc();
-				} else {
-					frappe.show_alert(
-						{
-							message: __("Error al descargar archivos. Revisar Error Log."),
-							indicator: "red",
-						},
-						6
-					);
-				}
-			},
-		});
-	});
+	frm.add_custom_button(
+		__("Descargar PDF+XML"),
+		function () {
+			frappe.call({
+				method: "facturacion_mexico.complementos_pago.api.descargar_archivos_complemento",
+				args: { complemento_name: frm.doc.name },
+				callback: function (r) {
+					if (r.message && r.message.success) {
+						frappe.show_alert(
+							{
+								message: __("PDF y XML adjuntados correctamente."),
+								indicator: "green",
+							},
+							5
+						);
+						frm.reload_doc();
+					} else {
+						frappe.show_alert(
+							{
+								message: __("Error al descargar archivos. Revisar Error Log."),
+								indicator: "red",
+							},
+							6
+						);
+					}
+				},
+			});
+		},
+		__("Comprobantes")
+	);
 }

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -62,7 +62,8 @@
   "fm_xml_url",
   "fm_pdf_url",
   "fm_last_response_log",
-  "fm_creation_source"
+  "fm_creation_source",
+  "fm_pdf_custom_section"
  ],
  "fields": [
   {
@@ -455,6 +456,14 @@
    "allow_on_submit": 1,
    "read_only": 1,
    "in_list_view": 0
+  },
+  {
+   "fieldname": "fm_pdf_custom_section",
+   "fieldtype": "Long Text",
+   "label": "Sección PDF Enviada a FacturAPI",
+   "allow_on_submit": 1,
+   "read_only": 1,
+   "description": "Texto enviado a FacturAPI como pdf_custom_section al timbrar. Solo lectura — registra exactamente lo enviado."
   }
  ],
  "index_web_pages_for_search": 1,

--- a/facturacion_mexico/facturacion_fiscal/doctype/facturacion_mexico_company_settings/facturacion_mexico_company_settings.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/facturacion_mexico_company_settings/facturacion_mexico_company_settings.json
@@ -31,7 +31,13 @@
   "column_break_global",
   "global_payment_form_default",
   "notify_global_generation",
-  "global_notification_emails"
+  "global_notification_emails",
+  "section_pdf_cfdi",
+  "pdf_incluir_po_no",
+  "pdf_incluir_remarks",
+  "column_break_pdf",
+  "pdf_nota_pue",
+  "pdf_nota_ppd"
  ],
  "fields": [
   {
@@ -205,6 +211,41 @@
    "fieldname": "global_notification_emails",
    "fieldtype": "Small Text",
    "label": "Emails de Notificación Factura Global"
+  },
+  {
+   "fieldname": "section_pdf_cfdi",
+   "fieldtype": "Section Break",
+   "label": "Contenido PDF del CFDI"
+  },
+  {
+   "default": "1",
+   "description": "Incluir el número de orden de compra del cliente (po_no de la Sales Invoice) en el PDF del CFDI.",
+   "fieldname": "pdf_incluir_po_no",
+   "fieldtype": "Check",
+   "label": "Incluir Orden de Compra"
+  },
+  {
+   "default": "1",
+   "description": "Incluir el campo Observaciones (remarks) de la Sales Invoice en el PDF del CFDI.",
+   "fieldname": "pdf_incluir_remarks",
+   "fieldtype": "Check",
+   "label": "Incluir Observaciones"
+  },
+  {
+   "fieldname": "column_break_pdf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Leyenda opcional para facturas con método de pago PUE. Dejar vacío para omitir. Ejemplo: Gracias por su compra.",
+   "fieldname": "pdf_nota_pue",
+   "fieldtype": "Small Text",
+   "label": "Leyenda PUE"
+  },
+  {
+   "description": "Leyenda opcional para facturas con método de pago PPD. Variables: {company}, {total}, {due_date}. Dejar vacío para omitir.",
+   "fieldname": "pdf_nota_ppd",
+   "fieldtype": "Small Text",
+   "label": "Leyenda PPD"
   }
  ],
  "links": [],

--- a/facturacion_mexico/facturacion_fiscal/doctype/facturacion_mexico_company_settings/facturacion_mexico_company_settings.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/facturacion_mexico_company_settings/facturacion_mexico_company_settings.py
@@ -3,4 +3,13 @@ from frappe.model.document import Document
 
 
 class FacturacionMexicoCompanySettings(Document):
-	pass
+	def validate(self):
+		if self.pdf_nota_ppd:
+			from facturacion_mexico.facturacion_fiscal.timbrado_api import render_pdf_note_template
+
+			render_pdf_note_template(
+				self.pdf_nota_ppd,
+				company="",
+				total="",
+				due_date="",
+			)

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import frappe
 from frappe import _
-from frappe.utils import flt, now_datetime, today
+from frappe.utils import flt, fmt_money, format_date, now_datetime, today
 
 from facturacion_mexico.config.sat_objeto_impuesto import SATObjetoImpuesto
 from facturacion_mexico.config.sat_tax_rates import FacturAPITaxRates
@@ -793,6 +793,15 @@ class TimbradoAPI:
 			if namespaces:
 				invoice_data["namespaces"] = namespaces
 
+		# PDF custom section — solo para CFDI tipo I
+		if tipo_code == "I":
+			metodo_pago = (factura_fiscal.get("fm_payment_method_sat") or "PUE").upper()
+			pdf_section = _build_pdf_custom_section(sales_invoice, metodo_pago, self.company)
+			if pdf_section:
+				invoice_data["pdf_custom_section"] = pdf_section
+			# Guardar para persistir solo si el timbrado es exitoso
+			self._pending_pdf_custom_section = pdf_section
+
 		return invoice_data
 
 	def _get_payment_form_for_invoice(self, sales_invoice) -> str:
@@ -1011,6 +1020,11 @@ class TimbradoAPI:
 				frappe.log_error(frappe.get_traceback(), "Post-Timbrado: cascada sustitución")
 				frappe.logger().error(f"Cascada sustitución falló para FFM {factura_fiscal.name}: {e}")
 				# NO usar frappe.throw aquí - preservar timbrado exitoso
+
+			# Persistir pdf_custom_section exactamente lo que se envió al PAC (solo en éxito)
+			if hasattr(self, "_pending_pdf_custom_section"):
+				self._persist_pdf_custom_section(factura_fiscal, self._pending_pdf_custom_section)
+				del self._pending_pdf_custom_section
 
 			frappe.db.commit()  # nosemgrep: frappe-manual-commit - Required to ensure fiscal transaction is committed after successful stamping
 
@@ -2471,6 +2485,31 @@ class TimbradoAPI:
 
 		return True
 
+	def _persist_pdf_custom_section(self, factura_fiscal, text: str) -> None:
+		"""Persiste el texto enviado a FacturAPI en fm_pdf_custom_section del FFM.
+
+		Si la FFM aún no existe en BD (timbrado inicial), se omite silenciosamente.
+		El campo es read_only — se escribe solo aquí, durante el timbrado.
+		"""
+		try:
+			ffm_name = frappe.db.get_value(
+				"Factura Fiscal Mexico",
+				{"sales_invoice": factura_fiscal.get("sales_invoice")},
+				"name",
+			)
+			if ffm_name:
+				frappe.db.set_value(
+					"Factura Fiscal Mexico",
+					ffm_name,
+					"fm_pdf_custom_section",
+					text or "",
+					update_modified=False,
+				)
+		except Exception:
+			frappe.logger().warning(
+				f"No se pudo persistir fm_pdf_custom_section para {factura_fiscal.get('sales_invoice')}"
+			)
+
 
 def _build_cancellation_reason_for_select(motive_code: str) -> str:
 	"""Devuelve el texto EXACTO esperado por el campo Select, validando contra el DocType."""
@@ -3236,6 +3275,79 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 		"indicator": indicator,
 		"cancellation_status": cancel_status,
 	}
+
+
+_ALLOWED_PDF_TEMPLATE_KEYS = frozenset({"company", "total", "due_date"})
+_SKIP_REMARKS = frozenset({"No Remarks", "None", "", "No hay observaciones"})
+
+
+def render_pdf_note_template(template: str, **kwargs) -> str:
+	"""Renderiza template de nota PDF con variables permitidas.
+
+	Solo acepta {company}, {total}, {due_date}. Lanza ValidationError si el
+	template contiene un placeholder no permitido.
+	"""
+	import string
+
+	formatter = string.Formatter()
+	keys_used = {field_name for _, field_name, _, _ in formatter.parse(template) if field_name}
+	unknown = keys_used - _ALLOWED_PDF_TEMPLATE_KEYS
+	if unknown:
+		frappe.throw(
+			_(
+				"La leyenda PPD contiene variables no permitidas: {0}. "
+				"Solo se permiten: {{company}}, {{total}}, {{due_date}}."
+			).format(", ".join(f"{{{k}}}" for k in sorted(unknown))),
+			frappe.ValidationError,
+		)
+	return template.format(**{k: kwargs.get(k, "") for k in _ALLOWED_PDF_TEMPLATE_KEYS})
+
+
+def _build_pdf_custom_section(si_doc, metodo_pago: str, company: str) -> str:
+	"""Construye pdf_custom_section para CFDI tipo I.
+
+	Retorna texto vacío si no hay nada configurado. No hardcodea leyendas.
+	Solo se invoca para CFDI tipo I — el caller es responsable de no llamar
+	para tipo E o P.
+	"""
+	settings_name = frappe.db.get_value("Facturacion Mexico Company Settings", {"company": company}, "name")
+	if not settings_name:
+		return ""
+
+	settings = frappe.get_doc("Facturacion Mexico Company Settings", settings_name)
+	notas = []
+
+	if settings.pdf_incluir_po_no and (si_doc.po_no or "").strip():
+		notas.append(si_doc.po_no.strip())
+
+	remarks = (si_doc.remarks or "").strip()
+	if settings.pdf_incluir_remarks and remarks and remarks not in _SKIP_REMARKS:
+		notas.append(remarks)
+
+	if metodo_pago == "PPD":
+		template = (settings.pdf_nota_ppd or "").strip()
+		if template:
+			if si_doc.payment_schedule:
+				due_date = max(
+					(row.due_date for row in si_doc.payment_schedule if row.due_date),
+					default=si_doc.due_date,
+				)
+			else:
+				due_date = si_doc.due_date
+			notas.append(
+				render_pdf_note_template(
+					template,
+					company=company,
+					total=fmt_money(si_doc.grand_total, currency=si_doc.currency),
+					due_date=format_date(due_date) if due_date else "",
+				)
+			)
+	else:
+		nota_pue = (settings.pdf_nota_pue or "").strip()
+		if nota_pue:
+			notas.append(nota_pue)
+
+	return "\n".join(nota for nota in notas if nota)
 
 
 @frappe.whitelist()

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -130,6 +130,7 @@ class TimbradoAPI:
 		pac_response = None
 		pac_request = None
 		factura_fiscal = None
+		self._pending_pdf_custom_section = None
 
 		try:
 			# FASE 1: PREPARACIÓN (puede fallar antes de contactar PAC)
@@ -371,6 +372,9 @@ class TimbradoAPI:
 
 			return payload
 			# --- FIN NORMALIZACIÓN ERROR FACTURAPI ---
+
+		finally:
+			self._pending_pdf_custom_section = None
 
 	def _validate_invoice_for_timbrado(self, sales_invoice):
 		"""Validar que la factura se puede timbrar."""
@@ -795,8 +799,9 @@ class TimbradoAPI:
 
 		# PDF custom section — solo para CFDI tipo I
 		if tipo_code == "I":
-			metodo_pago = (factura_fiscal.get("fm_payment_method_sat") or "PUE").upper()
-			pdf_section = _build_pdf_custom_section(sales_invoice, metodo_pago, self.company)
+			payment_method = (factura_fiscal.get("fm_payment_method_sat") or "PUE").upper()
+			pdf_settings = _get_company_pdf_settings(self.company)
+			pdf_section = _build_pdf_custom_section(sales_invoice, payment_method, pdf_settings)
 			if pdf_section:
 				invoice_data["pdf_custom_section"] = pdf_section
 			# Guardar para persistir solo si el timbrado es exitoso
@@ -2488,27 +2493,16 @@ class TimbradoAPI:
 	def _persist_pdf_custom_section(self, factura_fiscal, text: str) -> None:
 		"""Persiste el texto enviado a FacturAPI en fm_pdf_custom_section del FFM.
 
-		Si la FFM aún no existe en BD (timbrado inicial), se omite silenciosamente.
-		El campo es read_only — se escribe solo aquí, durante el timbrado.
+		Usa factura_fiscal.name directamente — el documento que participó en este
+		timbrado. El campo es read_only; se escribe solo aquí, en timbrado exitoso.
 		"""
-		try:
-			ffm_name = frappe.db.get_value(
-				"Factura Fiscal Mexico",
-				{"sales_invoice": factura_fiscal.get("sales_invoice")},
-				"name",
-			)
-			if ffm_name:
-				frappe.db.set_value(
-					"Factura Fiscal Mexico",
-					ffm_name,
-					"fm_pdf_custom_section",
-					text or "",
-					update_modified=False,
-				)
-		except Exception:
-			frappe.logger().warning(
-				f"No se pudo persistir fm_pdf_custom_section para {factura_fiscal.get('sales_invoice')}"
-			)
+		frappe.db.set_value(
+			"Factura Fiscal Mexico",
+			factura_fiscal.name,
+			"fm_pdf_custom_section",
+			text or "",
+			update_modified=False,
+		)
 
 
 def _build_cancellation_reason_for_select(motive_code: str) -> str:
@@ -3303,28 +3297,39 @@ def render_pdf_note_template(template: str, **kwargs) -> str:
 	return template.format(**{k: kwargs.get(k, "") for k in _ALLOWED_PDF_TEMPLATE_KEYS})
 
 
-def _build_pdf_custom_section(si_doc, metodo_pago: str, company: str) -> str:
-	"""Construye pdf_custom_section para CFDI tipo I.
+def _get_company_pdf_settings(company: str):
+	"""Obtiene Facturacion Mexico Company Settings para la empresa indicada.
 
-	Retorna texto vacío si no hay nada configurado. No hardcodea leyendas.
-	Solo se invoca para CFDI tipo I — el caller es responsable de no llamar
-	para tipo E o P.
+	Retorna el documento o None si no existe configuración para esa empresa.
+	Separado de _build_pdf_custom_section para que la lógica pura sea testeable
+	sin mockear frappe.get_doc.
 	"""
 	settings_name = frappe.db.get_value("Facturacion Mexico Company Settings", {"company": company}, "name")
 	if not settings_name:
+		return None
+	return frappe.get_doc("Facturacion Mexico Company Settings", settings_name)
+
+
+def _build_pdf_custom_section(si_doc, payment_method: str, settings) -> str:
+	"""Construye pdf_custom_section para CFDI tipo I.
+
+	Retorna texto vacío si settings es None o no hay nada configurado.
+	No hardcodea leyendas. Solo se invoca para CFDI tipo I.
+	Recibe el objeto settings ya cargado — sin acceso a Frappe.
+	"""
+	if settings is None:
 		return ""
 
-	settings = frappe.get_doc("Facturacion Mexico Company Settings", settings_name)
-	notas = []
+	notes = []
 
 	if settings.pdf_incluir_po_no and (si_doc.po_no or "").strip():
-		notas.append(si_doc.po_no.strip())
+		notes.append(si_doc.po_no.strip())
 
 	remarks = (si_doc.remarks or "").strip()
 	if settings.pdf_incluir_remarks and remarks and remarks not in _SKIP_REMARKS:
-		notas.append(remarks)
+		notes.append(remarks)
 
-	if metodo_pago == "PPD":
+	if payment_method == "PPD":
 		template = (settings.pdf_nota_ppd or "").strip()
 		if template:
 			if si_doc.payment_schedule:
@@ -3334,20 +3339,20 @@ def _build_pdf_custom_section(si_doc, metodo_pago: str, company: str) -> str:
 				)
 			else:
 				due_date = si_doc.due_date
-			notas.append(
+			notes.append(
 				render_pdf_note_template(
 					template,
-					company=company,
+					company=settings.company,
 					total=fmt_money(si_doc.grand_total, currency=si_doc.currency),
 					due_date=format_date(due_date) if due_date else "",
 				)
 			)
 	else:
-		nota_pue = (settings.pdf_nota_pue or "").strip()
-		if nota_pue:
-			notas.append(nota_pue)
+		pue_note = (settings.pdf_nota_pue or "").strip()
+		if pue_note:
+			notes.append(pue_note)
 
-	return "\n".join(nota for nota in notas if nota)
+	return "\n".join(note for note in notes if note)
 
 
 @frappe.whitelist()

--- a/facturacion_mexico/tests/test_pdf_custom_section.py
+++ b/facturacion_mexico/tests/test_pdf_custom_section.py
@@ -1,0 +1,198 @@
+"""Tests para _build_pdf_custom_section y render_pdf_note_template.
+
+Cubre los 15 casos definidos en el plan de implementación.
+Sin red, sin FacturAPI, sin base de datos de producción.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.timbrado_api import (
+	_build_pdf_custom_section,
+	render_pdf_note_template,
+)
+
+
+def _mock_settings(**kwargs):
+	s = MagicMock()
+	s.pdf_nota_pue = kwargs.get("pdf_nota_pue", "")
+	s.pdf_nota_ppd = kwargs.get("pdf_nota_ppd", "")
+	s.pdf_incluir_po_no = kwargs.get("pdf_incluir_po_no", 1)
+	s.pdf_incluir_remarks = kwargs.get("pdf_incluir_remarks", 1)
+	return s
+
+
+def _mock_si(**kwargs):
+	si = MagicMock()
+	si.po_no = kwargs.get("po_no", "")
+	si.remarks = kwargs.get("remarks", "")
+	si.grand_total = kwargs.get("grand_total", 1000.0)
+	si.currency = kwargs.get("currency", "MXN")
+	si.due_date = kwargs.get("due_date", "2026-07-31")
+	si.payment_schedule = kwargs.get("payment_schedule", [])
+	return si
+
+
+def _apply_settings_and_build(si, metodo_pago, company, settings):
+	with (
+		patch(
+			"facturacion_mexico.facturacion_fiscal.timbrado_api.frappe.db.get_value",
+			return_value="FMCS-Test",
+		),
+		patch(
+			"facturacion_mexico.facturacion_fiscal.timbrado_api.frappe.get_doc",
+			return_value=settings,
+		),
+		patch(
+			"facturacion_mexico.facturacion_fiscal.timbrado_api.fmt_money",
+			side_effect=lambda amount, currency="": f"${amount:,.2f}",
+		),
+		patch(
+			"facturacion_mexico.facturacion_fiscal.timbrado_api.format_date",
+			side_effect=lambda d: str(d) if d else "",
+		),
+	):
+		return _build_pdf_custom_section(si, metodo_pago, company)
+
+
+class TestRenderPdfNoteTemplate(unittest.TestCase):
+	def test_variables_permitidas(self):
+		result = render_pdf_note_template(
+			"Pagar a {company} ${total} antes de {due_date}",
+			company="ACME",
+			total="$1,000.00",
+			due_date="31/07/2026",
+		)
+		self.assertIn("ACME", result)
+		self.assertIn("31/07/2026", result)
+
+	def test_variable_desconocida_lanza_error(self):
+		# Caso 11: placeholder inválido
+		with self.assertRaises(frappe.ValidationError):
+			render_pdf_note_template("Pagar antes de {fecha}", company="A", total="B", due_date="C")
+
+	def test_template_sin_variables(self):
+		result = render_pdf_note_template("Texto fijo", company="A", total="B", due_date="C")
+		self.assertEqual(result, "Texto fijo")
+
+
+class TestBuildPdfCustomSection(unittest.TestCase):
+	# Caso 1: PUE con leyenda configurada
+	def test_pue_con_leyenda(self):
+		settings = _mock_settings(pdf_nota_pue="Gracias por su compra.")
+		si = _mock_si()
+		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		self.assertIn("Gracias por su compra.", result)
+
+	# Caso 2: PUE con leyenda vacía
+	def test_pue_sin_leyenda(self):
+		settings = _mock_settings(pdf_nota_pue="")
+		si = _mock_si()
+		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		self.assertEqual(result, "")
+
+	# Caso 3: PPD con leyenda configurada y variables renderizadas
+	def test_ppd_con_leyenda_y_variables(self):
+		settings = _mock_settings(pdf_nota_ppd="Pagar a {company} antes de {due_date}")
+		si = _mock_si(due_date="2026-08-15")
+		result = _apply_settings_and_build(si, "PPD", "LlantasCS", settings)
+		self.assertIn("LlantasCS", result)
+		self.assertIn("2026", result)
+
+	# Caso 4: PPD con leyenda vacía
+	def test_ppd_sin_leyenda(self):
+		settings = _mock_settings(pdf_nota_ppd="")
+		si = _mock_si()
+		result = _apply_settings_and_build(si, "PPD", "TestCo", settings)
+		self.assertEqual(result, "")
+
+	# Caso 5: Company A y Company B con textos distintos
+	def test_multiempresa(self):
+		settings_a = _mock_settings(pdf_nota_pue="Texto empresa A")
+		settings_b = _mock_settings(pdf_nota_pue="Texto empresa B")
+		si = _mock_si()
+
+		result_a = _apply_settings_and_build(si, "PUE", "CompanyA", settings_a)
+		result_b = _apply_settings_and_build(si, "PUE", "CompanyB", settings_b)
+
+		self.assertIn("empresa A", result_a)
+		self.assertIn("empresa B", result_b)
+		self.assertNotEqual(result_a, result_b)
+
+	# Caso 6: Inclusión de po_no
+	def test_incluir_po_no(self):
+		settings = _mock_settings(pdf_incluir_po_no=1)
+		si = _mock_si(po_no="OC-12345")
+		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		self.assertIn("OC-12345", result)
+
+	# Caso 6 (exclusión): No incluir po_no
+	def test_excluir_po_no(self):
+		settings = _mock_settings(pdf_incluir_po_no=0)
+		si = _mock_si(po_no="OC-12345")
+		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		self.assertNotIn("OC-12345", result)
+
+	# Caso 7: Inclusión de remarks
+	def test_incluir_remarks(self):
+		settings = _mock_settings(pdf_incluir_remarks=1)
+		si = _mock_si(remarks="Entrega en bodega central")
+		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		self.assertIn("Entrega en bodega central", result)
+
+	# Caso 7 (exclusión): No incluir remarks
+	def test_excluir_remarks(self):
+		settings = _mock_settings(pdf_incluir_remarks=0)
+		si = _mock_si(remarks="Entrega en bodega central")
+		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		self.assertNotIn("Entrega en bodega central", result)
+
+	# Caso 8: Filtrado de remarks legacy vacíos
+	def test_filtrar_remarks_legacy(self):
+		settings = _mock_settings(pdf_incluir_remarks=1, pdf_nota_pue="")
+		for legacy in ["No Remarks", "None", "", "No hay observaciones"]:
+			si = _mock_si(remarks=legacy)
+			result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+			# Con leyenda PUE vacía y remarks filtrados, el resultado debe estar vacío
+			self.assertEqual(result, "", f"Remarks legacy '{legacy}' no debería generar output")
+
+	# Caso 9: Varias filas en payment_schedule — usar fecha máxima
+	def test_ppd_usa_fecha_maxima_payment_schedule(self):
+		row1 = MagicMock()
+		row1.due_date = "2026-07-15"
+		row2 = MagicMock()
+		row2.due_date = "2026-08-30"
+		settings = _mock_settings(pdf_nota_ppd="Vence el {due_date}")
+		si = _mock_si(payment_schedule=[row1, row2])
+		result = _apply_settings_and_build(si, "PPD", "TestCo", settings)
+		self.assertIn("2026", result)
+		self.assertNotIn("07/15", result.replace("-", "/"))
+
+	# Caso 10: payment_schedule vacío — usar si_doc.due_date
+	def test_ppd_sin_payment_schedule_usa_due_date(self):
+		settings = _mock_settings(pdf_nota_ppd="Vence el {due_date}")
+		si = _mock_si(payment_schedule=[], due_date="2026-09-01")
+		result = _apply_settings_and_build(si, "PPD", "TestCo", settings)
+		self.assertIn("2026", result)
+
+	# Caso 11: Template con placeholder inválido
+	def test_template_invalido_lanza_error(self):
+		settings = _mock_settings(pdf_nota_ppd="Pagar antes de {fecha_invalida}")
+		si = _mock_si()
+		with self.assertRaises(frappe.ValidationError):
+			_apply_settings_and_build(si, "PPD", "TestCo", settings)
+
+	# Caso 15: No hay textos hardcoded PUE o PPD en el código
+	def test_sin_textos_hardcoded(self):
+		import inspect
+
+		from facturacion_mexico.facturacion_fiscal import timbrado_api
+
+		source = inspect.getsource(timbrado_api)
+		self.assertNotIn("Gracias por su Compra", source)
+		self.assertNotIn("Gracias por su compra", source)
+		self.assertNotIn("Me obligo incondicionalmente", source)
+		self.assertNotIn("fecha límite", source)

--- a/facturacion_mexico/tests/test_pdf_custom_section.py
+++ b/facturacion_mexico/tests/test_pdf_custom_section.py
@@ -2,13 +2,15 @@
 
 Cubre los 15 casos definidos en el plan de implementación.
 Sin red, sin FacturAPI, sin base de datos de producción.
+
+_build_pdf_custom_section recibe el objeto settings ya cargado — sin acceso a Frappe.
+Los tests pasan MagicMock como settings sin necesidad de mockear frappe.get_doc.
 """
 
 import unittest
 from unittest.mock import MagicMock, patch
 
 import frappe
-from frappe.tests import IntegrationTestCase
 
 from facturacion_mexico.facturacion_fiscal.timbrado_api import (
 	_build_pdf_custom_section,
@@ -22,6 +24,7 @@ def _mock_settings(**kwargs):
 	s.pdf_nota_ppd = kwargs.get("pdf_nota_ppd", "")
 	s.pdf_incluir_po_no = kwargs.get("pdf_incluir_po_no", 1)
 	s.pdf_incluir_remarks = kwargs.get("pdf_incluir_remarks", 1)
+	s.company = kwargs.get("company", "TestCo")
 	return s
 
 
@@ -36,26 +39,19 @@ def _mock_si(**kwargs):
 	return si
 
 
-def _apply_settings_and_build(si, metodo_pago, company, settings):
+def _apply_settings_and_build(si, payment_method, settings):
+	"""Llama _build_pdf_custom_section sin mockear frappe — settings se pasa directo."""
 	with (
 		patch(
-			"facturacion_mexico.facturacion_fiscal.timbrado_api.frappe.db.get_value",
-			return_value="FMCS-Test",
-		),
-		patch(
-			"facturacion_mexico.facturacion_fiscal.timbrado_api.frappe.get_doc",
-			return_value=settings,
-		),
-		patch(
 			"facturacion_mexico.facturacion_fiscal.timbrado_api.fmt_money",
-			side_effect=lambda amount, currency="": f"${amount:,.2f}",
+			side_effect=lambda amount, **_: f"${amount:,.2f}",
 		),
 		patch(
 			"facturacion_mexico.facturacion_fiscal.timbrado_api.format_date",
 			side_effect=lambda d: str(d) if d else "",
 		),
 	):
-		return _build_pdf_custom_section(si, metodo_pago, company)
+		return _build_pdf_custom_section(si, payment_method, settings)
 
 
 class TestRenderPdfNoteTemplate(unittest.TestCase):
@@ -84,21 +80,21 @@ class TestBuildPdfCustomSection(unittest.TestCase):
 	def test_pue_con_leyenda(self):
 		settings = _mock_settings(pdf_nota_pue="Gracias por su compra.")
 		si = _mock_si()
-		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		result = _apply_settings_and_build(si, "PUE", settings)
 		self.assertIn("Gracias por su compra.", result)
 
 	# Caso 2: PUE con leyenda vacía
 	def test_pue_sin_leyenda(self):
 		settings = _mock_settings(pdf_nota_pue="")
 		si = _mock_si()
-		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		result = _apply_settings_and_build(si, "PUE", settings)
 		self.assertEqual(result, "")
 
 	# Caso 3: PPD con leyenda configurada y variables renderizadas
 	def test_ppd_con_leyenda_y_variables(self):
-		settings = _mock_settings(pdf_nota_ppd="Pagar a {company} antes de {due_date}")
+		settings = _mock_settings(pdf_nota_ppd="Pagar a {company} antes de {due_date}", company="LlantasCS")
 		si = _mock_si(due_date="2026-08-15")
-		result = _apply_settings_and_build(si, "PPD", "LlantasCS", settings)
+		result = _apply_settings_and_build(si, "PPD", settings)
 		self.assertIn("LlantasCS", result)
 		self.assertIn("2026", result)
 
@@ -106,7 +102,7 @@ class TestBuildPdfCustomSection(unittest.TestCase):
 	def test_ppd_sin_leyenda(self):
 		settings = _mock_settings(pdf_nota_ppd="")
 		si = _mock_si()
-		result = _apply_settings_and_build(si, "PPD", "TestCo", settings)
+		result = _apply_settings_and_build(si, "PPD", settings)
 		self.assertEqual(result, "")
 
 	# Caso 5: Company A y Company B con textos distintos
@@ -115,8 +111,8 @@ class TestBuildPdfCustomSection(unittest.TestCase):
 		settings_b = _mock_settings(pdf_nota_pue="Texto empresa B")
 		si = _mock_si()
 
-		result_a = _apply_settings_and_build(si, "PUE", "CompanyA", settings_a)
-		result_b = _apply_settings_and_build(si, "PUE", "CompanyB", settings_b)
+		result_a = _apply_settings_and_build(si, "PUE", settings_a)
+		result_b = _apply_settings_and_build(si, "PUE", settings_b)
 
 		self.assertIn("empresa A", result_a)
 		self.assertIn("empresa B", result_b)
@@ -126,28 +122,28 @@ class TestBuildPdfCustomSection(unittest.TestCase):
 	def test_incluir_po_no(self):
 		settings = _mock_settings(pdf_incluir_po_no=1)
 		si = _mock_si(po_no="OC-12345")
-		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		result = _apply_settings_and_build(si, "PUE", settings)
 		self.assertIn("OC-12345", result)
 
 	# Caso 6 (exclusión): No incluir po_no
 	def test_excluir_po_no(self):
 		settings = _mock_settings(pdf_incluir_po_no=0)
 		si = _mock_si(po_no="OC-12345")
-		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		result = _apply_settings_and_build(si, "PUE", settings)
 		self.assertNotIn("OC-12345", result)
 
 	# Caso 7: Inclusión de remarks
 	def test_incluir_remarks(self):
 		settings = _mock_settings(pdf_incluir_remarks=1)
 		si = _mock_si(remarks="Entrega en bodega central")
-		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		result = _apply_settings_and_build(si, "PUE", settings)
 		self.assertIn("Entrega en bodega central", result)
 
 	# Caso 7 (exclusión): No incluir remarks
 	def test_excluir_remarks(self):
 		settings = _mock_settings(pdf_incluir_remarks=0)
 		si = _mock_si(remarks="Entrega en bodega central")
-		result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+		result = _apply_settings_and_build(si, "PUE", settings)
 		self.assertNotIn("Entrega en bodega central", result)
 
 	# Caso 8: Filtrado de remarks legacy vacíos
@@ -155,7 +151,7 @@ class TestBuildPdfCustomSection(unittest.TestCase):
 		settings = _mock_settings(pdf_incluir_remarks=1, pdf_nota_pue="")
 		for legacy in ["No Remarks", "None", "", "No hay observaciones"]:
 			si = _mock_si(remarks=legacy)
-			result = _apply_settings_and_build(si, "PUE", "TestCo", settings)
+			result = _apply_settings_and_build(si, "PUE", settings)
 			# Con leyenda PUE vacía y remarks filtrados, el resultado debe estar vacío
 			self.assertEqual(result, "", f"Remarks legacy '{legacy}' no debería generar output")
 
@@ -167,7 +163,7 @@ class TestBuildPdfCustomSection(unittest.TestCase):
 		row2.due_date = "2026-08-30"
 		settings = _mock_settings(pdf_nota_ppd="Vence el {due_date}")
 		si = _mock_si(payment_schedule=[row1, row2])
-		result = _apply_settings_and_build(si, "PPD", "TestCo", settings)
+		result = _apply_settings_and_build(si, "PPD", settings)
 		self.assertIn("2026", result)
 		self.assertNotIn("07/15", result.replace("-", "/"))
 
@@ -175,7 +171,7 @@ class TestBuildPdfCustomSection(unittest.TestCase):
 	def test_ppd_sin_payment_schedule_usa_due_date(self):
 		settings = _mock_settings(pdf_nota_ppd="Vence el {due_date}")
 		si = _mock_si(payment_schedule=[], due_date="2026-09-01")
-		result = _apply_settings_and_build(si, "PPD", "TestCo", settings)
+		result = _apply_settings_and_build(si, "PPD", settings)
 		self.assertIn("2026", result)
 
 	# Caso 11: Template con placeholder inválido
@@ -183,7 +179,7 @@ class TestBuildPdfCustomSection(unittest.TestCase):
 		settings = _mock_settings(pdf_nota_ppd="Pagar antes de {fecha_invalida}")
 		si = _mock_si()
 		with self.assertRaises(frappe.ValidationError):
-			_apply_settings_and_build(si, "PPD", "TestCo", settings)
+			_apply_settings_and_build(si, "PPD", settings)
 
 	# Caso 15: No hay textos hardcoded PUE o PPD en el código
 	def test_sin_textos_hardcoded(self):


### PR DESCRIPTION
## Objetivo

Correcciones post go-live para LlantasCS (erpstar.llantascs.com): fix de UI en
Complemento Pago MX y feature de contenido PDF configurable por empresa en CFDI tipo I.

## Cambios principales

### fix(cpmx): botón "Descargar PDF+XML" al grupo "Comprobantes"
El botón de descarga quedó fuera del grupo "Comprobantes" al implementar el botón
de email en PR #193. Movido al mismo grupo que "Enviar por email", consistente con FFM.

### feat(timbrado): pdf_custom_section configurable por empresa

Migra la lógica hardcoded de notas PDF del legacy (`facturacion_mx`) a campos
configurables en `Facturacion Mexico Company Settings`, sin textos predeterminados.

- 4 campos nativos en Company Settings: `pdf_nota_pue`, `pdf_nota_ppd`,
  `pdf_incluir_po_no`, `pdf_incluir_remarks` — sin defaults, sin textos hardcoded
- 1 campo nativo en Factura Fiscal Mexico: `fm_pdf_custom_section` (read-only, trazabilidad)
- Solo para CFDI tipo I — tipos E y P quedan sin este campo
- Persistencia solo en timbrado exitoso (`_process_timbrado_success`)
- Validación de template PPD al guardar Company Settings (placeholder desconocido = error)
- 17 tests unitarios — 17/17 OK

## Documentación actualizada

- `docs/tecnico/arquitectura.md` — campo `fm_pdf_custom_section` + sección `pdf_custom_section`
- `docs/usuario/getting-started.md` — sección "Contenido PDF del CFDI" en Company Settings

## Validaciones realizadas

- `bench migrate` en `llantascs-mig.local` — limpio
- `bench migrate` en `test-facturacion.localhost` — limpio
- GUI: campos visibles en Company Settings (puerto 8409)
- GUI: pdf_custom_section aparece en PDF generado por FacturAPI (sandbox, LlantasCS)
- 17 tests unitarios en `test_pdf_custom_section.py` — 17/17 OK
- `mkdocs build --strict` — sin errores

## Fuera de alcance

- Configuración por Customer o por Sales Invoice
- Textos predeterminados o fallbacks en código
- Migración automática de textos legacy
- CFDI tipo E y P

## Riesgos / pendientes

- **Requiere `bench migrate` en producción** al deployar — sin esto los campos no existen en BD
- Los textos PUE/PPD de LlantasCS deben configurarse manualmente en Company Settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable custom PDF content for CFDI invoices, including support for custom legends, purchase order numbers, and remarks based on payment method (PUE/PPD).
  * New Company Settings configuration panel for managing PDF content and payment-specific text templates.

* **Documentation**
  * Updated technical and user guides with PDF customization instructions and field descriptions.

* **Tests**
  * Added comprehensive test coverage for PDF customization and template validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->