### PR TITLE
fix(ffm): permisos de cancelación + cleanup errores 403/417

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-06-19
 **Rama activa:** `fix/ffm-cancel-permissions`
-**Tarea actual:** Correcciones post go-live — permisos cancelación + cleanup 403/417
+**Tarea actual:** Correcciones post go-live — PR abierto (permisos cancelación + cleanup 403/417)
 
 ---
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-06-19
 **Rama activa:** `fix/ffm-cancel-permissions`
-**Tarea actual:** Correcciones post go-live — PR abierto (permisos cancelación + cleanup 403/417)
+**Tarea actual:** PR #197 — fixes CodeRabbit aplicados (6/6)
 
 ---
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,23 +2,24 @@
 
 **Fecha:** 2026-06-19
 **Rama activa:** `fix/ffm-cancel-permissions`
-**Tarea actual:** Restricción de permisos de cancelación FFM — commit en curso
+**Tarea actual:** Correcciones post go-live — permisos cancelación + cleanup 403/417
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Fix de permisos para cancelación de Factura Fiscal Mexico — solo 3 roles autorizados.
+Dos correcciones post go-live LlantasCS en la misma rama: (1) permisos de cancelación
+FFM restringidos a 3 roles; (2) cleanup de errores 403/417 al refrescar FFM.
 
 Plan que estoy siguiendo:
-Correcciones post go-live LlantasCS — permisos y flujo de cancelación.
+Correcciones post go-live LlantasCS. Multi-sucursal fiscal documentado en issue #196.
 
 Objetivo inmediato:
-Commit + push + PR de este fix.
+Push + PR de esta rama.
 
 Criterio de avance:
-PR mergeado y cambios en producción vía bench migrate.
+PR mergeado y cambios en producción vía bench migrate + bench build.
 
 ---
 
@@ -28,9 +29,12 @@ PR mergeado y cambios en producción vía bench migrate.
 - PR #195 mergeado: fix pdf_custom_section + CodeRabbit
 - PR #193 mergeado: fixes post go-live timbrado + CPMX email
 - PR #192 mergeado: migración Fase 2 FFM + CPMX
+- Issue #196 creado: habilitación explícita multi-sucursal fiscal por Company
 
 ### En progreso
-- Rama `fix/ffm-cancel-permissions`: permisos cancelación FFM
+- Rama `fix/ffm-cancel-permissions` (2 commits):
+  - 1452ed5: permisos cancelación FFM (3 roles)
+  - (en curso): cleanup 403/417 JS + prueba estática
 
 ### Pendiente inmediato
 1. Push de esta rama
@@ -38,36 +42,38 @@ PR mergeado y cambios en producción vía bench migrate.
 3. Deploy en producción: `bench migrate` + `bench build`
 4. Configurar textos PUE/PPD en Company Settings de LlantasCS en producción
 5. Ejecutar `fix_fm_tax_regime_from_tax_category.py` en producción cuando esté listo
-6. Reporte pendientes migración entregado al cliente (93 casos + 21 SIs adicionales)
+6. Multi-sucursal fiscal (issue #196) — implementación fin de semana
 
 ### No repetir
 - NO persistir fm_pdf_custom_section en el payload — solo en _process_timbrado_success
 - NO mergear chore/track-working-docs-archive directo — tiene código obsoleto mezclado
-- Bug `frappe.utils.get_site_config` en factura_fiscal_mexico.js pendiente — no urgente
+- NO conectar fm_branch al timbrado en esta rama — eso es trabajo del issue #196
+- NO tocar series/folios/lugar_expedicion/payload en esta rama
+
+### No repetir (multi-sucursal — para #196)
+- El timbrado lee `branch` (campo inexistente en SI); SI usa `fm_branch`
+- La serie siempre cae en "F" (timbrado_api.py:698)
+- BranchFolioManager y Configuracion Fiscal Sucursal desconectados del timbrado
+- El indicador debe ser explícito por Company: `multisucursal_fiscal_enabled`
 
 ---
 
 ## Decisiones vigentes
-- Solo 3 roles pueden cancelar FFM: System Manager, Facturacion Mexico Manager, Facturacion Mexico System Manager
-- Accounts Manager y Accounts User: cancel=0 explícito en DocPerm
+- Solo 3 roles cancelan FFM: System Manager, Facturacion Mexico Manager, Facturacion Mexico System Manager
+- `control_multisucursal_field_visibility` solo oculta campos localmente (sin llamadas servidor)
 - `pdf_custom_section` solo para CFDI tipo I
-- Solo Company Settings (sin Customer ni SI override)
 
 ---
 
 ## Archivos relevantes ahora
 
-### Probablemente editar
-- `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py`
-- `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json`
-
 ### No tocar
 - `patches.txt` — vacío por diseño (RG-010b)
 - `one_offs/fix_fm_tax_regime_from_tax_category.py` — pendiente ejecución producción
+- `timbrado_api.py` — NO modificar en esta rama (es trabajo de #196)
 
 ---
 
 ## Riesgos / cuidados
-- Producción necesita `bench migrate` para activar permisos nuevos en FFM
+- Producción necesita `bench migrate` + `bench build` para activar permisos y JS nuevos
 - `chore/track-working-docs-archive` tiene código obsoleto — no mergear sin cherry-pick
-- Bug `frappe.utils.get_site_config` en JS genera ruido en consola pero no bloquea funcionalidad

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,72 +1,73 @@
 # CONTINUITY.md — facturacion_mexico
 
 **Fecha:** 2026-06-19
-**Rama activa:** `fix/post-golive-corrections`
-**Tarea actual:** PR abierto — fix/post-golive-corrections → main
+**Rama activa:** `fix/ffm-cancel-permissions`
+**Tarea actual:** Restricción de permisos de cancelación FFM — commit en curso
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-PR de correcciones post go-live LlantasCS — UI CPMX y pdf_custom_section configurable.
+Fix de permisos para cancelación de Factura Fiscal Mexico — solo 3 roles autorizados.
 
 Plan que estoy siguiendo:
-PR #195 (o el número asignado) — esperando review de CodeRabbit y merge.
+Correcciones post go-live LlantasCS — permisos y flujo de cancelación.
 
 Objetivo inmediato:
-Merge del PR y deploy en producción (erpstar.llantascs.com).
+Commit + push + PR de este fix.
 
 Criterio de avance:
-PR mergeado, bench migrate en producción, textos PPD/PUE configurados en Company Settings de LlantasCS.
+PR mergeado y cambios en producción vía bench migrate.
 
 ---
 
 ## Estado actual
 
-### Ya cerrado (en esta rama)
-- `1b4f82e` fix(cpmx): botón "Descargar PDF+XML" movido al grupo "Comprobantes"
-- `5cedd69` feat(timbrado): pdf_custom_section configurable por empresa (17/17 tests)
-- `5ac431b` docs(usuario): sección "Contenido PDF del CFDI" en getting-started
-- `ca5bb73` docs(usuario): corrección — sin textos prescriptivos ni recomendados
+### Ya cerrado
+- PR #195 mergeado: fix pdf_custom_section + CodeRabbit
+- PR #193 mergeado: fixes post go-live timbrado + CPMX email
+- PR #192 mergeado: migración Fase 2 FFM + CPMX
 
 ### En progreso
-- PR abierto — esperando CodeRabbit y autorización de merge
+- Rama `fix/ffm-cancel-permissions`: permisos cancelación FFM
 
 ### Pendiente inmediato
-1. Merge del PR
-2. Deploy: `bench migrate` en erpstar.llantascs.com
-3. Configurar manualmente textos PUE/PPD en Company Settings de LlantasCS
+1. Push de esta rama
+2. Abrir PR
+3. Deploy en producción: `bench migrate` + `bench build`
+4. Configurar textos PUE/PPD en Company Settings de LlantasCS en producción
+5. Ejecutar `fix_fm_tax_regime_from_tax_category.py` en producción cuando esté listo
+6. Reporte pendientes migración entregado al cliente (93 casos + 21 SIs adicionales)
 
 ### No repetir
-- NO persistir `fm_pdf_custom_section` en el payload — solo en `_process_timbrado_success`
-- NO incluir textos específicos del cliente en docs generales del app
-- NO hardcodear leyendas PUE/PPD en código
+- NO persistir fm_pdf_custom_section en el payload — solo en _process_timbrado_success
+- NO mergear chore/track-working-docs-archive directo — tiene código obsoleto mezclado
+- Bug `frappe.utils.get_site_config` en factura_fiscal_mexico.js pendiente — no urgente
 
 ---
 
 ## Decisiones vigentes
+- Solo 3 roles pueden cancelar FFM: System Manager, Facturacion Mexico Manager, Facturacion Mexico System Manager
+- Accounts Manager y Accounts User: cancel=0 explícito en DocPerm
 - `pdf_custom_section` solo para CFDI tipo I
-- Sin defaults en pdf_nota_pue/ppd — vacío = no enviar
 - Solo Company Settings (sin Customer ni SI override)
-- Template PPD validado al guardar (placeholder desconocido = ValidationError)
-- Persistencia solo en timbrado exitoso
 
 ---
 
 ## Archivos relevantes ahora
 
-### Leer primero
-- `facturacion_fiscal/timbrado_api.py` — `_build_pdf_custom_section`, `_process_timbrado_success`
-- `docs/usuario/getting-started.md` — sección "Contenido PDF del CFDI"
+### Probablemente editar
+- `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py`
+- `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json`
 
 ### No tocar
 - `patches.txt` — vacío por diseño (RG-010b)
-- `one_offs/` — no commitear
+- `one_offs/fix_fm_tax_regime_from_tax_category.py` — pendiente ejecución producción
 
 ---
 
 ## Riesgos / cuidados
-- Requiere `bench migrate` en producción al deployar — sin esto los campos no existen en BD
-- LlantasCS debe configurar manualmente sus textos PPD/PUE en Company Settings
-- `llantascs-mig.local` (8409) tiene encryption key distinta — API keys deben re-ingresarse
+- Producción necesita `bench migrate` para activar permisos nuevos en FFM
+- `chore/track-working-docs-archive` tiene código obsoleto — no mergear sin cherry-pick
+- Bug `frappe.utils.get_site_config` en JS genera ruido en consola pero no bloquea funcionalidad

--- a/docs/usuario/cancelar-cfdi.md
+++ b/docs/usuario/cancelar-cfdi.md
@@ -94,6 +94,22 @@ Puedes verificar cualquier operación de cancelación en **FacturAPI Response Lo
 
 ---
 
+## Permisos requeridos para cancelar
+
+Solo los siguientes roles pueden cancelar una Factura Fiscal Mexico:
+
+| Rol | Puede cancelar FFM |
+|---|---|
+| System Manager | ✅ Sí |
+| Facturacion Mexico Manager | ✅ Sí |
+| Facturacion Mexico System Manager | ✅ Sí |
+| Accounts Manager | ❌ No |
+| Accounts User | ❌ No |
+
+El botón **Cancel** no aparece en la UI si el usuario no tiene uno de los roles autorizados.
+
+---
+
 ## Restricciones adicionales
 
 - Solo se pueden cancelar facturas con `fm_fiscal_status = TIMBRADO`

--- a/docs/usuario/cancelar-cfdi.md
+++ b/docs/usuario/cancelar-cfdi.md
@@ -106,7 +106,13 @@ Solo los siguientes roles pueden cancelar una Factura Fiscal Mexico:
 | Accounts Manager | ❌ No |
 | Accounts User | ❌ No |
 
-El botón **Cancel** no aparece en la UI si el usuario no tiene uno de los roles autorizados.
+El control de acceso opera en dos niveles:
+
+- **Botón Cancel nativo de Frappe** — depende del permiso `cancel` del DocPerm: solo se
+  habilita para los roles con `cancel=1`.
+- **Acción de cancelación personalizada** (`cancel_ffm_keep_si`) — la autorización se valida
+  en el servidor mediante `frappe.only_for`. Si el usuario no tiene uno de los roles
+  autorizados, la operación se rechaza con error de permisos al ejecutarse.
 
 ---
 

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -1610,9 +1610,6 @@
 			"cancellation_date", // Fecha de Cancelación
 		];
 
-		// NUEVA FUNCIONALIDAD: Control de lugar_expedicion basado en multi-sucursal
-		control_multisucursal_field_visibility(frm);
-
 		// Usar estados centralizados para lógica de visibilidad
 		load_fiscal_states(function (states) {
 			if (!states) {
@@ -1624,6 +1621,8 @@
 					hide_section(frm, "section_break_archivos");
 					hide_section(frm, "section_break_cancelacion");
 				}
+				// El ocultamiento multi-sucursal debe prevalecer al terminar el refresh.
+				control_multisucursal_field_visibility(frm);
 				return;
 			}
 
@@ -1670,6 +1669,13 @@
 				show_section(frm, "section_break_archivos");
 				hide_section(frm, "section_break_cancelacion"); // Aún no confirmada
 			}
+
+			// El ocultamiento multi-sucursal debe prevalecer al terminar el refresh.
+			// fm_serie_folio está en facturapi_response_fields y los show_fields de
+			// arriba lo re-exponen; esta llamada al final garantiza que quede oculto
+			// mientras multi-sucursal fiscal no esté habilitado (corrección temporal —
+			// solución definitiva en issue #196).
+			control_multisucursal_field_visibility(frm);
 		});
 	}
 

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -1710,32 +1710,19 @@
 	// ========================================
 
 	function control_multisucursal_field_visibility(frm) {
-		// Control de visibilidad de campos multi-sucursal basado en configuración
-
-		// Verificar si multi-sucursal está habilitado a nivel de sitio
-		frappe.call({
-			method: "frappe.client.get_value",
-			args: {
-				doctype: "System Settings",
-				fieldname: ["multisucursal_enabled"],
-			},
-			callback: function (r) {
-				const is_multisucursal_enabled = r.message && r.message.multisucursal_enabled;
-
-				// Controlar visibilidad del campo lugar_expedicion
-				if (is_multisucursal_enabled) {
-					// Si multi-sucursal está habilitado, mostrar lugar_expedicion
-					show_multisucursal_fields(frm);
-				} else {
-					// Si multi-sucursal NO está habilitado, ocultar lugar_expedicion
-					hide_multisucursal_fields(frm);
-				}
-			},
-			error: function () {
-				// En caso de error, verificar por site_config.json
-				check_site_config_multisucursal(frm);
-			},
-		});
+		// Control de visibilidad de campos multi-sucursal.
+		//
+		// Multi-sucursal fiscal NO está implementado todavía: no existe un
+		// indicador explícito por Company que lo habilite. Mientras tanto,
+		// se ocultan los campos sin hacer llamadas al servidor.
+		//
+		// Antes este método consultaba "System Settings.multisucursal_enabled"
+		// (campo inexistente → 403) y como fallback "frappe.utils.get_site_config"
+		// (método eliminado en Frappe v16 → 417). Ambas llamadas se ejecutaban en
+		// cada refresh de la FFM y ensuciaban la consola sin efecto funcional.
+		//
+		// Ver issue de raíz sobre habilitación explícita de multi-sucursal fiscal.
+		hide_multisucursal_fields(frm);
 	}
 
 	function show_multisucursal_fields(frm) {
@@ -1779,29 +1766,6 @@
 		// Ocultar sección multi-sucursal si existe
 		hide_section(frm, "section_break_multisucursal");
 		hide_section(frm, "fm_multibranch_section");
-	}
-
-	function check_site_config_multisucursal(frm) {
-		// Verificar configuración multi-sucursal en site_config.json
-		frappe.call({
-			method: "frappe.utils.get_site_config",
-			args: {
-				key: "multisucursal_enabled",
-			},
-			callback: function (r) {
-				const is_multisucursal_enabled = r.message === 1 || r.message === true;
-
-				if (is_multisucursal_enabled) {
-					show_multisucursal_fields(frm);
-				} else {
-					hide_multisucursal_fields(frm);
-				}
-			},
-			error: function () {
-				// Si falla todo, usar comportamiento por defecto (ocultar)
-				hide_multisucursal_fields(frm);
-			},
-		});
 	}
 
 	// ========================================

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -477,6 +477,7 @@
  "permissions": [
   {
    "amend": 0,
+   "cancel": 0,
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -490,7 +491,9 @@
   },
   {
    "amend": 0,
+   "cancel": 0,
    "create": 1,
+   "delete": 0,
    "email": 1,
    "export": 1,
    "print": 1,
@@ -502,6 +505,7 @@
   },
   {
    "amend": 0,
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -511,6 +515,37 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 0,
+   "cancel": 1,
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Facturacion Mexico Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 0,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Facturacion Mexico System Manager",
+   "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -1330,10 +1330,10 @@ def check_si_customer_rfc_validated(si_name: str):
 @frappe.whitelist()
 def cancel_ffm_keep_si(ffm_name: str):
 	"""Cancela SOLO la FFM (sin cfdi_uuid) y libera la Sales Invoice enlazada.
-	- Requiere rol: System Manager o Facturacion Mexico System Manager
+	- Requiere rol: System Manager, Facturacion Mexico System Manager o Facturacion Mexico Manager
 	- Deja la SI viva (docstatus=1) y sin link a FFM, lista para reintentar.
 	"""
-	frappe.only_for(("System Manager", "Facturacion Mexico System Manager"))
+	frappe.only_for(("System Manager", "Facturacion Mexico System Manager", "Facturacion Mexico Manager"))
 
 	ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
 	if ffm.docstatus != 1 or getattr(ffm, "fm_uuid", None):

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_cancel_permissions.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_cancel_permissions.py
@@ -1,0 +1,128 @@
+"""Tests de permisos de cancelación en Factura Fiscal Mexico.
+
+Verifica que solo los roles autorizados pueden cancelar FFMs:
+- Facturacion Mexico Manager: SÍ puede cancelar
+- Facturacion Mexico System Manager: SÍ puede cancelar
+- System Manager: SÍ puede cancelar (superuser)
+- Accounts Manager: NO puede cancelar
+- Accounts User: NO puede cancelar
+"""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+	cancel_ffm_keep_si,
+)
+
+ROLES_AUTORIZADOS = [
+	"Facturacion Mexico Manager",
+	"Facturacion Mexico System Manager",
+]
+
+ROLES_BLOQUEADOS = [
+	"Accounts Manager",
+	"Accounts User",
+	"Facturacion Mexico User",
+]
+
+
+def _make_test_user(roles: list[str]) -> str:
+	uid = "test-ffm-cancel-" + frappe.generate_hash()[:8] + "@test.com"
+	user = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": uid,
+			"first_name": "Test",
+			"send_welcome_email": 0,
+			"roles": [{"role": r} for r in roles],
+		}
+	)
+	user.insert(ignore_permissions=True)
+	return uid
+
+
+def _make_test_ffm() -> str:
+	"""Crea una FFM sin UUID (sin timbre) para probar cancel_ffm_keep_si."""
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"status": "ERROR",
+			"fm_tipo_comprobante": "I",
+			"company": frappe.defaults.get_global_default("company") or "_Test Company",
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.db_insert()
+	return ffm.name
+
+
+class TestFFMCancelPermisos(IntegrationTestCase):
+	def setUp(self):
+		self.ffm_names = []
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for name in self.ffm_names:
+			frappe.db.delete("Factura Fiscal Mexico", {"name": name})
+		frappe.db.commit()
+
+	def _ffm(self):
+		name = _make_test_ffm()
+		self.ffm_names.append(name)
+		return name
+
+	def test_facturacion_mexico_manager_puede_cancelar(self):
+		uid = _make_test_user(["Facturacion Mexico Manager"])
+		ffm_name = self._ffm()
+		frappe.set_user(uid)
+		try:
+			cancel_ffm_keep_si(ffm_name)
+		except frappe.PermissionError:
+			self.fail("Facturacion Mexico Manager no debería recibir PermissionError al cancelar FFM")
+		except Exception:
+			# Otros errores (DB transaction, validaciones) son aceptables —
+			# lo importante es que el check de permiso pasó.
+			pass
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_facturacion_mexico_system_manager_puede_cancelar(self):
+		uid = _make_test_user(["Facturacion Mexico System Manager"])
+		ffm_name = self._ffm()
+		frappe.set_user(uid)
+		try:
+			cancel_ffm_keep_si(ffm_name)
+		except frappe.PermissionError:
+			self.fail("Facturacion Mexico System Manager no debería recibir PermissionError")
+		except Exception:
+			pass
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_accounts_manager_no_puede_cancelar(self):
+		uid = _make_test_user(["Accounts Manager"])
+		ffm_name = self._ffm()
+		frappe.set_user(uid)
+		with self.assertRaises(frappe.PermissionError):
+			cancel_ffm_keep_si(ffm_name)
+		frappe.set_user("Administrator")
+
+	def test_accounts_user_no_puede_cancelar(self):
+		uid = _make_test_user(["Accounts User"])
+		ffm_name = self._ffm()
+		frappe.set_user(uid)
+		with self.assertRaises(frappe.PermissionError):
+			cancel_ffm_keep_si(ffm_name)
+		frappe.set_user("Administrator")
+
+	def test_facturacion_mexico_user_no_puede_cancelar(self):
+		uid = _make_test_user(["Facturacion Mexico User"])
+		ffm_name = self._ffm()
+		frappe.set_user(uid)
+		with self.assertRaises(frappe.PermissionError):
+			cancel_ffm_keep_si(ffm_name)
+		frappe.set_user("Administrator")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_cancel_permissions.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_cancel_permissions.py
@@ -1,11 +1,12 @@
 """Tests de permisos de cancelación en Factura Fiscal Mexico.
 
 Verifica que solo los roles autorizados pueden cancelar FFMs:
+- System Manager: SÍ puede cancelar (superuser)
 - Facturacion Mexico Manager: SÍ puede cancelar
 - Facturacion Mexico System Manager: SÍ puede cancelar
-- System Manager: SÍ puede cancelar (superuser)
 - Accounts Manager: NO puede cancelar
 - Accounts User: NO puede cancelar
+- Facturacion Mexico User: NO puede cancelar
 """
 
 import frappe
@@ -15,12 +16,13 @@ from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura
 	cancel_ffm_keep_si,
 )
 
-ROLES_AUTORIZADOS = [
+ALLOWED_ROLES = [
+	"System Manager",
 	"Facturacion Mexico Manager",
 	"Facturacion Mexico System Manager",
 ]
 
-ROLES_BLOQUEADOS = [
+BLOCKED_ROLES = [
 	"Accounts Manager",
 	"Accounts User",
 	"Facturacion Mexico User",
@@ -63,26 +65,37 @@ def _make_test_ffm() -> str:
 class TestFFMCancelPermisos(IntegrationTestCase):
 	def setUp(self):
 		self.ffm_names = []
+		self.user_ids = []
+		# Garantizar reset de usuario aunque una aserción falle a mitad de test.
+		self.addCleanup(frappe.set_user, "Administrator")
 
 	def tearDown(self):
 		frappe.set_user("Administrator")
 		for name in self.ffm_names:
 			frappe.db.delete("Factura Fiscal Mexico", {"name": name})
+		for uid in self.user_ids:
+			frappe.db.delete("User", {"name": uid})
 		frappe.db.commit()
+
+	def _user(self, roles):
+		uid = _make_test_user(roles)
+		self.user_ids.append(uid)
+		return uid
 
 	def _ffm(self):
 		name = _make_test_ffm()
 		self.ffm_names.append(name)
 		return name
 
-	def test_facturacion_mexico_manager_puede_cancelar(self):
-		uid = _make_test_user(["Facturacion Mexico Manager"])
+	def _assert_puede_cancelar(self, role: str):
+		"""Verifica que el rol NO recibe PermissionError al cancelar FFM."""
+		uid = self._user([role])
 		ffm_name = self._ffm()
 		frappe.set_user(uid)
 		try:
 			cancel_ffm_keep_si(ffm_name)
 		except frappe.PermissionError:
-			self.fail("Facturacion Mexico Manager no debería recibir PermissionError al cancelar FFM")
+			self.fail(f"El rol '{role}' no debería recibir PermissionError al cancelar FFM")
 		except Exception:
 			# Otros errores (DB transaction, validaciones) son aceptables —
 			# lo importante es que el check de permiso pasó.
@@ -90,39 +103,31 @@ class TestFFMCancelPermisos(IntegrationTestCase):
 		finally:
 			frappe.set_user("Administrator")
 
-	def test_facturacion_mexico_system_manager_puede_cancelar(self):
-		uid = _make_test_user(["Facturacion Mexico System Manager"])
+	def _assert_no_puede_cancelar(self, role: str):
+		"""Verifica que el rol SÍ recibe PermissionError al cancelar FFM."""
+		uid = self._user([role])
 		ffm_name = self._ffm()
 		frappe.set_user(uid)
 		try:
-			cancel_ffm_keep_si(ffm_name)
-		except frappe.PermissionError:
-			self.fail("Facturacion Mexico System Manager no debería recibir PermissionError")
-		except Exception:
-			pass
+			with self.assertRaises(frappe.PermissionError):
+				cancel_ffm_keep_si(ffm_name)
 		finally:
 			frappe.set_user("Administrator")
 
+	def test_system_manager_puede_cancelar(self):
+		self._assert_puede_cancelar("System Manager")
+
+	def test_facturacion_mexico_manager_puede_cancelar(self):
+		self._assert_puede_cancelar("Facturacion Mexico Manager")
+
+	def test_facturacion_mexico_system_manager_puede_cancelar(self):
+		self._assert_puede_cancelar("Facturacion Mexico System Manager")
+
 	def test_accounts_manager_no_puede_cancelar(self):
-		uid = _make_test_user(["Accounts Manager"])
-		ffm_name = self._ffm()
-		frappe.set_user(uid)
-		with self.assertRaises(frappe.PermissionError):
-			cancel_ffm_keep_si(ffm_name)
-		frappe.set_user("Administrator")
+		self._assert_no_puede_cancelar("Accounts Manager")
 
 	def test_accounts_user_no_puede_cancelar(self):
-		uid = _make_test_user(["Accounts User"])
-		ffm_name = self._ffm()
-		frappe.set_user(uid)
-		with self.assertRaises(frappe.PermissionError):
-			cancel_ffm_keep_si(ffm_name)
-		frappe.set_user("Administrator")
+		self._assert_no_puede_cancelar("Accounts User")
 
 	def test_facturacion_mexico_user_no_puede_cancelar(self):
-		uid = _make_test_user(["Facturacion Mexico User"])
-		ffm_name = self._ffm()
-		frappe.set_user(uid)
-		with self.assertRaises(frappe.PermissionError):
-			cancel_ffm_keep_si(ffm_name)
-		frappe.set_user("Administrator")
+		self._assert_no_puede_cancelar("Facturacion Mexico User")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_js_multisucursal_cleanup.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_js_multisucursal_cleanup.py
@@ -1,0 +1,127 @@
+"""Prueba estática del cleanup de multi-sucursal en el JS de Factura Fiscal Mexico.
+
+Verifica que la corrección temporal de los errores 403/417 (al abrir/refrescar
+una FFM) quedó correctamente aplicada en el cliente, sin tocar la lógica de
+timbrado.
+
+Contexto: `control_multisucursal_field_visibility` consultaba campos/métodos
+inexistentes en Frappe v16 (`System Settings.multisucursal_enabled` → 403 y
+`frappe.utils.get_site_config` → 417). La corrección elimina esas llamadas y
+oculta los campos multi-sucursal sin tocar el servidor. La implementación
+definitiva de multi-sucursal fiscal está documentada en su issue de raíz.
+
+Esta prueba es estática (lee los archivos) — no abre formularios ni ejecuta JS.
+"""
+
+import os
+import re
+import unittest
+
+APP_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+FFM_JS = os.path.join(
+	APP_ROOT,
+	"facturacion_fiscal",
+	"doctype",
+	"factura_fiscal_mexico",
+	"factura_fiscal_mexico.js",
+)
+
+TIMBRADO_API = os.path.join(APP_ROOT, "facturacion_fiscal", "timbrado_api.py")
+
+
+def _strip_js_line_comments(source: str) -> str:
+	"""Devuelve solo las líneas de código JS, eliminando las de comentario `//`.
+
+	El comentario explicativo del cleanup menciona intencionalmente las cadenas
+	eliminadas ("System Settings", "frappe.utils.get_site_config"); esta función
+	las descarta para que las aserciones evalúen únicamente código ejecutable.
+	"""
+	code_lines = []
+	for line in source.splitlines():
+		if line.strip().startswith("//"):
+			continue
+		code_lines.append(line)
+	return "\n".join(code_lines)
+
+
+class TestFFMJsMultisucursalCleanup(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		with open(FFM_JS, encoding="utf-8") as f:
+			cls.js_raw = f.read()
+		cls.js_code = _strip_js_line_comments(cls.js_raw)
+		with open(TIMBRADO_API, encoding="utf-8") as f:
+			cls.timbrado_src = f.read()
+
+	def test_no_system_settings_en_logica_activa(self):
+		"""No debe quedar ninguna consulta a System Settings en código ejecutable."""
+		self.assertNotIn(
+			"System Settings",
+			self.js_code,
+			"Quedó una referencia activa a 'System Settings' en el JS de FFM (causa 403).",
+		)
+
+	def test_no_get_site_config(self):
+		"""No debe quedar ninguna llamada a frappe.utils.get_site_config (causa 417)."""
+		self.assertNotIn(
+			"frappe.utils.get_site_config",
+			self.js_code,
+			"Quedó una referencia activa a 'frappe.utils.get_site_config' en el JS de FFM (causa 417).",
+		)
+
+	def test_no_existe_check_site_config_multisucursal(self):
+		"""La función fallback check_site_config_multisucursal debe estar eliminada."""
+		self.assertNotIn(
+			"check_site_config_multisucursal",
+			self.js_raw,
+			"La función 'check_site_config_multisucursal' no fue eliminada del JS.",
+		)
+
+	def test_control_visibility_llama_hide(self):
+		"""control_multisucursal_field_visibility debe llamar a hide_multisucursal_fields."""
+		match = re.search(
+			r"function\s+control_multisucursal_field_visibility\s*\(frm\)\s*\{(.*?)\n\t\}",
+			self.js_raw,
+			re.DOTALL,
+		)
+		self.assertIsNotNone(
+			match,
+			"No se encontró la función control_multisucursal_field_visibility.",
+		)
+		body = match.group(1)
+		self.assertIn(
+			"hide_multisucursal_fields(frm)",
+			body,
+			"control_multisucursal_field_visibility no llama a hide_multisucursal_fields.",
+		)
+		# No debe hacer llamadas al servidor dentro de esta función.
+		body_code = _strip_js_line_comments(body)
+		self.assertNotIn(
+			"frappe.call",
+			body_code,
+			"control_multisucursal_field_visibility no debe hacer llamadas al servidor.",
+		)
+
+	def test_timbrado_api_serie_intacta(self):
+		"""Guard: la lógica de serie en timbrado_api.py no fue modificada."""
+		self.assertIn(
+			'serie_for_pac = "F"',
+			self.timbrado_src,
+			"Se modificó la resolución de serie en timbrado_api.py (debe permanecer intacta).",
+		)
+
+	def test_timbrado_api_payload_sin_lugar_expedicion(self):
+		"""Guard: el payload a FacturAPI sigue sin incluir lugar_expedicion."""
+		# Aislar el dict invoice_data principal para no leer comentarios sueltos.
+		match = re.search(
+			r"invoice_data\s*=\s*\{(.*?)\n\t\t\}",
+			self.timbrado_src,
+			re.DOTALL,
+		)
+		self.assertIsNotNone(match, "No se encontró el dict invoice_data en timbrado_api.py.")
+		self.assertNotIn(
+			"lugar_expedicion",
+			match.group(1),
+			"El payload invoice_data ahora incluye lugar_expedicion (no debe cambiar en esta corrección).",
+		)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_js_multisucursal_cleanup.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_js_multisucursal_cleanup.py
@@ -81,9 +81,8 @@ class TestFFMJsMultisucursalCleanup(unittest.TestCase):
 	def test_control_visibility_llama_hide(self):
 		"""control_multisucursal_field_visibility debe llamar a hide_multisucursal_fields."""
 		match = re.search(
-			r"function\s+control_multisucursal_field_visibility\s*\(frm\)\s*\{(.*?)\n\t\}",
+			r"function\s+control_multisucursal_field_visibility\s*\(frm\)\s*\{([\s\S]*?)\n\s*\}",
 			self.js_raw,
-			re.DOTALL,
 		)
 		self.assertIsNotNone(
 			match,
@@ -115,9 +114,8 @@ class TestFFMJsMultisucursalCleanup(unittest.TestCase):
 		"""Guard: el payload a FacturAPI sigue sin incluir lugar_expedicion."""
 		# Aislar el dict invoice_data principal para no leer comentarios sueltos.
 		match = re.search(
-			r"invoice_data\s*=\s*\{(.*?)\n\t\t\}",
+			r"invoice_data\s*=\s*\{([\s\S]*?)\n\s*\}",
 			self.timbrado_src,
-			re.DOTALL,
 		)
 		self.assertIsNotNone(match, "No se encontró el dict invoice_data en timbrado_api.py.")
 		self.assertNotIn(


### PR DESCRIPTION
## Objetivo

Dos correcciones post go-live LlantasCS, ambas sobre Factura Fiscal Mexico:
1. Restringir la cancelación de FFM a roles autorizados.
2. Eliminar los errores 403/417 que aparecían en consola al abrir/refrescar una FFM.

## Cambios principales

### Permisos de cancelación (commit 1452ed5)
- DocPerm de `Factura Fiscal Mexico`: solo `System Manager`, `Facturacion Mexico Manager` y `Facturacion Mexico System Manager` pueden cancelar. `Accounts Manager` y `Accounts User` quedan con `cancel=0`.
- `cancel_ffm_keep_si`: `only_for` actualizado con los 3 roles autorizados.
- 5 tests de cobertura de permisos (2 roles permitidos + 3 bloqueados).

### Cleanup 403/417 (commit ac66352)
- `control_multisucursal_field_visibility` ya no consulta `System Settings.multisucursal_enabled` (403) ni `frappe.utils.get_site_config` (417, método eliminado en v16). Ahora solo oculta los campos localmente.
- Eliminada la función fallback `check_site_config_multisucursal`.
- Sin cambio de comportamiento visible: los campos multi-sucursal ya se ocultaban.
- Prueba estática que verifica la ausencia de las llamadas eliminadas y confirma que `timbrado_api.py` no fue modificado.

## Documentación actualizada
- `docs/usuario/cancelar-cfdi.md` — tabla de roles autorizados para cancelar FFM.

## Validaciones realizadas
- `bench --site test-facturacion.localhost run-tests`:
  - `test_ffm_cancel_permissions` → 5/5 OK
  - `test_ffm_js_multisucursal_cleanup` → 6/6 OK
- `ruff check` → All checks passed
- `mkdocs build --strict` → sin errores
- `bench --site facturacion-v16.dev migrate` → limpio (permisos aplicados)

## Fuera de alcance
- Implementación de multi-sucursal fiscal → documentada en issue #196 (fin de semana).
- No se tocó `timbrado_api.py`, series, folios, lugar de expedición ni payload FacturAPI.

## Riesgos / pendientes
- Requiere `bench migrate` + `bench build` en producción para activar los permisos nuevos y el JS corregido.
- El indicador explícito de multi-sucursal por Company queda pendiente (issue #196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added reference guide for user roles and permissions required when canceling Factura Fiscal Mexico documents.

* **Changes**
  * Updated FFM cancellation access controls to restrict authorization to specific roles.
  * Corrected multi-sucursal field visibility and eliminated problematic configuration lookup errors.

* **Tests**
  * Added tests validating FFM cancellation permissions and multi-sucursal form field behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->