### PR TITLE
fix(fiscal): integridad y correlación de Factura Fiscal Mexico (incidente doble FFM)

### DIFF
--- a/docs/adr/0034-integridad-correlacion-ffm.md
+++ b/docs/adr/0034-integridad-correlacion-ffm.md
@@ -40,7 +40,7 @@ Una Sales Invoice (SI) terminó con **dos Factura Fiscal Mexico (FFM)** y una **
 | `factura_fiscal_mexico/factura_fiscal_mexico.py` | `get_or_create_active_ffm` (creación centralizada + lock + resolución por activos), guard `before_insert` (Regla B) |
 | `config/fiscal_states_config.py` | `ACTIVE_STATES` + helpers `is_active`/`is_final` |
 | `api/fiscal_operations.py` | Refacturación 02/03/04: eliminación del guard `pending` |
-| `public/js/sales_invoice.js` | Botón "Generar Factura Fiscal" → `get_or_create_active_ffm` (servidor); elimina `client.insert`/`set_value` |
+| `public/js/sales_invoice.js` | Botón "Timbrar Factura" → `get_or_create_active_ffm` (servidor); elimina `client.insert`/`set_value` |
 
 ### Los 11 commits
 | # | Hash | Propósito | Depende de | Antes → Después | Riesgo |
@@ -224,7 +224,7 @@ PASO 1 ok (estado fiscal persistido) · PASO 2 falla → rollback al savepoint �
 
 ## 13. Observabilidad posterior al despliegue
 
-Revisar: nuevos FFM duplicados por SI · frecuencia de `FiscalCorrelationError` · distribución de `fm_sync_status` · errores de Response Log (`audit_log_failed`) · FFM en `ERROR` · resultados con `retry_allowed=False` / mensajes "No repita la operación" · tiempos de espera por lock · cancelaciones en `PENDIENTE_CANCELACION` · errores JS del botón "Generar Factura Fiscal".
+Revisar: nuevos FFM duplicados por SI · frecuencia de `FiscalCorrelationError` · distribución de `fm_sync_status` · errores de Response Log (`audit_log_failed`) · FFM en `ERROR` · resultados con `retry_allowed=False` / mensajes "No repita la operación" · tiempos de espera por lock · cancelaciones en `PENDIENTE_CANCELACION` · errores JS del botón "Timbrar Factura".
 
 ---
 

--- a/docs/adr/0034-integridad-correlacion-ffm.md
+++ b/docs/adr/0034-integridad-correlacion-ffm.md
@@ -1,0 +1,273 @@
+# ADR-0034 — Integridad y correlación de Factura Fiscal Mexico
+
+- **Estado:** Propuesto
+- **Fecha:** 2026-06-21
+- **Rango de código:** `9d7353d^..52676d7` (11 commits)
+- **Supersede parcialmente:** ADR-0018 (estados FFM), ADR-0015 (relación SI↔FFM)
+- **Declaración previa:** Este bloque **NO** implementa un motor de conciliación automática FFM ↔ PAC/SAT. Ese motor **no forma parte de este ADR** (ver §8).
+
+---
+
+## 1. Contexto e incidente original
+
+### Incidente original (producción LlantasCS)
+Una Sales Invoice (SI) terminó con **dos Factura Fiscal Mexico (FFM)** y una **cancelación se aplicó al FFM equivocado**. Causa raíz: la respuesta del PAC se asociaba al FFM resolviendo **por Sales Invoice** (`frappe.db.get_value` con `order_by` por defecto → `ORDER BY creation`, es decir el más antiguo), no por el FFM que originó la operación.
+
+### Defectos estructurales descubiertos durante el análisis
+- Creación del FFM en **JavaScript** (`frappe.client.insert` + `frappe.client.set_value`), con **ventana de carrera** entre la lectura del vínculo y la inserción.
+- Podían **coexistir varios FFM activos** para una SI (sin regla de cardinalidad).
+- Un fallo del **Response Log** podía revertir u ocultar el estado fiscal ya confirmado por el PAC.
+- `fm_sync_status` con **semántica inconsistente**: escrito como "¿la respuesta trae `success`?", consumido como "¿hay operación en curso?".
+- La refacturación 02/03/04 se **bloqueaba incorrectamente** por `fm_sync_status == "pending"`.
+- En timbrado exitoso, el writer derivaba **`ERROR` transitorio** porque el UUID llega dentro de `raw_response`, no a nivel superior.
+
+### Datos históricos existentes (no creados por este bloque)
+- 11.668 FFM cargan correctamente.
+- 77 con `fm_sync_status="pending"` (70 `TIMBRADO`, 6 `BORRADOR`, 1 `ERROR`); los 70 `TIMBRADO` tienen `fm_uuid` y `facturapi_id`.
+- 6 grupos con 2 FFM activos por SI (patrón `TIMBRADO + BORRADOR/ERROR`).
+
+> Separación: **(a)** incidente original = doble FFM + cancelación equivocada; **(b)** defectos estructurales = causas que lo permitieron; **(c)** datos históricos = residuos que este bloque **no** repara.
+
+---
+
+## 2. Alcance exacto
+
+### Seis archivos productivos
+| Archivo | Responsabilidad |
+|---|---|
+| `facturacion_fiscal/api/__init__.py` | Writer PAC: correlación estricta, persistencia independiente del log, derivación de estado/UUID/`facturapi_id`, `_derive_sync_status_from_response`, propagación de `FiscalCorrelationError` |
+| `facturacion_fiscal/timbrado_api.py` | Orquestación timbrado/cancelación/consulta: propagación FCE, advertencia de auditoría (6B1), recuperación de persistencia (6B2), escritura de sync best-effort |
+| `factura_fiscal_mexico/factura_fiscal_mexico.py` | `get_or_create_active_ffm` (creación centralizada + lock + resolución por activos), guard `before_insert` (Regla B) |
+| `config/fiscal_states_config.py` | `ACTIVE_STATES` + helpers `is_active`/`is_final` |
+| `api/fiscal_operations.py` | Refacturación 02/03/04: eliminación del guard `pending` |
+| `public/js/sales_invoice.js` | Botón "Generar Factura Fiscal" → `get_or_create_active_ffm` (servidor); elimina `client.insert`/`set_value` |
+
+### Los 11 commits
+| # | Hash | Propósito | Depende de | Antes → Después | Riesgo |
+|---|---|---|---|---|---|
+| 1 | `9d7353d` | Correlación estricta por `FFM.name` | — | respuesta por SI (ambigua) → por FFM explícito | Medio |
+| 2 | `13bdd97` | Estado fiscal independiente del Response Log | 1 | log falla → revertía estado → estado primero, log aislado (savepoint) | Medio |
+| 3 | `caed009` | Creación centralizada `get_or_create_active_ffm` | — | JS `client.insert` → servidor | Medio-alto |
+| 4 | `d0b97ea` | Lock `for_update` sobre SI | 3 | carrera concurrente → serializado | Medio |
+| 5 | `0bb8caf` | Regla B (1 FFM activo) + `before_insert` | 3,4 | múltiples activos → uno; guard toda vía de inserción | **Alto** |
+| 6 | `c0c5e97` | Propagación `FiscalCorrelationError` | 1 | aplanada/ignorada → detiene flujo con mensaje seguro | Medio |
+| 7 | `503bf15` | TIMBRADO correcto (UUID en `raw_response`) | 2 | ERROR transitorio → TIMBRADO directo; persiste `facturapi_id` | Medio |
+| 8 | `3430fae` | Advertencia no bloqueante de auditoría | 6 | `audit_log_failed` silencioso → advertencia + metadata | Bajo |
+| 9 | `2a92aea` | Recuperación tras fallo del writer | 7,8 | `success=False` ignorado → verificación post-FASE 3 | Medio |
+| 10 | `2ac44ac` | Semántica de `fm_sync_status` | 7,9 | `response.get("success")` → respuesta concluyente | Bajo-medio |
+| 11 | `52676d7` | Refacturación sin guard `pending` | 10 | bloqueo incorrecto → solo estado/motivo | Bajo |
+
+---
+
+## 3. Decisiones arquitectónicas
+
+1. **Correlación estricta por `FFM.name`.** La respuesta del PAC se asocia **solo** al FFM explícito (`factura_fiscal_name`). *Alt.:* resolver por SI / por UUID. *Seleccionado:* nombre explícito. *+:* elimina ambigüedad. *−:* el caller debe pasar el nombre. *Dep.:* 2, 6.
+2. **Prohibición de selección arbitraria por SI.** Ante ≥2 activos: `FiscalCorrelationError`, no se elige. *+:* integridad. *−:* requiere intervención manual. *Dep.:* 6.
+3. **Estado fiscal independiente del Response Log.** PASO 1 persiste y **commitea** el FFM (`api/__init__.py:614`); PASO 2 (log) aislado con **savepoint** (`pac_audit_log`). *Alt.:* log primero. *+:* el fallo de auditoría no revierte fiscal. *−:* doble paso. *Dep.:* 1.
+4. **Creación exclusiva por servicio servidor** (`get_or_create_active_ffm`). *Alt.:* mantener JS. *+:* punto único e idempotente. *−:* —. *Dep.:* base de 4, 5.
+5. **Lock `for_update` sobre la SI.** `frappe.get_doc("Sales Invoice", name, for_update=True)`. *Alt. rechazadas:* `filelock` (libera antes del commit del request), índice único (rompe Regla B). *Seleccionado:* row lock liberado por el commit/rollback normal del request, **sin commit manual**. *+:* serializa concurrencia. *−:* espera bajo contención. *Dep.:* 3, 4.
+6. **Regla B — máx. 1 FFM activo por SI.** Decisión por `status` (no `docstatus`); búsqueda por `sales_invoice` + `status in ACTIVE_STATES`. *Alt.:* unicidad absoluta. *Seleccionado:* Regla B. *+:* permite reemisión tras CANCELADO; varios históricos. *−:* ≥2 activos preexistentes requieren intervención. *Dep.:* 4, 5.
+7. **Estados activos/terminales.** `ACTIVE_STATES = {BORRADOR, PROCESANDO, TIMBRADO, ERROR, PENDIENTE_CANCELACION}`; terminales `FINAL_STATES = {CANCELADO, ARCHIVADO}`. *Razón:* CANCELADO/ARCHIVADO no tienen operación viva; ARCHIVADO sin transiciones salientes y ningún flujo lo asigna. *+:* fuente única. *Dep.:* 6.
+8. **Propagación de `FiscalCorrelationError`.** El wrapper público re-lanza la FCE (no la aplana a `{success:False}`); los flujos la preservan y detienen con mensaje seguro ("No repita la operación…"). *+:* restaura la garantía de la decisión 1 en la orquestación. *−:* —. *Dep.:* 1.
+9. **Doble persistencia writer / FASE 3 como defensa en profundidad.** El writer persiste el estado esencial (commit inmediato); la FASE 3 reafirma y completa campos. *Alt.:* consolidar en una. *Seleccionado:* conservar ambas. *Razón:* recuperación cruzada de 6B2 (writer falla → FASE 3 recupera; FASE 3 falla → writer ya commiteó). *−:* inconsistencia temporal en campos **secundarios** entre dos commits. *Dep.:* 2, 9 (6B2).
+10. **Semántica final de `fm_sync_status`.** `synced` = respuesta concluyente del PAC reflejada (incluye rechazo conocido y HTTP 2xx/4xx); `pending` = inconclusa (timeout/5xx/0/sin señal); `error` = no resuelto (6B2). Fallback `fiscal_event_*` no altera el campo. *Razón:* el flag indica sincronización local, no operación viva. *Dep.:* 7, 9.
+11. **Refacturación 02/03/04 independiente de `fm_sync_status`.** Se eliminó el guard `pending`; el flujo se delimita por `docstatus==1` + `status==CANCELADO` + motivo 02/03/04. *Razón:* un FFM CANCELADO es terminal, no tiene operación viva. *Dep.:* 10.
+
+---
+
+## 4. Invariantes que el código debe preservar
+
+- Una SI puede tener **varios FFM históricos**.
+- Solo puede existir **un FFM activo** por SI (Regla B).
+- FFM `CANCELADO` o `ARCHIVADO` **no bloquea** la creación de uno nuevo.
+- Ninguna respuesta PAC puede actualizar un FFM **ambiguo** (sin nombre explícito / de otra SI).
+- UUID o `facturapi_id` **contradictorios** detienen la operación (`FiscalCorrelationError`).
+- Un **fallo de auditoría** (Response Log) no revierte el estado fiscal.
+- Una respuesta PAC exitosa **nunca** provoca repetición automática de timbrado/cancelación.
+- `pending` = respuesta **inconclusa**, no operación activa.
+- Documentos **históricos duplicados** deben poder abrirse.
+- `before_insert` **no** bloquea actualizaciones de documentos existentes (solo inserciones).
+
+---
+
+## 5. Flujos afectados
+
+Notación: **In** = documento de entrada · **Id** = identidad usada · **Lock** · **P** = persistencia · **U** = respuesta al usuario · **Fin** = estado final.
+
+### 5.1 Generación de FFM desde SI
+`In:` SI submitted sin FFM · `Id:` SI.name · `Lock:` `for_update` SI · `P:` insert FFM + `set_value` vínculo (commit request) · `U:` "Documento fiscal listo" + navegación · `Fin:` 1 FFM activo vinculado.
+
+### 5.2 Segunda solicitud secuencial
+Igual, pero bajo el lock se halla el activo existente → **se reutiliza y repara el vínculo**. `Fin:` mismo FFM, no se crea otro.
+
+### 5.3 Solicitudes concurrentes
+La 2ª espera el `for_update` de la 1ª; al desbloquearse ve el FFM vinculado → reutiliza. `Fin:` 1 solo FFM.
+
+### 5.4 Timbrado exitoso
+`In:` SI+FFM · PAC `create_invoice` OK · writer persiste `TIMBRADO`+`fm_uuid`+`facturapi_id`+`synced` (commit) · FASE 3 completa serie/folio/fecha/total · `U:` "Timbrado Exitoso" · `Fin:` TIMBRADO/synced.
+
+### 5.5 Rechazo de timbrado
+PAC rechaza → `except pac_error` → writer registra `ERROR`+`synced` (rechazo conocido) · SI→ERROR · `U:` "Timbrado rechazado". `Fin:` ERROR/synced.
+
+### 5.6 Cancelación inmediata
+PAC `cancel_invoice` OK · FASE 3 → `CANCELADO` · writer → `synced` · `Fin:` CANCELADO/synced.
+
+### 5.7 Cancelación pendiente
+FASE 3 → `PENDIENTE_CANCELACION` (estado fiscal) · `fm_sync_status=synced` (la respuesta ya se reflejó). `Fin:` PENDIENTE_CANCELACION/synced.
+
+### 5.8 Consulta de cancelación (`revisar_estatus_cancelacion`)
+`query_pac_status` → escribe estado sobre **el mismo FFM** → writer log. `Fin:` estado verificado/synced.
+
+### 5.9 Fallo del writer con recuperación (6B2)
+writer `success=False` (PAC OK) → FASE 3 ejecuta una vez → **verificación con lectura nueva de BD** → si OK: `success=True` + `persistence_status=recovered_by_phase3` + `retry_allowed=False`; si no: `unresolved`/`error`. **Nunca** re-PAC.
+
+### 5.10 Fallo del Response Log
+PASO 1 ok (estado fiscal persistido) · PASO 2 falla → rollback al savepoint · `audit_log_failed=True` + advertencia. `Fin:` estado fiscal **conservado**, sin Response Log.
+
+### 5.11 Refacturación 02/03/04
+`In:` SI + FFM `CANCELADO` motivo 02/03/04 · `refacturar_misma_si` **desvincula** la SI (no toca el FFM) · luego "Generar" → `get_or_create` crea nuevo FFM (CANCELADO no bloquea). `Fin:` SI→nuevo FFM activo; cancelado intacto; 1 activo.
+
+---
+
+## 6. Transacciones y commits
+
+- **`frappe.db.commit()` del writer:** `api/__init__.py` (`_update_factura_fiscal`, PASO 1). Persiste el estado fiscal esencial **de inmediato** → **no revertible** por excepción posterior.
+- **Savepoint:** `pac_audit_log` (PASO 2). Su rollback afecta **solo** el Response Log, no el FFM ya commiteado.
+- **FASE 3:** commit propio (timbrado/cancelación). Es un **segundo commit**, separado del writer.
+- **`get_or_create_active_ffm`:** **sin** commit manual; el lock `for_update` se libera con el commit/rollback **normal del request**.
+- **`fiscal_operations.py` / `timbrado_api.py` (consulta):** `frappe.db.commit()` preexistentes (no añadidos como atajo).
+- **Qué persiste el writer:** `status`, `fm_uuid`, `facturapi_id` (TIMBRADO), `fm_sync_status`, `fm_last_pac_sync`.
+- **Qué persiste FASE 3:** reafirma `status`/`fm_uuid`/`facturapi_id` + `serie`, `folio`, `fecha_timbrado`, `total_fiscal`, URLs, campos de la SI.
+- **Si falla cada etapa:** PASO 1 falla → relanza, no se crea log, 6B2 evalúa; PASO 2 falla → 6B1 advierte, estado conservado; FASE 3 falla con writer ok → estado del writer sobrevive.
+- **Por qué se conserva la doble escritura:** recuperación cruzada de 6B2 (§3.9).
+- **Riesgo de inconsistencia temporal:** entre el commit del writer y el de FASE 3, el FFM está commiteado con estado fiscal correcto pero **sin** campos secundarios (serie/folio/fecha). Antes de 6B0 esta ventana mostraba `ERROR`; 6B0 la redujo a campos secundarios. **No se minimiza esta complejidad: existe y es intencional.**
+
+---
+
+## 7. Compatibilidad con datos existentes (hallazgos reales, lectura)
+
+- **11.668 FFM históricos** cargan correctamente con el código nuevo.
+- **77** con `fm_sync_status="pending"` (70 `TIMBRADO`, 6 `BORRADOR`, 1 `ERROR`).
+- Los **70 `TIMBRADO+pending`** tienen `fm_uuid` y `facturapi_id` (ya sincronizados con el PAC; el flag es residuo del bug).
+- **6 grupos** con 2 FFM activos por SI (`TIMBRADO + BORRADOR/ERROR`).
+- **Estos datos NO se reparan en este bloque.**
+- `get_or_create_active_ffm` ante un grupo con ≥2 activos **se detiene** (`FiscalCorrelationError`), no elige.
+- Los documentos existentes (incluidos los duplicados) **sí pueden abrirse y evaluarse** (helpers de solo lectura).
+
+---
+
+## 8. Qué NO resuelve este bloque (declaración expresa)
+
+- **No** existe motor automático de conciliación FFM ↔ PAC/SAT (las funciones `process_pending_complements` y `reconcile_payment_tracking` son **placeholders vacíos**, preexistentes).
+- **No** consulta automáticamente los 70 FFM contra el PAC.
+- **No** repara los 77 `pending`.
+- **No** corrige los 6 grupos duplicados.
+- **No** repara el caso incidente.
+- **No** resuelve referencias rotas (`refacturar_misma_si` hace `get_doc` sin verificar existencia).
+- **No** corrige el `TypeError` defensivo de `_derive_status_from_response` (raw_response `dict` sin `status_code`).
+- **No** modifica datos históricos.
+- **No** agrega scheduler de conciliación.
+
+---
+
+## 9. Pruebas y evidencia
+
+| Tipo | Detalle |
+|---|---|
+| Unitarias / integración | **110** pruebas en 11 suites del bloque (todas verdes) |
+| Concurrencia | procesos independientes (`multiprocessing` spawn), `for_update` serializa |
+| Funcionales reales (site test) | `get_or_create_active_ffm` y `refacturar_misma_si` reales; flujo integrado 02/04 |
+| Lectura histórica | 11.668 FFM evaluados en `llantascs-v16.dev` (solo lectura, baseline inicial=final) |
+| Aislamiento PAC | cliente real **no instanciable** en `test-facturacion.localhost` (sin Company Settings); boundaries mockeados |
+| Suites relacionadas | `ffm_cancel_permissions` (6), `ffm_js_multisucursal_cleanup` (6), `layer1` (5) verdes |
+
+**Limitaciones / deuda documentadas:**
+- **Smoke GUI real (navegador) NO ejecutado** por el agente CLI (sin navegador). Pendiente para operador humano.
+- Fallos **preexistentes de entorno**: `test_custom_fields_naming_consistency` (custom fields UAE/VAT de ERPNext), `test_refacturar_workflow`/`test_tipo_e_nota_credito` (`_Test Item is not a stock Item`, setup de stock). Ajenos al bloque.
+- **Response Logs residuales** en site de test por `tearDown` incompleto de algunas suites (deuda de entorno, no productiva).
+
+---
+
+## 10. Matriz de riesgos
+
+| Riesgo | Prob. | Impacto | Parte del código | Prueba que mitiga | Monitoreo | Rollback |
+|---|---|---|---|---|---|---|
+| Bloqueo legítimo por cardinalidad | Media | Alto | `before_insert` (commit 5) | `test_unico_ffm_activo` (16) | alertas "FFM activo ya existe" | revert commit 5 |
+| Deadlock/espera por `for_update` | Baja | Medio | `get_or_create` (commit 4) | `test_get_or_create_concurrencia` (4) | tiempos de lock | revert commit 4 |
+| Inconsistencia writer/FASE 3 | Baja | Bajo | api/timbrado (2,9) | suites 6B2 | FFM TIMBRADO sin serie/folio | — (defensa en profundidad) |
+| Consumidor con semántica vieja de `fm_sync_status` | Baja | Medio | sync (10) | `test_sync_status_semantics` (15) | uso de `pending` en reportes | revert commit 10 |
+| Documentos duplicados existentes | Baja | Alto | Regla B / `before_insert` | `test_15` (modificación no bloqueada) + lectura prod | apertura de FFM viejos | — |
+| Errores JS / permisos no verificados en GUI | Media | Medio | `sales_invoice.js` | análisis estático + `ffm_cancel_permissions` | **smoke GUI humano** | revert commit 3 (JS) |
+| Ausencia de conciliación automática | Alta | Medio (negocio) | — (no existe) | — | `pending` que no se cierran solos | feature nueva (fuera de alcance) |
+
+---
+
+## 11. Despliegue (documentado, no ejecutado)
+
+- **No hay** cambios de esquema, patches nuevos ni fixtures nuevos en el bloque.
+- La rama **no requiere `migrate` por sí misma**.
+- ⚠️ `bench migrate` ejecutaría los hooks `after_migrate` (5 funciones que **escriben** Item Groups/Items/UOM/estados) y sincronizaría `fixtures` (Custom Fields + catálogos SAT) → puede **modificar datos**. Evaluar por separado.
+- Pasos a evaluar (sin comandos destructivos aquí): pull/checkout del código → `bench build` de assets → reinicio controlado (vía `frappe-multisite`) → smoke test → monitoreo.
+
+---
+
+## 12. Rollback
+
+- **Reversión por commits:** `git revert` del rango / del PR squash. Código puro, sin migraciones → reversión limpia.
+- **Efecto sobre documentos creados mientras el bloque estuvo activo:** los FFM creados por `get_or_create` bajo Regla B **permanecen**; revertir el código no los borra.
+- **Si ya existen nuevos FFM bajo Regla B:** seguirán siendo válidos; sin el guard `before_insert`, futuras inserciones dejan de validarse (vuelve el riesgo de duplicado).
+- **Datos no revertidos automáticamente:** estados fiscales, `fm_sync_status` y vínculos ya persistidos.
+- **Backup previo obligatorio** antes de desplegar (para poder restaurar datos si fuese necesario).
+- **Criterios objetivos de rollback:** aparición de nuevos FFM duplicados atribuibles al bloque; `FiscalCorrelationError` masivos en flujos legítimos; bloqueo de creación/refacturación legítima; errores de timbrado introducidos por el cambio.
+
+---
+
+## 13. Observabilidad posterior al despliegue
+
+Revisar: nuevos FFM duplicados por SI · frecuencia de `FiscalCorrelationError` · distribución de `fm_sync_status` · errores de Response Log (`audit_log_failed`) · FFM en `ERROR` · resultados con `retry_allowed=False` / mensajes "No repita la operación" · tiempos de espera por lock · cancelaciones en `PENDIENTE_CANCELACION` · errores JS del botón "Generar Factura Fiscal".
+
+---
+
+## 14. Decisión
+
+**Se adopta el bloque de 11 commits** que: (a) corrige la correlación y la creación del FFM, (b) establece la cardinalidad Regla B, (c) hace la persistencia fiscal resiliente al Response Log, (d) corrige la semántica de `fm_sync_status` y la refacturación 02/03/04.
+
+**Necesidad:** previene la repetición del incidente (doble FFM / cancelación equivocada), defecto con impacto fiscal y de negocio.
+
+**Condición de despliegue:** sin `migrate` obligatorio por el bloque; con `build` + reinicio controlado + backup previo + smoke GUI humano + monitoreo de §13.
+
+**Trabajo pendiente (fuera de este ADR):** motor de conciliación FFM ↔ SAT; reparación de los 77 `pending`, los 6 grupos duplicados y el caso incidente; referencias rotas; `TypeError` defensivo. **Este ADR no declara el sistema completo ni la recuperación de los 70 como resueltos.**
+
+---
+
+## Anexo A — Trazabilidad commit → decisión → prueba
+
+| Commit | Decisión(es) | Suite(s) de prueba |
+|---|---|---|
+| `9d7353d` | D1, D2 | `test_pac_response_correlacion` (9) |
+| `13bdd97` | D3 | `test_estado_fiscal_independiente_log` (7) |
+| `caed009` | D4 | `test_get_or_create_active_ffm` (15) |
+| `d0b97ea` | D5 | `test_get_or_create_concurrencia` (4) |
+| `0bb8caf` | D6, D7 | `test_unico_ffm_activo` (16) |
+| `c0c5e97` | D8 | `test_correlacion_propagacion` (8) |
+| `503bf15` | (UUID/`facturapi_id`) | `test_writer_timbrado_uuid` (8) |
+| `3430fae` | (6B1 auditoría) | `test_audit_warning` (9) |
+| `2a92aea` | D9 (6B2) | `test_persistence_recovery` (11) |
+| `2ac44ac` | D10 | `test_sync_status_semantics` (15) |
+| `52676d7` | D11 | `test_refacturar_guard` (8) |
+
+## Anexo B — Afirmaciones verificadas contra código
+- Correlación estricta por `factura_fiscal_name` y rechazo de selección por SI — verificado en `_resolve_validated_ffm` / `get_or_create_active_ffm`.
+- `frappe.db.commit()` del writer y savepoint `pac_audit_log` — verificado en `api/__init__.py`.
+- `for_update=True` genera `SELECT ... FOR UPDATE` — verificado empíricamente.
+- `before_insert` solo bloquea inserciones (no updates) — verificado (`test_15`).
+- JS del botón llama solo `get_or_create_active_ffm`, sin `client.insert`/`set_value`, sin segunda creación — verificado en `sales_invoice.js`.
+- Guard `pending` eliminado de `refacturar_misma_si`; guards `docstatus`/`status`/`motivo` intactos — verificado en `fiscal_operations.py`.
+- `ACTIVE_STATES`/`FINAL_STATES` y `ARCHIVADO` sin transiciones salientes — verificado en `fiscal_states_config.py` y `valid_transitions`.
+- 70 `TIMBRADO+pending` con `fm_uuid` y `facturapi_id`; 6 grupos duplicados — verificado por lectura en `llantascs-v16.dev`.
+- `process_pending_complements`/`reconcile_payment_tracking` son placeholders — verificado.
+
+## Anexo C — Puntos NO verificados (limitaciones)
+- Comportamiento **visual en navegador**: render del botón, red/DevTools, consola JS, visibilidad por rol en UI — **no verificado** (sin navegador).
+- Comportamiento del bloque bajo **carga real concurrente de producción** (solo probado con procesos de test).
+- Efecto de `bench migrate` real en un site con datos de producción (solo analizado, no ejecutado).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -37,3 +37,4 @@ Registro permanente de decisiones de arquitectura. Un ADR nunca se modifica — 
 | [0031](0031-migracion-settings-por-company.md) | Migración Settings global (Single) a configuración por Company |
 | [0032](0032-ereceipts-facturapi-arquitectura.md) | Arquitectura E-Receipts — FacturAPI como motor fiscal, ERPNext como trazabilidad |
 | [0033](0033-factura-global-hardcodes.md) | Eliminación de defaults fiscales silenciosos en Factura Global |
+| [0034](0034-integridad-correlacion-ffm.md) | Integridad y correlación de Factura Fiscal Mexico |

--- a/docs/usuario/emitir-cfdi.md
+++ b/docs/usuario/emitir-cfdi.md
@@ -9,7 +9,9 @@ Guía del flujo completo: Sales Invoice → Factura Fiscal Mexico → Timbrado.
 El timbrado en facturacion_mexico tiene dos documentos:
 
 - **Sales Invoice** — la venta en ERPNext. Se submittea normalmente.
-- **Factura Fiscal Mexico (FFM)** — el documento fiscal. Se crea automáticamente al hacer Submit del Sales Invoice y es donde ocurre el timbrado real.
+- **Factura Fiscal Mexico (FFM)** — el documento fiscal. Se crea la primera vez que haces clic en **"Timbrar Factura"** sobre el Sales Invoice, y es donde ocurre el timbrado real.
+
+> **Un solo FFM activo por Sales Invoice.** La creación del FFM la resuelve el servidor: la primera vez crea el documento y lo vincula; las siguientes veces reutiliza el mismo. No se pueden generar dos facturas fiscales activas para la misma venta.
 
 Los dos documentos están vinculados. El estado fiscal visible en el Sales Invoice (campo `fm_fiscal_status`) refleja siempre el estado del FFM.
 
@@ -56,13 +58,15 @@ Antes de hacer Submit, verificar:
 ### 2. Submit del Sales Invoice
 
 Al hacer Submit:
-- El sistema detecta que el cliente tiene RFC
-- Crea automáticamente un documento **Factura Fiscal Mexico** en estado `BORRADOR`
 - El Sales Invoice muestra el botón **"Timbrar Factura"** como acción primaria
+- Todavía **no** existe Factura Fiscal Mexico — se crea en el siguiente paso
 
-### 3. Abrir la Factura Fiscal Mexico
+### 3. Generar / abrir la Factura Fiscal Mexico
 
-Clic en **"Timbrar Factura"** en el Sales Invoice → abre el FFM vinculado.
+Clic en **"Timbrar Factura"** en el Sales Invoice:
+- Si la venta aún no tiene FFM, el servidor **crea** uno en estado `BORRADOR`, lo vincula y te lleva a él.
+- Si ya tiene un FFM activo, **reutiliza** el existente y te lleva a él (no crea otro).
+- Si el FFM ya está `TIMBRADO`, el sistema avisa que no se puede volver a timbrar.
 
 En el FFM revisar antes de timbrar:
 - **Régimen fiscal** (`fm_tax_system`) — cargado desde el cliente

--- a/docs/usuario/troubleshooting.md
+++ b/docs/usuario/troubleshooting.md
@@ -20,6 +20,22 @@ Solución a los problemas más comunes.
 
 ---
 
+## Mensajes de integridad fiscal (correlación y persistencia)
+
+El sistema protege la integridad de la Factura Fiscal Mexico: una sola factura fiscal activa por
+venta y cada respuesta del PAC asociada únicamente a su documento. En casos excepcionales pueden
+aparecer estos mensajes:
+
+| Mensaje | Qué significa | Qué hacer |
+|---|---|---|
+| "No repita la operación. Contacte a soporte." | El sistema detectó una **inconsistencia de correlación** (p. ej. más de una factura fiscal activa para la misma venta, o una respuesta que no corresponde al documento). Se detuvo de forma segura para no timbrar ni cancelar el documento equivocado. | **No reintentar.** Revisar `FacturAPI Response Log` y los FFM vinculados a esa Sales Invoice; escalar a soporte. |
+| Advertencia de **auditoría incompleta** tras un timbrado exitoso | El CFDI **sí** se timbró y el estado fiscal es correcto, pero no pudo registrarse por completo la bitácora de auditoría (Response Log). | El comprobante es válido. Informar a soporte para completar la trazabilidad; **no** volver a timbrar. |
+| "La operación pudo haberse procesado; no reintentar" (persistencia no resuelta) | El PAC respondió pero el sistema no pudo confirmar la persistencia local del resultado. | **No reintentar automáticamente.** Verificar en `FacturAPI Response Log` y en el portal de FacturAPI si la operación ya ocurrió antes de cualquier acción manual. |
+
+> Estos mensajes son de **excepción**, no del flujo normal. En operación habitual no aparecen.
+
+---
+
 ## Item sin clave SAT
 
 El sistema bloquea el timbrado si algún item no tiene `fm_producto_servicio_sat`.

--- a/facturacion_mexico/api/fiscal_operations.py
+++ b/facturacion_mexico/api/fiscal_operations.py
@@ -129,9 +129,10 @@ def refacturar_misma_si(si_name: str):
 				)
 			)
 
-		# Guard avanzado: verificar que no hay operaciones pendientes
-		if ffm.get("fm_sync_status") == "pending":
-			frappe.throw(_("Operación pendiente en FFM. Espera a que complete antes de re-facturar."))
+		# Corrección 7A2: se eliminó el guard `fm_sync_status == "pending"`. Tras 7A1,
+		# fm_sync_status indica sincronización local (no una operación PAC activa); un FFM
+		# CANCELADO es terminal y no tiene operación en curso. Los guards de docstatus,
+		# status==CANCELADO y motivo 02/03/04 ya delimitan completamente el flujo.
 
 	# IDEMPOTENCIA: Si ya está desvinculado, respuesta elegante
 	if not si.get("fm_factura_fiscal_mx"):

--- a/facturacion_mexico/config/fiscal_states_config.py
+++ b/facturacion_mexico/config/fiscal_states_config.py
@@ -55,6 +55,19 @@ class FiscalStates:
 	# Estados finales (no se pueden modificar)
 	FINAL_STATES: ClassVar[list] = [CANCELADO, ARCHIVADO]
 
+	# Estados activos / no resueltos: un FFM en cualquiera de estos estados BLOQUEA la
+	# creación de otro FFM para la misma Sales Invoice (Regla B — cardinalidad).
+	# Son los estados principales que NO son terminales (CANCELADO/ARCHIVADO).
+	# ARCHIVADO es terminal verdadero: en valid_transitions no tiene transiciones salientes
+	# y ningún flujo del código lo asigna; por eso no bloquea una nueva emisión.
+	ACTIVE_STATES: ClassVar[list] = [
+		BORRADOR,
+		PROCESANDO,
+		TIMBRADO,
+		ERROR,
+		PENDIENTE_CANCELACION,
+	]
+
 	# Estados de error recuperables
 	RECOVERABLE_ERROR_STATES: ClassVar[list] = [ERROR, PROCESANDO]
 
@@ -77,6 +90,11 @@ class FiscalStates:
 	def is_final(cls, state):
 		"""Verifica si es un estado final."""
 		return state in cls.FINAL_STATES
+
+	@classmethod
+	def is_active(cls, state):
+		"""Verifica si el estado es activo/no resuelto (bloquea crear otro FFM por SI)."""
+		return state in cls.ACTIVE_STATES
 
 	@classmethod
 	def is_recoverable_error(cls, state):

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -587,6 +587,14 @@ class PACResponseWriter:
 				# Limpiar UUID si hay error de timbrado para higiene
 				update_fields["fm_uuid"] = None
 
+			# Corrección 6B0: en timbrado exitoso, persistir también facturapi_id si la respuesta
+			# lo trae (top-level o dentro de raw_response). Se limita a TIMBRADO para no alterar
+			# la semántica de cancelación/consulta.
+			if new_status == "TIMBRADO":
+				_resp_uuid, facturapi_id = _extract_response_identifiers(response_data)
+				if facturapi_id:
+					update_fields["facturapi_id"] = facturapi_id
+
 			# Actualizar URLs si están en respuesta
 			if "download" in response_data:
 				download = response_data["download"]
@@ -665,7 +673,10 @@ class PACResponseWriter:
 			m = re.search(r"FacturAPI\s+(\d{3})", error_text)
 			status_code = cint(m.group(1)) if m else 500
 
-		uuid = (resp.get("uuid") or "").strip()
+		# Corrección 6B0: el UUID del timbrado llega dentro de raw_response, no solo a nivel
+		# superior. Reutilizar el extractor normalizado evita derivar ERROR en un timbrado
+		# exitoso por no encontrar el UUID en el nivel equivocado.
+		uuid, _facturapi_id = _extract_response_identifiers(resp)
 
 		# REGLA CANÓNICA POR TIPO DE OPERACIÓN
 		if operation_type == "Timbrado":

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -35,6 +35,52 @@ def _get_fallback_dir():
 		return fallback_path
 
 
+class FiscalCorrelationError(frappe.ValidationError):
+	"""La respuesta del PAC no puede asociarse de forma inequívoca al FFM de origen.
+
+	No debe degradarse al fallback de filesystem: representa una contradicción de
+	integridad fiscal, no una indisponibilidad de BD.
+	"""
+
+
+def _alerta_correlacion_critica(motivo: str, contexto: dict) -> None:
+	"""Registrar alerta crítica de correlación fiscal (Corrección 1).
+
+	Se invoca cuando la respuesta del PAC no puede asociarse de forma inequívoca
+	al FFM que inició la operación. No modifica ningún documento.
+	"""
+	try:
+		frappe.log_error(
+			message=json.dumps({"motivo": motivo, "contexto": contexto}, default=str, indent=2),
+			title="PAC Correlación Crítica FFM",
+		)
+	except Exception:
+		# El logging nunca debe enmascarar el error de correlación original.
+		pass
+
+
+def _extract_response_identifiers(response_data: dict) -> tuple[str, str]:
+	"""Extraer (uuid, facturapi_id) de una respuesta PAC, si están presentes.
+
+	Busca tanto a nivel superior como dentro de raw_response. Devuelve cadenas
+	vacías cuando el identificador no viene en la respuesta (p. ej. timbrado que
+	aún no devuelve UUID, o errores). La comparación de contradicción solo aplica
+	cuando ambos lados (FFM y respuesta) tienen valor.
+	"""
+	if not isinstance(response_data, dict):
+		return "", ""
+	raw = response_data.get("raw_response")
+	raw = raw if isinstance(raw, dict) else {}
+	uuid = (response_data.get("uuid") or raw.get("uuid") or "").strip()
+	facturapi_id = (
+		response_data.get("facturapi_id")
+		or response_data.get("id")
+		or raw.get("id")
+		or ""
+	).strip()
+	return uuid, facturapi_id
+
+
 def _derive_http_status(data: dict, default=500) -> int:
 	# Éxito explícito → 200 fijo, ignorar 'status_code' dentro del payload y cualquier regex
 	if isinstance(data, dict) and data.get("success") is True:
@@ -109,15 +155,20 @@ class PACResponseWriter:
 		request_data: dict[str, Any],
 		response_data: dict[str, Any],
 		operation_type: str = "timbrado",
+		*,
+		factura_fiscal_name: str | None = None,
 	) -> dict[str, Any]:
 		"""
 		Escribir respuesta PAC con máxima resilencia.
 
 		Args:
-			sales_invoice_name: Nombre de Sales Invoice
+			sales_invoice_name: Nombre de Sales Invoice (solo para validación cruzada)
 			request_data: Datos del request enviado
 			response_data: Respuesta completa de FacturAPI
 			operation_type: Tipo operación (timbrado/cancelacion/consulta)
+			factura_fiscal_name: Nombre EXPLÍCITO del FFM que inició la operación.
+				Obligatorio. La respuesta se asocia exclusivamente a este FFM —
+				nunca se resuelve por Sales Invoice. Ver Corrección 1 (integridad fiscal).
 
 		Returns:
 			Dict con status y referencias creadas
@@ -133,7 +184,11 @@ class PACResponseWriter:
 		try:
 			# PASO 1: Intentar escritura a BD (principal)
 			response_log = self._write_to_database(
-				sales_invoice_name, request_data, response_data, operation_type
+				sales_invoice_name,
+				request_data,
+				response_data,
+				operation_type,
+				factura_fiscal_name=factura_fiscal_name,
 			)
 
 			if response_log:
@@ -141,13 +196,21 @@ class PACResponseWriter:
 				result["response_log_name"] = response_log.name
 				result["method"] = "database"
 
-				# PASO 2: Actualizar Factura Fiscal Mexico si existe
+				# PASO 2: Actualizar el MISMO FFM explícito (nunca por Sales Invoice)
 				self._update_factura_fiscal(
-					sales_invoice_name, response_data, response_log.name, operation_type
+					sales_invoice_name,
+					response_data,
+					response_log.name,
+					operation_type,
+					factura_fiscal_name=factura_fiscal_name,
 				)
 
 				return result
 
+		except FiscalCorrelationError:
+			# Contradicción de correlación: NO degradar a filesystem. Propagar el
+			# error controlado para que el caller lo maneje y nada se modifique.
+			raise
 		except Exception as db_error:
 			result["errors"].append(f"DB Error: {db_error!s}")
 			frappe.log_error(f"Error escritura BD PAC: {traceback.format_exc()}", "PAC Writer DB Error")
@@ -155,7 +218,11 @@ class PACResponseWriter:
 		# PASO 3: Fallback a filesystem si BD falla
 		try:
 			fallback_file = self._write_to_filesystem(
-				sales_invoice_name, request_data, response_data, operation_type
+				sales_invoice_name,
+				request_data,
+				response_data,
+				operation_type,
+				factura_fiscal_name=factura_fiscal_name,
 			)
 
 			result["success"] = True
@@ -203,17 +270,136 @@ class PACResponseWriter:
 
 		return result
 
+	def _resolve_validated_ffm(
+		self,
+		factura_fiscal_name: str | None,
+		sales_invoice_name: str,
+		response_data: dict[str, Any],
+		operation_type: str,
+	) -> str:
+		"""Validar y devolver el FFM EXPLÍCITO que inició la operación.
+
+		Corrección 1 — Correlación estricta por FFM.name:
+		- Nunca resuelve el FFM por Sales Invoice ni por UUID/facturapi_id.
+		- Si falta el nombre, el FFM no existe, pertenece a otra SI, o hay
+		  contradicción de UUID/facturapi_id → registra alerta crítica y lanza
+		  error controlado SIN modificar ningún documento.
+
+		Returns:
+			El factura_fiscal_name validado.
+		"""
+		if not factura_fiscal_name:
+			_alerta_correlacion_critica(
+				"Falta factura_fiscal_name en persistencia de respuesta PAC",
+				{
+					"sales_invoice": sales_invoice_name,
+					"operation_type": operation_type,
+				},
+			)
+			frappe.throw(
+				_("No se puede registrar la respuesta del PAC: falta el FFM de origen."),
+				title=_("Correlación fiscal requerida"),
+				exc=FiscalCorrelationError,
+			)
+
+		ffm = frappe.db.get_value(
+			"Factura Fiscal Mexico",
+			factura_fiscal_name,
+			["name", "sales_invoice", "fm_uuid", "facturapi_id"],
+			as_dict=True,
+		)
+		if not ffm:
+			_alerta_correlacion_critica(
+				"FFM explícito inexistente en persistencia de respuesta PAC",
+				{
+					"factura_fiscal_name": factura_fiscal_name,
+					"sales_invoice": sales_invoice_name,
+					"operation_type": operation_type,
+				},
+			)
+			frappe.throw(
+				_("No se puede registrar la respuesta del PAC: el FFM {0} no existe.").format(
+					factura_fiscal_name
+				),
+				title=_("Correlación fiscal inválida"),
+				exc=FiscalCorrelationError,
+			)
+
+		# El FFM debe pertenecer a la Sales Invoice indicada (cuando se provee).
+		if sales_invoice_name and ffm.get("sales_invoice") and ffm["sales_invoice"] != sales_invoice_name:
+			_alerta_correlacion_critica(
+				"FFM explícito pertenece a otra Sales Invoice",
+				{
+					"factura_fiscal_name": factura_fiscal_name,
+					"ffm_sales_invoice": ffm.get("sales_invoice"),
+					"sales_invoice_param": sales_invoice_name,
+					"operation_type": operation_type,
+				},
+			)
+			frappe.throw(
+				_("No se puede registrar la respuesta del PAC: el FFM {0} pertenece a otra factura.").format(
+					factura_fiscal_name
+				),
+				title=_("Correlación fiscal inválida"),
+				exc=FiscalCorrelationError,
+			)
+
+		# Contradicción de UUID/facturapi_id: solo se valida cuando AMBOS lados
+		# tienen valor (en timbrado el FFM aún no los tiene → no aplica).
+		resp_uuid, resp_facturapi_id = _extract_response_identifiers(response_data)
+		if resp_uuid and ffm.get("fm_uuid") and resp_uuid != ffm["fm_uuid"]:
+			_alerta_correlacion_critica(
+				"UUID de la respuesta PAC no coincide con el FFM explícito",
+				{
+					"factura_fiscal_name": factura_fiscal_name,
+					"ffm_uuid": ffm.get("fm_uuid"),
+					"response_uuid": resp_uuid,
+					"operation_type": operation_type,
+				},
+			)
+			frappe.throw(
+				_("Respuesta del PAC con UUID contradictorio para el FFM {0}.").format(factura_fiscal_name),
+				title=_("Correlación fiscal inválida"),
+				exc=FiscalCorrelationError,
+			)
+		if (
+			resp_facturapi_id
+			and ffm.get("facturapi_id")
+			and resp_facturapi_id != ffm["facturapi_id"]
+		):
+			_alerta_correlacion_critica(
+				"facturapi_id de la respuesta PAC no coincide con el FFM explícito",
+				{
+					"factura_fiscal_name": factura_fiscal_name,
+					"ffm_facturapi_id": ffm.get("facturapi_id"),
+					"response_facturapi_id": resp_facturapi_id,
+					"operation_type": operation_type,
+				},
+			)
+			frappe.throw(
+				_("Respuesta del PAC con facturapi_id contradictorio para el FFM {0}.").format(
+					factura_fiscal_name
+				),
+				title=_("Correlación fiscal inválida"),
+				exc=FiscalCorrelationError,
+			)
+
+		return ffm["name"]
+
 	def _write_to_database(
 		self,
 		sales_invoice_name: str,
 		request_data: dict[str, Any],
 		response_data: dict[str, Any],
 		operation_type: str,
+		*,
+		factura_fiscal_name: str | None = None,
 	) -> Any | None:
 		"""Escribir a FacturAPI Response Log en BD."""
-		# Obtener referencia a Factura Fiscal Mexico si existe
-		factura_fiscal = frappe.db.get_value(
-			"Factura Fiscal Mexico", {"sales_invoice": sales_invoice_name}, "name"
+		# Correlación estricta: el FFM es SIEMPRE el explícito de la operación.
+		# Nunca se resuelve por Sales Invoice.
+		factura_fiscal = self._resolve_validated_ffm(
+			factura_fiscal_name, sales_invoice_name, response_data, operation_type
 		)
 
 		# Mapear operation_type a valores válidos del DocType (ARQUITECTURA RESILIENTE)
@@ -346,6 +532,8 @@ class PACResponseWriter:
 		request_data: dict[str, Any],
 		response_data: dict[str, Any],
 		operation_type: str,
+		*,
+		factura_fiscal_name: str | None = None,
 	) -> str:
 		"""Escribir respuesta a filesystem como fallback."""
 		timestamp = now().replace(" ", "_").replace(":", "-")
@@ -355,6 +543,8 @@ class PACResponseWriter:
 
 		fallback_data = {
 			"sales_invoice": sales_invoice_name,
+			# FFM explícito de origen — necesario para recuperar con correlación estricta.
+			"factura_fiscal_name": factura_fiscal_name,
 			"operation_type": operation_type,
 			"request_data": request_data,
 			"response_data": response_data,
@@ -374,15 +564,16 @@ class PACResponseWriter:
 		response_data: dict[str, Any],
 		response_log_name: str,
 		operation_type: str = "Timbrado",
+		*,
+		factura_fiscal_name: str | None = None,
 	):
 		"""Actualizar Factura Fiscal Mexico con datos de respuesta."""
 		try:
-			factura_fiscal_name = frappe.db.get_value(
-				"Factura Fiscal Mexico", {"sales_invoice": sales_invoice_name}, "name"
+			# Correlación estricta: actualizar SOLO el FFM explícito de la operación.
+			# Nunca se resuelve por Sales Invoice.
+			factura_fiscal_name = self._resolve_validated_ffm(
+				factura_fiscal_name, sales_invoice_name, response_data, operation_type
 			)
-
-			if not factura_fiscal_name:
-				return
 
 			# Normalize operation_type to match _derive_status_from_response expectations
 			_normalized_op = {
@@ -502,17 +693,23 @@ class PACResponseWriter:
 
 @frappe.whitelist()
 def write_pac_response(
-	sales_invoice_name: str, request_data: str, response_data: str, operation_type: str = "timbrado"
+	sales_invoice_name: str,
+	request_data: str,
+	response_data: str,
+	operation_type: str = "timbrado",
+	factura_fiscal_name: str | None = None,
 ) -> dict[str, Any]:
 	"""
 	API pública para escribir respuesta PAC.
 	Ultra-resiliente con filesystem fallback.
 
 	Args:
-		sales_invoice_name: Nombre Sales Invoice
+		sales_invoice_name: Nombre Sales Invoice (validación cruzada)
 		request_data: JSON string con datos request
 		response_data: JSON string con respuesta FacturAPI
 		operation_type: timbrado/cancelacion/consulta
+		factura_fiscal_name: Nombre EXPLÍCITO del FFM que inició la operación
+			(obligatorio para correlación estricta — Corrección 1).
 
 	Returns:
 		Dict con resultado operación
@@ -524,7 +721,13 @@ def write_pac_response(
 
 		# Usar writer resiliente
 		writer = PACResponseWriter()
-		result = writer.write_pac_response(sales_invoice_name, request_dict, response_dict, operation_type)
+		result = writer.write_pac_response(
+			sales_invoice_name,
+			request_dict,
+			response_dict,
+			operation_type,
+			factura_fiscal_name=factura_fiscal_name,
+		)
 
 		return result
 
@@ -535,15 +738,20 @@ def write_pac_response(
 
 @frappe.whitelist()
 def write_pac_timeout(
-	sales_invoice_name: str, request_data: str, timeout_seconds: int = 30
+	sales_invoice_name: str,
+	request_data: str,
+	timeout_seconds: int = 30,
+	factura_fiscal_name: str | None = None,
 ) -> dict[str, Any]:
 	"""
 	Registrar timeout de PAC y programar recovery.
 
 	Args:
-		sales_invoice_name: Nombre Sales Invoice
+		sales_invoice_name: Nombre Sales Invoice (validación cruzada)
 		request_data: JSON string con datos request original
 		timeout_seconds: Segundos de timeout
+		factura_fiscal_name: Nombre EXPLÍCITO del FFM de origen (obligatorio para
+			correlación estricta — Corrección 1).
 
 	Returns:
 		Dict con resultado y recovery task creado
@@ -563,7 +771,11 @@ def write_pac_timeout(
 		# Escribir usando writer resiliente
 		writer = PACResponseWriter()
 		result = writer.write_pac_response(
-			sales_invoice_name, request_dict, timeout_response, "timeout_recovery"
+			sales_invoice_name,
+			request_dict,
+			timeout_response,
+			"timeout_recovery",
+			factura_fiscal_name=factura_fiscal_name,
 		)
 
 		return result
@@ -601,13 +813,16 @@ def recover_from_file(fallback_file_path: str) -> dict[str, Any]:
 				"already_recovered": True,
 			}
 
-		# Procesar con writer (que intentará BD primero)
+		# Procesar con writer (que intentará BD primero). El FFM explícito viaja en
+		# el archivo fallback; si falta (archivos previos a Corrección 1), el writer
+		# generará alerta crítica de correlación en lugar de resolver por SI.
 		writer = PACResponseWriter()
 		result = writer.write_pac_response(
 			fallback_data["sales_invoice"],
 			fallback_data["request_data"],
 			fallback_data["response_data"],
 			fallback_data["operation_type"],
+			factura_fiscal_name=fallback_data.get("factura_fiscal_name"),
 		)
 
 		if result["success"] and result.get("method") == "database":

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -78,6 +78,63 @@ def _extract_response_identifiers(response_data: dict) -> tuple[str, str]:
 	return uuid, facturapi_id
 
 
+def _derive_sync_status_from_response(response_data: dict, operation_type: str) -> str | None:
+	"""Derivar fm_sync_status según si el PAC dio una respuesta CONCLUYENTE persistida (7A1).
+
+	Semántica: fm_sync_status indica si el FFM local refleja de forma verificable la última
+	respuesta conocida del PAC. NO se confunde con el estado fiscal (PENDIENTE_CANCELACION es
+	'synced' si la respuesta del PAC ya se reflejó localmente).
+
+	Devuelve:
+	- 'synced'  → hubo una respuesta concluyente del PAC (éxito, rechazo conocido o estado de
+	  cancelación) interpretable; el estado local la refleja.
+	- 'pending' → la respuesta es realmente inconclusa (timeout o sin información suficiente).
+	- None      → la llamada NO representa una respuesta del PAC (fallback de logging de eventos
+	  desde create_fiscal_event); en ese caso el caller NO debe alterar fm_sync_status.
+	"""
+	# Fallback no-PAC (create_fiscal_event → _log_event_to_response_log): no es una respuesta
+	# del PAC. operation_type viene como "fiscal_event_*". No tocar fm_sync_status.
+	if isinstance(operation_type, str) and operation_type.startswith("fiscal_event_"):
+		return None
+
+	if not isinstance(response_data, dict):
+		return "pending"
+
+	# Timeout u operación realmente inconclusa.
+	if response_data.get("timeout_flag"):
+		return "pending"
+
+	# Identificadores del CFDI o estado de cancelación (top-level o en raw_response) → el PAC dio
+	# una respuesta concluyente interpretable.
+	uuid, facturapi_id = _extract_response_identifiers(response_data)
+	if uuid or facturapi_id:
+		return "synced"
+	raw = response_data.get("raw_response")
+	raw = raw if isinstance(raw, dict) else {}
+	for d in (response_data, raw):
+		if d.get("status") or d.get("cancellation_status"):
+			return "synced"
+
+	# Código HTTP: 2xx (aceptado) y 4xx (rechazo conocido del PAC) son concluyentes. 5xx (error de
+	# servidor/transporte) y 0/ausente NO son concluyentes solo por tener código → no marcar synced.
+	sc = response_data.get("status_code")
+	try:
+		code = int(sc) if sc is not None else 0
+	except (TypeError, ValueError):
+		code = 0
+	if 200 <= code < 500:
+		return "synced"
+	if code >= 500:
+		return "pending"
+
+	# Sin código concluyente: solo un 'success' explícitamente True cuenta como concluyente.
+	# success=False sin 4xx (timeout/transporte) o sin información → realmente pendiente.
+	if response_data.get("success") is True:
+		return "synced"
+
+	return "pending"
+
+
 def _derive_http_status(data: dict, default=500) -> int:
 	# Éxito explícito → 200 fijo, ignorar 'status_code' dentro del payload y cualquier regex
 	if isinstance(data, dict) and data.get("success") is True:
@@ -569,11 +626,15 @@ class PACResponseWriter:
 			# Corrección 2: NO se establece aquí fm_last_response_log. El estado fiscal
 			# debe persistir ANTES e independientemente del Response Log; la referencia
 			# al log se asigna después, cuando el log ya existe.
-			success = bool(response_data.get("success"))
+			# Corrección 7A1: fm_sync_status refleja si hubo una respuesta CONCLUYENTE del PAC
+			# persistida (no `response_data.get("success")`, que el raw de cancelación no trae).
+			# Si la llamada es un fallback no-PAC (fiscal_event_*), no se altera fm_sync_status.
 			update_fields = {
 				"fm_last_pac_sync": now_datetime(),
-				"fm_sync_status": "synced" if success else "pending",
 			}
+			sync_status = _derive_sync_status_from_response(response_data, operation_type)
+			if sync_status is not None:
+				update_fields["fm_sync_status"] = sync_status
 
 			# Solo actualizar estado fiscal si la operación lo requiere (new_status no es None)
 			if new_status is not None:

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -181,8 +181,31 @@ class PACResponseWriter:
 			"timestamp": now(),
 		}
 
+		# Corrección 2: el ESTADO FISCAL se persiste PRIMERO e independientemente del
+		# Response Log. El log es auditoría; su fallo no debe revertir ni ocultar el
+		# resultado fiscal confirmado por el PAC, ni degradar a filesystem.
+
+		# PASO 1: Actualizar y persistir el FFM (estado fiscal, UUID, facturapi_id,
+		# fm_sync_status). Valida correlación estricta (Corrección 1) y commitea el FFM.
+		# - FiscalCorrelationError → propaga (no se toca nada).
+		# - Otro fallo de actualización → _update_factura_fiscal alerta y relanza:
+		#   NO se crea el Response Log y NO se presenta como persistido (punto 3).
+		self._update_factura_fiscal(
+			sales_invoice_name,
+			response_data,
+			None,  # fm_last_response_log se asigna después, cuando el log exista
+			operation_type,
+			factura_fiscal_name=factura_fiscal_name,
+		)
+		result["success"] = True
+		result["method"] = "database"
+		result["fiscal_updated"] = True
+
+		# PASO 2: Response Log de auditoría, AISLADO con savepoint. Si su inserción
+		# falla, se revierte SOLO el log (rollback al savepoint); el FFM ya persistido
+		# permanece intacto. No se relanza y no se degrada a filesystem (prueba 4).
 		try:
-			# PASO 1: Intentar escritura a BD (principal)
+			frappe.db.savepoint("pac_audit_log")
 			response_log = self._write_to_database(
 				sales_invoice_name,
 				request_data,
@@ -190,83 +213,48 @@ class PACResponseWriter:
 				operation_type,
 				factura_fiscal_name=factura_fiscal_name,
 			)
+			result["response_log_name"] = response_log.name
 
-			if response_log:
-				result["success"] = True
-				result["response_log_name"] = response_log.name
-				result["method"] = "database"
-
-				# PASO 2: Actualizar el MISMO FFM explícito (nunca por Sales Invoice)
-				self._update_factura_fiscal(
-					sales_invoice_name,
-					response_data,
+			# PASO 3: enlazar la referencia de auditoría tras crear el log. Su fallo no
+			# revierte ni el FFM fiscal ni el log ya creado.
+			try:
+				frappe.db.set_value(
+					"Factura Fiscal Mexico",
+					factura_fiscal_name,
+					"fm_last_response_log",
 					response_log.name,
-					operation_type,
-					factura_fiscal_name=factura_fiscal_name,
+				)
+			except Exception as ref_error:
+				result["audit_log_ref_failed"] = True
+				_alerta_correlacion_critica(
+					"No se pudo enlazar fm_last_response_log; FFM y Response Log conservados",
+					{
+						"factura_fiscal_name": factura_fiscal_name,
+						"response_log": response_log.name,
+						"error": str(ref_error),
+					},
 				)
 
-				return result
-
 		except FiscalCorrelationError:
-			# Contradicción de correlación: NO degradar a filesystem. Propagar el
-			# error controlado para que el caller lo maneje y nada se modifique.
+			# El log también valida correlación; si contradice, propagar.
 			raise
-		except Exception as db_error:
-			result["errors"].append(f"DB Error: {db_error!s}")
-			frappe.log_error(f"Error escritura BD PAC: {traceback.format_exc()}", "PAC Writer DB Error")
-
-		# PASO 3: Fallback a filesystem si BD falla
-		try:
-			fallback_file = self._write_to_filesystem(
-				sales_invoice_name,
-				request_data,
-				response_data,
-				operation_type,
-				factura_fiscal_name=factura_fiscal_name,
+		except Exception as log_error:
+			frappe.db.rollback(save_point="pac_audit_log")
+			result["audit_log_failed"] = True
+			result["errors"].append(f"Audit log error: {log_error!s}")
+			_alerta_correlacion_critica(
+				"Fallo al guardar Response Log; estado fiscal ya persistido se conserva",
+				{
+					"factura_fiscal_name": factura_fiscal_name,
+					"sales_invoice": sales_invoice_name,
+					"operation_type": operation_type,
+					"error": str(log_error),
+				},
 			)
-
-			result["success"] = True
-			result["fallback_file"] = fallback_file
-			result["method"] = "filesystem_fallback"
-			result["errors"].append("BD no disponible - guardado en filesystem para recovery")
-
-			# Programar recovery automático
-			self._schedule_recovery_task(fallback_file)
-
-			return result
-
-		except Exception as fs_error:
-			result["errors"].append(f"Filesystem Error: {fs_error!s}")
 			frappe.log_error(
-				f"Error filesystem fallback: {traceback.format_exc()}", "PAC Writer Filesystem Error"
+				f"Error guardando Response Log (estado fiscal conservado): {traceback.format_exc()}",
+				"PAC Writer Audit Log Error",
 			)
-
-		# PASO 4: Si todo falla, log crítico pero NO falla silenciosamente
-		result["errors"].append("CRÍTICO: Falló escritura BD y filesystem - respuesta PAC en riesgo")
-		frappe.log_error(
-			f"CRÍTICO PAC Response Writer: {json.dumps(result, indent=2)}", "PAC Writer CRITICAL FAILURE"
-		)
-
-		# Incluso en falla completa, intentamos un último log de emergencia
-		try:
-			emergency_log = {
-				"sales_invoice": sales_invoice_name,
-				"response_data": response_data,
-				"timestamp": now(),
-				"emergency_flag": True,
-			}
-
-			emergency_file = (
-				f"/tmp/pac_emergency_{sales_invoice_name}_{now().replace(' ', '_').replace(':', '-')}.json"
-			)
-			with open(emergency_file, "w") as f:
-				json.dump(emergency_log, f, indent=2, default=str)
-
-			result["emergency_file"] = emergency_file
-
-		except Exception:
-			# Si incluso el log de emergencia falla, al menos tenemos el error en result
-			pass
 
 		return result
 
@@ -585,9 +573,11 @@ class PACResponseWriter:
 			new_status, _status_code, uuid = self._derive_status_from_response(response_data, _normalized_op)
 
 			# Preparar campos a actualizar - NORMALIZACIÓN CRÍTICA A MAYÚSCULAS
+			# Corrección 2: NO se establece aquí fm_last_response_log. El estado fiscal
+			# debe persistir ANTES e independientemente del Response Log; la referencia
+			# al log se asigna después, cuando el log ya existe.
 			success = bool(response_data.get("success"))
 			update_fields = {
-				"fm_last_response_log": response_log_name,
 				"fm_last_pac_sync": now_datetime(),
 				"fm_sync_status": "synced" if success else "pending",
 			}
@@ -618,11 +608,28 @@ class PACResponseWriter:
 			for field, value in update_fields.items():
 				frappe.db.set_value("Factura Fiscal Mexico", factura_fiscal_name, field, value)
 
+			# Persistir el estado fiscal confirmado por el PAC ANTES e independientemente
+			# del Response Log (Corrección 2). Commit ya existente — no se agrega ninguno.
 			frappe.db.commit()
 
+		except FiscalCorrelationError:
+			# Contradicción de correlación (Corrección 1): propagar sin tocar nada.
+			raise
 		except Exception as e:
-			# No fallar si actualización Factura Fiscal falla - respuesta PAC ya guardada
+			# Corrección 2: un fallo al persistir el estado fiscal NO debe ocultarse ni
+			# presentarse como operación correcta. Se alerta de forma crítica y se relanza
+			# para que el orquestador NO cree el Response Log ni reporte éxito.
+			_alerta_correlacion_critica(
+				"Fallo al actualizar el estado fiscal del FFM tras respuesta PAC",
+				{
+					"factura_fiscal_name": factura_fiscal_name,
+					"sales_invoice": sales_invoice_name,
+					"operation_type": operation_type,
+					"error": str(e),
+				},
+			)
 			frappe.log_error(f"Error actualizando Factura Fiscal: {e!s}", "PAC Writer Update Error")
+			raise
 
 	def _is_success_response(self, response_data: dict[str, Any]) -> bool:
 		"""Determinar si respuesta PAC fue exitosa."""

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -73,10 +73,7 @@ def _extract_response_identifiers(response_data: dict) -> tuple[str, str]:
 	raw = raw if isinstance(raw, dict) else {}
 	uuid = (response_data.get("uuid") or raw.get("uuid") or "").strip()
 	facturapi_id = (
-		response_data.get("facturapi_id")
-		or response_data.get("id")
-		or raw.get("id")
-		or ""
+		response_data.get("facturapi_id") or response_data.get("id") or raw.get("id") or ""
 	).strip()
 	return uuid, facturapi_id
 
@@ -350,11 +347,7 @@ class PACResponseWriter:
 				title=_("Correlación fiscal inválida"),
 				exc=FiscalCorrelationError,
 			)
-		if (
-			resp_facturapi_id
-			and ffm.get("facturapi_id")
-			and resp_facturapi_id != ffm["facturapi_id"]
-		):
+		if resp_facturapi_id and ffm.get("facturapi_id") and resp_facturapi_id != ffm["facturapi_id"]:
 			_alerta_correlacion_critica(
 				"facturapi_id de la respuesta PAC no coincide con el FFM explícito",
 				{
@@ -738,6 +731,11 @@ def write_pac_response(
 
 		return result
 
+	except FiscalCorrelationError:
+		# Corrección 6A: la correlación crítica (Corrección 1) NO se degrada a {success:False}.
+		# Se propaga para que el orquestador detenga el flujo (no reintentar, no continuar a
+		# FASE 3, no re-llamar al PAC). La evidencia técnica ya quedó en la alerta del writer.
+		raise
 	except Exception as e:
 		frappe.log_error(f"Error en write_pac_response API: {traceback.format_exc()}", "PAC API Error")
 		return {"success": False, "error": str(e), "timestamp": now()}

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -629,9 +629,12 @@ class PACResponseWriter:
 			# Corrección 7A1: fm_sync_status refleja si hubo una respuesta CONCLUYENTE del PAC
 			# persistida (no `response_data.get("success")`, que el raw de cancelación no trae).
 			# Si la llamada es un fallback no-PAC (fiscal_event_*), no se altera fm_sync_status.
-			update_fields = {
-				"fm_last_pac_sync": now_datetime(),
-			}
+			# M1 (CodeRabbit): tampoco se refresca fm_last_pac_sync en eventos internos no-PAC;
+			# hacerlo haría que un fallback interno parezca una sincronización fresca con el PAC.
+			_is_fiscal_event = isinstance(operation_type, str) and operation_type.startswith("fiscal_event_")
+			update_fields = {}
+			if not _is_fiscal_event:
+				update_fields["fm_last_pac_sync"] = now_datetime()
 			sync_status = _derive_sync_status_from_response(response_data, operation_type)
 			if sync_status is not None:
 				update_fields["fm_sync_status"] = sync_status
@@ -857,6 +860,10 @@ def write_pac_timeout(
 
 		return result
 
+	except FiscalCorrelationError:
+		# Corrección 6A (consistencia): una contradicción de correlación debe DETENER el flujo,
+		# no degradarse a {success: False} como un fallo ordinario de escritura de timeout.
+		raise
 	except Exception as e:
 		frappe.log_error(f"Error en write_pac_timeout: {traceback.format_exc()}", "PAC Timeout Error")
 		return {"success": False, "error": str(e), "timestamp": now()}

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -4,6 +4,7 @@ from frappe.contacts.doctype.address.address import get_address_display
 from frappe.model.document import Document
 from frappe.utils import cint, flt, now_datetime
 
+from facturacion_mexico.config.fiscal_states_config import FiscalStates
 from facturacion_mexico.sat.constants import TIPO_COMPROBANTE, TIPO_RELACION, parse_select_code
 
 # Lista blanca de campos permisibles tras submit (operativos, no fiscales)
@@ -153,6 +154,10 @@ class FacturaFiscalMexico(Document):
 				self.customer = sales_invoice.customer
 
 	def before_insert(self):
+		# Regla B (Corrección 5): impedir un segundo FFM activo/no resuelto por Sales Invoice.
+		# Protege TODA vía de inserción (Desk, API, scripts, .insert() directo, código futuro).
+		self._validate_unico_ffm_activo()
+
 		if not (self.fm_payment_method_sat or "").strip() or self.fm_payment_method_sat == "PUE":
 			company = self.company or frappe.defaults.get_global_default("company")
 			self.fm_payment_method_sat = (
@@ -525,6 +530,48 @@ class FacturaFiscalMexico(Document):
 		if new_status not in valid_transitions.get(old_status, []):
 			frappe.throw(
 				_("Transición de estado inválida: {0} → {1}").format(old_status or "nuevo", new_status)
+			)
+
+	def _validate_unico_ffm_activo(self):
+		"""Regla B (Corrección 5): impedir un segundo FFM activo/no resuelto por Sales Invoice.
+
+		Se ejecuta en `before_insert`, por lo que protege TODA vía de creación
+		(Desk, API, scripts, `.insert()` directo) y NO afecta a documentos ya existentes
+		(abrir/guardar/consultar/corregir un FFM previo no dispara esta validación).
+
+		Adquiere el lock transaccional de la fila de la Sales Invoice (`for_update`) para
+		serializar inserciones concurrentes; si ya existe otro FFM activo de esa SI, detiene
+		la inserción con un error controlado. La función centralizada `get_or_create_active_ffm`
+		reutiliza el activo y no llega a insertar; la inserción directa de un segundo activo falla.
+		"""
+		if not self.sales_invoice:
+			return
+
+		if not frappe.db.exists("Sales Invoice", self.sales_invoice):
+			frappe.throw(
+				_("La Sales Invoice {0} no existe.").format(self.sales_invoice),
+				title=_("Sales Invoice inexistente"),
+			)
+
+		# Lock de fila de la SI: serializa con get_or_create_active_ffm y otras inserciones.
+		frappe.get_doc("Sales Invoice", self.sales_invoice, for_update=True)
+
+		otros_activos = frappe.get_all(
+			"Factura Fiscal Mexico",
+			filters={
+				"sales_invoice": self.sales_invoice,
+				"status": ["in", FiscalStates.ACTIVE_STATES],
+				"name": ["!=", self.name or "new-ffm"],
+			},
+			pluck="name",
+		)
+		if otros_activos:
+			frappe.throw(
+				_(
+					"La Sales Invoice {0} ya tiene un FFM activo ({1}). No se permite crear otro "
+					"(Regla B: un solo FFM activo por factura)."
+				).format(self.sales_invoice, ", ".join(otros_activos)),
+				title=_("FFM activo ya existe"),
 			)
 
 	def validate_no_duplicate_timbrado(self):
@@ -1311,8 +1358,15 @@ def get_or_create_active_ffm(sales_invoice: str, extra_fields: str | dict | None
 	"""Obtener o crear el FFM de una Sales Invoice — única vía de creación e idempotente.
 
 	Centraliza en servidor la creación que antes hacía el botón con `frappe.client.insert`
-	+ `set_value`. Reutiliza el FFM ya vinculado en `Sales Invoice.fm_factura_fiscal_mx`;
-	si la referencia está vacía, crea uno con la MISMA lógica y valores del botón y lo vincula.
+	+ `set_value`.
+
+	Corrección 5 — cardinalidad (Regla B): la decisión de crear o reutilizar NO depende
+	solo de `Sales Invoice.fm_factura_fiscal_mx`, sino de los FFM activos/no resueltos
+	(status en `FiscalStates.ACTIVE_STATES`) cuyo `sales_invoice` es esta SI:
+	- 0 activos → crea uno y lo vincula (incluye el caso de referencia a FFM terminal/roto);
+	- 1 activo → lo reutiliza y repara el vínculo de la SI si está vacío/desactualizado;
+	- ≥2 activos → alerta crítica y error controlado (no elige ni crea, no toca estados).
+	Si la referencia apunta a un FFM de OTRA Sales Invoice → error de integridad.
 
 	Corrección 4 — concurrencia: la Sales Invoice se relee con `for_update=True`
 	(`SELECT ... FOR UPDATE`), que adquiere un lock de fila transaccional. Dos solicitudes
@@ -1324,8 +1378,6 @@ def get_or_create_active_ffm(sales_invoice: str, extra_fields: str | dict | None
 	No llama al PAC.
 	"""
 	import json
-
-	from facturacion_mexico.config.fiscal_states_config import FiscalStates
 
 	if isinstance(extra_fields, str):
 		extra_fields = json.loads(extra_fields) if extra_fields else {}
@@ -1347,38 +1399,78 @@ def get_or_create_active_ffm(sales_invoice: str, extra_fields: str | dict | None
 	si = frappe.get_doc("Sales Invoice", sales_invoice, for_update=True)
 	si.check_permission("read")
 
-	# Reutilizar el FFM ya vinculado, si la referencia es válida (lectura post-lock).
+	# Reglas de resolución (Corrección 5 — Regla B, un solo FFM activo por SI). La decisión
+	# NO depende solo de Sales Invoice.fm_factura_fiscal_mx: se basa en los FFM activos
+	# (status en ACTIVE_STATES) cuyo sales_invoice es esta SI.
+	from facturacion_mexico.facturacion_fiscal.api import (
+		FiscalCorrelationError,
+		_alerta_correlacion_critica,
+	)
+
 	existing_ref = si.get("fm_factura_fiscal_mx")
+
+	# Integridad: si la SI referencia un FFM que pertenece a OTRA Sales Invoice, detener.
+	# No se reutiliza ni se sobrescribe silenciosamente la relación.
 	if existing_ref:
-		ffm = frappe.db.get_value("Factura Fiscal Mexico", existing_ref, ["name", "status"], as_dict=True)
-		if ffm:
-			if ffm.status in FiscalStates.FINAL_STATES:
-				# Apunta a un FFM terminal (CANCELADO/ARCHIVADO). La reemisión tras estado
-				# terminal es cardinalidad (Corrección 5); aquí se devuelve sin crear otro.
-				frappe.logger().info(
-					f"get_or_create_active_ffm: SI {sales_invoice} apunta a FFM terminal "
-					f"{existing_ref} ({ffm.status})"
-				)
-			return ffm.name
-		# Referencia rota: apunta a un FFM inexistente. Se documenta y se crea uno nuevo.
-		frappe.logger().warning(
-			f"get_or_create_active_ffm: SI {sales_invoice} apunta a FFM inexistente "
-			f"{existing_ref}; se creará uno nuevo"
+		ref_si = frappe.db.get_value("Factura Fiscal Mexico", existing_ref, "sales_invoice")
+		if ref_si and ref_si != si.name:
+			_alerta_correlacion_critica(
+				"Sales Invoice referencia un FFM de otra Sales Invoice",
+				{
+					"sales_invoice": si.name,
+					"fm_factura_fiscal_mx": existing_ref,
+					"ffm_sales_invoice": ref_si,
+				},
+			)
+			frappe.throw(
+				_(
+					"La Sales Invoice {0} referencia un FFM ({1}) que pertenece a otra "
+					"Sales Invoice ({2}). Integridad fiscal comprometida."
+				).format(si.name, existing_ref, ref_si),
+				title=_("Integridad fiscal"),
+				exc=FiscalCorrelationError,
+			)
+
+	# Todos los FFM activos/no resueltos de esta SI (por status, no por docstatus).
+	activos = frappe.get_all(
+		"Factura Fiscal Mexico",
+		filters={"sales_invoice": si.name, "status": ["in", FiscalStates.ACTIVE_STATES]},
+		pluck="name",
+		order_by="creation asc",
+	)
+
+	# Dos o más activos → integridad crítica. No elegir arbitrariamente, no crear, no tocar estados.
+	if len(activos) >= 2:
+		_alerta_correlacion_critica(
+			"Múltiples FFM activos para la misma Sales Invoice",
+			{"sales_invoice": si.name, "ffm_activos": activos},
+		)
+		frappe.throw(
+			_(
+				"La Sales Invoice {0} tiene {1} FFM activos ({2}). No se puede resolver "
+				"automáticamente; requiere intervención manual."
+			).format(si.name, len(activos), ", ".join(activos)),
+			title=_("Integridad fiscal"),
+			exc=FiscalCorrelationError,
 		)
 
-	# Documentar (sin reconciliar) FFM existentes por sales_invoice no vinculados a la SI.
-	# La reconciliación completa de cardinalidad corresponde a la Corrección 5.
-	no_vinculados = [
-		n
-		for n in frappe.get_all(
-			"Factura Fiscal Mexico", filters={"sales_invoice": sales_invoice}, pluck="name"
-		)
-		if n != existing_ref
-	]
-	if no_vinculados:
-		frappe.logger().warning(
-			f"get_or_create_active_ffm: SI {sales_invoice} tiene FFM no vinculados a la SI "
-			f"{no_vinculados} (reconciliación de cardinalidad pendiente — Corrección 5)"
+	# Exactamente un activo → reutilizarlo y reparar el vínculo de la SI si está vacío/desactualizado.
+	if len(activos) == 1:
+		ffm_name = activos[0]
+		if existing_ref != ffm_name:
+			frappe.db.set_value("Sales Invoice", si.name, "fm_factura_fiscal_mx", ffm_name)
+			frappe.logger().info(
+				f"get_or_create_active_ffm: SI {si.name} vínculo reparado al FFM activo {ffm_name} "
+				f"(antes: {existing_ref or 'vacío'})"
+			)
+		return ffm_name
+
+	# Ningún activo → se crea uno nuevo. La referencia previa (si existe) apuntaba a un FFM
+	# terminal (CANCELADO/ARCHIVADO) o inexistente; una nueva emisión está permitida (Regla B).
+	if existing_ref:
+		frappe.logger().info(
+			f"get_or_create_active_ffm: SI {si.name} sin FFM activo (ref previa {existing_ref} "
+			f"terminal o inexistente); se crea uno nuevo"
 		)
 
 	# Crear el FFM con la MISMA lógica/valores del botón (cálculo de IVA en servidor).

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -1383,6 +1383,32 @@ def get_or_create_active_ffm(sales_invoice: str, extra_fields: str | dict | None
 		extra_fields = json.loads(extra_fields) if extra_fields else {}
 	extra_fields = extra_fields or {}
 
+	from facturacion_mexico.facturacion_fiscal.api import (
+		FiscalCorrelationError,
+		_alerta_correlacion_critica,
+	)
+
+	# Blindaje (C1): `extra_fields` viene de un caller externo (el botón JS) y debe tener una
+	# superficie mínima autorizada. Solo se permiten los campos que hoy un caller legítimo
+	# necesita pasar (nota de crédito / devolución). Cualquier otra clave se rechaza de forma
+	# EXPLÍCITA: permitirla dejaría sobrescribir `sales_invoice`, `company`, `status`, UUID o
+	# `facturapi_id` —los campos de correlación y estado que esta función deriva y valida— y
+	# recrearía el mismatch SI↔FFM que esta corrección previene.
+	_ALLOWED_EXTRA_FIELDS = {
+		"fm_uuid_relacionado",
+		"fm_tipo_relacion_sat",
+	}
+	_campos_no_permitidos = set(extra_fields) - _ALLOWED_EXTRA_FIELDS
+	if _campos_no_permitidos:
+		frappe.throw(
+			_("extra_fields solo admite {0}. Campos no permitidos: {1}.").format(
+				", ".join(sorted(_ALLOWED_EXTRA_FIELDS)),
+				", ".join(sorted(_campos_no_permitidos)),
+			),
+			title=_("Integridad fiscal"),
+			exc=FiscalCorrelationError,
+		)
+
 	# La Sales Invoice debe existir (lectura previa SOLO para error temprano; no decide crear).
 	if not frappe.db.exists("Sales Invoice", sales_invoice):
 		frappe.throw(
@@ -1402,11 +1428,6 @@ def get_or_create_active_ffm(sales_invoice: str, extra_fields: str | dict | None
 	# Reglas de resolución (Corrección 5 — Regla B, un solo FFM activo por SI). La decisión
 	# NO depende solo de Sales Invoice.fm_factura_fiscal_mx: se basa en los FFM activos
 	# (status en ACTIVE_STATES) cuyo sales_invoice es esta SI.
-	from facturacion_mexico.facturacion_fiscal.api import (
-		FiscalCorrelationError,
-		_alerta_correlacion_critica,
-	)
-
 	existing_ref = si.get("fm_factura_fiscal_mx")
 
 	# Integridad: si la SI referencia un FFM que pertenece a OTRA Sales Invoice, detener.

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -657,6 +657,7 @@ class FacturaFiscalMexico(Document):
 				json.dumps({"event_type": event_type, "source": "fiscal_event_fallback"}),
 				json.dumps(event_data),
 				f"fiscal_event_{event_type}",
+				factura_fiscal_name=self.name,
 			)
 
 			frappe.logger().info(f"Fiscal event logged to Response Log: {event_type} for {self.name}")

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -1308,15 +1308,18 @@ def get_sales_invoice_for_ffm(
 
 @frappe.whitelist()
 def get_or_create_active_ffm(sales_invoice: str, extra_fields: str | dict | None = None) -> str:
-	"""Obtener o crear el FFM de una Sales Invoice — única vía de creación (Corrección 3).
+	"""Obtener o crear el FFM de una Sales Invoice — única vía de creación e idempotente.
 
 	Centraliza en servidor la creación que antes hacía el botón con `frappe.client.insert`
 	+ `set_value`. Reutiliza el FFM ya vinculado en `Sales Invoice.fm_factura_fiscal_mx`;
 	si la referencia está vacía, crea uno con la MISMA lógica y valores del botón y lo vincula.
 
-	⚠️ SIN LOCK TODAVÍA: dos llamadas concurrentes con `fm_factura_fiscal_mx` vacío aún pueden
-	crear dos FFM. La condición de carrera NO queda resuelta en esta corrección; la
-	Corrección 4 agregará el lock por Sales Invoice. No asumir unicidad concurrente aquí.
+	Corrección 4 — concurrencia: la Sales Invoice se relee con `for_update=True`
+	(`SELECT ... FOR UPDATE`), que adquiere un lock de fila transaccional. Dos solicitudes
+	concurrentes para la misma SI se serializan: la segunda espera al commit de la primera y,
+	al releer bajo el lock, encuentra el FFM ya vinculado y lo reutiliza. La DECISIÓN de crear
+	o reutilizar se toma SIEMPRE con la lectura posterior al lock. El lock se libera con el
+	commit/rollback NORMAL del request — NO se ejecuta ningún `frappe.db.commit()` aquí.
 
 	No llama al PAC.
 	"""
@@ -1328,24 +1331,26 @@ def get_or_create_active_ffm(sales_invoice: str, extra_fields: str | dict | None
 		extra_fields = json.loads(extra_fields) if extra_fields else {}
 	extra_fields = extra_fields or {}
 
-	# La Sales Invoice debe existir.
+	# La Sales Invoice debe existir (lectura previa SOLO para error temprano; no decide crear).
 	if not frappe.db.exists("Sales Invoice", sales_invoice):
 		frappe.throw(
 			_("La Sales Invoice {0} no existe.").format(sales_invoice),
 			title=_("Sales Invoice inexistente"),
 		)
 
-	# Recargar la SI desde servidor y validar permisos (lectura SI + creación FFM).
-	si = frappe.get_doc("Sales Invoice", sales_invoice)
-	si.check_permission("read")
+	# Permiso de creación de FFM (no requiere mantener la fila bloqueada).
 	frappe.has_permission("Factura Fiscal Mexico", "create", throw=True)
 
-	# Reutilizar el FFM ya vinculado, si la referencia es válida.
+	# --- Sección crítica: lock de fila transaccional sobre la Sales Invoice ---
+	# Releer con FOR UPDATE serializa las solicitudes concurrentes para la misma SI.
+	# La decisión de crear/reutilizar se basa EXCLUSIVAMENTE en este documento post-lock.
+	si = frappe.get_doc("Sales Invoice", sales_invoice, for_update=True)
+	si.check_permission("read")
+
+	# Reutilizar el FFM ya vinculado, si la referencia es válida (lectura post-lock).
 	existing_ref = si.get("fm_factura_fiscal_mx")
 	if existing_ref:
-		ffm = frappe.db.get_value(
-			"Factura Fiscal Mexico", existing_ref, ["name", "status"], as_dict=True
-		)
+		ffm = frappe.db.get_value("Factura Fiscal Mexico", existing_ref, ["name", "status"], as_dict=True)
 		if ffm:
 			if ffm.status in FiscalStates.FINAL_STATES:
 				# Apunta a un FFM terminal (CANCELADO/ARCHIVADO). La reemisión tras estado
@@ -1405,7 +1410,8 @@ def get_or_create_active_ffm(sales_invoice: str, extra_fields: str | dict | None
 	# Vincular el FFM creado a la Sales Invoice.
 	frappe.db.set_value("Sales Invoice", si.name, "fm_factura_fiscal_mx", ffm_doc.name)
 
-	# Devolver el nombre del FFM (sin llamar al PAC).
+	# Devolver el nombre del FFM (sin llamar al PAC). El lock de fila adquirido con
+	# for_update se libera con el commit/rollback NORMAL del request — sin commit manual.
 	return ffm_doc.name
 
 

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -1307,6 +1307,109 @@ def get_sales_invoice_for_ffm(
 
 
 @frappe.whitelist()
+def get_or_create_active_ffm(sales_invoice: str, extra_fields: str | dict | None = None) -> str:
+	"""Obtener o crear el FFM de una Sales Invoice — única vía de creación (Corrección 3).
+
+	Centraliza en servidor la creación que antes hacía el botón con `frappe.client.insert`
+	+ `set_value`. Reutiliza el FFM ya vinculado en `Sales Invoice.fm_factura_fiscal_mx`;
+	si la referencia está vacía, crea uno con la MISMA lógica y valores del botón y lo vincula.
+
+	⚠️ SIN LOCK TODAVÍA: dos llamadas concurrentes con `fm_factura_fiscal_mx` vacío aún pueden
+	crear dos FFM. La condición de carrera NO queda resuelta en esta corrección; la
+	Corrección 4 agregará el lock por Sales Invoice. No asumir unicidad concurrente aquí.
+
+	No llama al PAC.
+	"""
+	import json
+
+	from facturacion_mexico.config.fiscal_states_config import FiscalStates
+
+	if isinstance(extra_fields, str):
+		extra_fields = json.loads(extra_fields) if extra_fields else {}
+	extra_fields = extra_fields or {}
+
+	# La Sales Invoice debe existir.
+	if not frappe.db.exists("Sales Invoice", sales_invoice):
+		frappe.throw(
+			_("La Sales Invoice {0} no existe.").format(sales_invoice),
+			title=_("Sales Invoice inexistente"),
+		)
+
+	# Recargar la SI desde servidor y validar permisos (lectura SI + creación FFM).
+	si = frappe.get_doc("Sales Invoice", sales_invoice)
+	si.check_permission("read")
+	frappe.has_permission("Factura Fiscal Mexico", "create", throw=True)
+
+	# Reutilizar el FFM ya vinculado, si la referencia es válida.
+	existing_ref = si.get("fm_factura_fiscal_mx")
+	if existing_ref:
+		ffm = frappe.db.get_value(
+			"Factura Fiscal Mexico", existing_ref, ["name", "status"], as_dict=True
+		)
+		if ffm:
+			if ffm.status in FiscalStates.FINAL_STATES:
+				# Apunta a un FFM terminal (CANCELADO/ARCHIVADO). La reemisión tras estado
+				# terminal es cardinalidad (Corrección 5); aquí se devuelve sin crear otro.
+				frappe.logger().info(
+					f"get_or_create_active_ffm: SI {sales_invoice} apunta a FFM terminal "
+					f"{existing_ref} ({ffm.status})"
+				)
+			return ffm.name
+		# Referencia rota: apunta a un FFM inexistente. Se documenta y se crea uno nuevo.
+		frappe.logger().warning(
+			f"get_or_create_active_ffm: SI {sales_invoice} apunta a FFM inexistente "
+			f"{existing_ref}; se creará uno nuevo"
+		)
+
+	# Documentar (sin reconciliar) FFM existentes por sales_invoice no vinculados a la SI.
+	# La reconciliación completa de cardinalidad corresponde a la Corrección 5.
+	no_vinculados = [
+		n
+		for n in frappe.get_all(
+			"Factura Fiscal Mexico", filters={"sales_invoice": sales_invoice}, pluck="name"
+		)
+		if n != existing_ref
+	]
+	if no_vinculados:
+		frappe.logger().warning(
+			f"get_or_create_active_ffm: SI {sales_invoice} tiene FFM no vinculados a la SI "
+			f"{no_vinculados} (reconciliación de cardinalidad pendiente — Corrección 5)"
+		)
+
+	# Crear el FFM con la MISMA lógica/valores del botón (cálculo de IVA en servidor).
+	iva_total = 0.0
+	otros_impuestos = 0.0
+	for tax in si.taxes or []:
+		head = (tax.account_head or "").upper()
+		if "IVA" in head:
+			iva_total += flt(tax.tax_amount)
+		else:
+			otros_impuestos += flt(tax.tax_amount)
+
+	ffm_doc = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"sales_invoice": si.name,
+			"company": si.company,
+			"customer": si.customer,
+			"fm_fiscal_status": FiscalStates.BORRADOR,
+			"si_total_antes_iva": flt(si.net_total),
+			"si_total_neto": flt(si.grand_total),
+			"si_iva": iva_total,
+			"si_otros_impuestos": otros_impuestos,
+			**extra_fields,
+		}
+	)
+	ffm_doc.insert()
+
+	# Vincular el FFM creado a la Sales Invoice.
+	frappe.db.set_value("Sales Invoice", si.name, "fm_factura_fiscal_mx", ffm_doc.name)
+
+	# Devolver el nombre del FFM (sin llamar al PAC).
+	return ffm_doc.name
+
+
+@frappe.whitelist()
 def check_si_customer_rfc_validated(si_name: str):
 	"""Valida que la SI seleccionada tenga cliente con RFC validado (respaldo en on_change)."""
 	if not si_name:

--- a/facturacion_mexico/facturacion_fiscal/tests/test_audit_warning.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_audit_warning.py
@@ -1,0 +1,282 @@
+"""Manejo NO bloqueante de auditoría incompleta tras respuesta PAC (Corrección 6B1).
+
+Cuando `write_pac_response` reporta `audit_log_failed` o `audit_log_ref_failed`, la operación
+fiscal YA se procesó: el flujo continúa (FASE 3), conserva `success=True`, no re-llama al PAC,
+no crea Recovery Task ni reintenta, y agrega una advertencia visible no bloqueante. Una
+`FiscalCorrelationError` sigue deteniendo el flujo (6A); un error real del PAC o un fallo de
+la FASE 3 conservan su comportamiento existente.
+
+Todo con mocks de boundary. Cero llamadas reales al PAC.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.api import FiscalCorrelationError
+from facturacion_mexico.facturacion_fiscal.timbrado_api import TimbradoAPI, revisar_estatus_cancelacion
+
+_TIMBRADO_API = "facturacion_mexico.facturacion_fiscal.timbrado_api"
+
+
+def _seed_si(*, fiscal_status: str = "", ffm: str | None = None) -> str:
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+			"fm_fiscal_status": fiscal_status or None,
+			"fm_factura_fiscal_mx": ffm,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(sales_invoice, status: str, *, facturapi_id: str = "", uuid: str = "") -> str:
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"facturapi_id": facturapi_id or None,
+			"fm_uuid": uuid or None,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+def _set_value_si_noop_factory():
+	"""Neutraliza efectos colaterales de entorno de test en las escrituras de FASE 3.
+
+	- Sales Invoice: no-op (la SI mínima no pasa validación mandatory).
+	- Factura Fiscal Mexico: escribe con frappe.db.set_value (sin disparar on_update →
+	  create_fiscal_event → Response Log colateral, ajeno a 6B1). El estado fiscal sí se
+	  persiste para poder verificarlo.
+	"""
+	orig = frappe.set_value
+
+	def _fake(dt, dn, *args, **kwargs):
+		if dt == "Sales Invoice":
+			return None
+		if dt == "Factura Fiscal Mexico":
+			return frappe.db.set_value(dt, dn, *args, **kwargs)
+		return orig(dt, dn, *args, **kwargs)
+
+	return _fake
+
+
+class TestAuditWarning(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		has_recovery = frappe.db.exists("DocType", "Fiscal Recovery Task")
+		for ffm in self.ffm_names:
+			if has_recovery:
+				frappe.db.delete("Fiscal Recovery Task", {"reference_name": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def _si(self, **kwargs):
+		name = _seed_si(**kwargs)
+		self.si_names.append(name)
+		return name
+
+	def _ffm(self, *args, **kwargs):
+		name = _seed_ffm(*args, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	def _run_timbrado(self, si, ffm, *, writer_return=None, writer_side_effect=None, create_side_effect=None):
+		"""Ejecuta timbrar_factura con FASE 1 neutralizada y boundaries mockeados."""
+		ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm)
+		client = MagicMock()
+		if create_side_effect is not None:
+			client.create_invoice.side_effect = create_side_effect
+		else:
+			client.create_invoice.return_value = {"uuid": "U-1", "id": "FA-1", "total": 116}
+
+		wpr = patch(f"{_TIMBRADO_API}.write_pac_response")
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			with (
+				patch.object(TimbradoAPI, "_validate_invoice_for_timbrado"),
+				patch.object(TimbradoAPI, "_prepare_facturapi_data", return_value={}),
+				patch.object(TimbradoAPI, "_get_factura_fiscal", return_value=ffm_doc),
+				patch.object(TimbradoAPI, "_validate_amount_discrepancies"),
+				patch.object(TimbradoAPI, "_download_fiscal_files"),
+				patch.object(TimbradoAPI, "_send_fiscal_email"),
+				patch("frappe.set_value", side_effect=_set_value_si_noop_factory()),
+				wpr as mock_wpr,
+			):
+				if writer_side_effect is not None:
+					mock_wpr.side_effect = writer_side_effect
+				else:
+					mock_wpr.return_value = writer_return
+				result = api.timbrar_factura(si)
+		return result, client
+
+	# 1 — timbrado exitoso + audit_log_failed: no bloqueante, FFM TIMBRADO, advertencia
+	def test_01_timbrado_audit_log_failed_no_bloquea(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		result, client = self._run_timbrado(
+			si, ffm, writer_return={"success": True, "fiscal_updated": True, "audit_log_failed": True}
+		)
+		self.assertTrue(result["success"])
+		self.assertTrue(result.get("audit_warning"))
+		self.assertEqual(result.get("audit_status"), "incomplete")
+		self.assertEqual(result.get("audit_detail"), "audit_log_failed")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+		client.create_invoice.assert_called_once()
+
+	# 2 — timbrado exitoso + audit_log_ref_failed: mismo no-bloqueo, diferencia técnica
+	def test_02_timbrado_audit_log_ref_failed(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		result, _ = self._run_timbrado(
+			si, ffm, writer_return={"success": True, "fiscal_updated": True, "audit_log_ref_failed": True}
+		)
+		self.assertTrue(result["success"])
+		self.assertTrue(result.get("audit_warning"))
+		self.assertEqual(result.get("audit_detail"), "audit_log_ref_failed")
+
+	# 5 — writer sin problemas de auditoría: sin advertencia, comportamiento previo
+	def test_05_sin_problema_auditoria_no_advertencia(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		result, _ = self._run_timbrado(
+			si, ffm, writer_return={"success": True, "fiscal_updated": True, "response_log_name": "LOG-1"}
+		)
+		self.assertTrue(result["success"])
+		self.assertNotIn("audit_warning", result)
+
+	# 6 — error real del PAC: comportamiento existente (el except externo devuelve dict de
+	#     error), sin advertencia de auditoría ni mensaje de éxito.
+	def test_06_error_real_pac_conserva_comportamiento(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		result, client = self._run_timbrado(
+			si, ffm, writer_return={"success": True}, create_side_effect=RuntimeError("PAC 500")
+		)
+		self.assertNotIn("audit_warning", result)
+		self.assertNotEqual(result.get("message"), "Factura timbrada exitosamente")
+		client.create_invoice.assert_called_once()
+
+	# 7 — FiscalCorrelationError sigue deteniendo el flujo (6A), no se degrada a advertencia
+	def test_07_correlacion_sigue_deteniendo(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		with self.assertRaises(FiscalCorrelationError):
+			self._run_timbrado(si, ffm, writer_side_effect=FiscalCorrelationError("x"))
+
+	# 8 — fallo de la FASE 3: 6B1 no lo oculta ni lo transforma en éxito con advertencia
+	def test_08_fallo_fase3_no_se_oculta(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		with patch.object(TimbradoAPI, "_process_timbrado_success", side_effect=RuntimeError("frappe down")):
+			# El except frappe_error maneja: success=False, sin audit_warning.
+			ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm)
+			client = MagicMock()
+			client.create_invoice.return_value = {"uuid": "U-1", "id": "FA-1"}
+			with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+				api = TimbradoAPI(company="_Test Company")
+				with (
+					patch.object(TimbradoAPI, "_validate_invoice_for_timbrado"),
+					patch.object(TimbradoAPI, "_prepare_facturapi_data", return_value={}),
+					patch.object(TimbradoAPI, "_get_factura_fiscal", return_value=ffm_doc),
+					patch("frappe.set_value", side_effect=_set_value_si_noop_factory()),
+					patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": True}),
+				):
+					result = api.timbrar_factura(si)
+		self.assertFalse(result["success"])
+		self.assertNotIn("audit_warning", result)
+
+	# 3 — cancelación exitosa + auditoría incompleta: no bloqueante, sin Recovery, sin 2ª cancelación
+	def test_03_cancelacion_audit_incompleta(self):
+		ffm = self._ffm(None, "TIMBRADO", facturapi_id="FA-1", uuid="U-1")
+		si = self._si(fiscal_status="TIMBRADO", ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		frappe.db.commit()
+
+		recovery_dt = frappe.db.exists("DocType", "Fiscal Recovery Task")
+		recovery_before = (
+			frappe.db.count("Fiscal Recovery Task", {"reference_name": ffm}) if recovery_dt else 0
+		)
+
+		client = MagicMock()
+		client.cancel_invoice.return_value = {"success": True, "raw_response": {"status": "canceled"}}
+
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			with (
+				patch("frappe.set_value", side_effect=_set_value_si_noop_factory()),
+				patch(
+					f"{_TIMBRADO_API}.write_pac_response",
+					return_value={"success": True, "fiscal_updated": True, "audit_log_failed": True},
+				),
+			):
+				result = api.cancelar_factura(si, "02")
+
+		self.assertTrue(result["success"])
+		self.assertTrue(result.get("audit_warning"))
+		client.cancel_invoice.assert_called_once()  # sin segunda cancelación
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "CANCELADO")
+		if recovery_dt:
+			self.assertEqual(
+				frappe.db.count("Fiscal Recovery Task", {"reference_name": ffm}), recovery_before
+			)
+
+	# 4 — consulta exitosa + auditoría incompleta: estado conservado, advertencia, sin repetir PAC
+	def test_04_consulta_audit_incompleta(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1", uuid="U-1")
+
+		mock_query = patch(
+			"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
+			return_value={"success": True, "data": {"cancellation_status": "accepted"}},
+		)
+		with (
+			mock_query as mq,
+			patch("frappe.set_value", side_effect=_set_value_si_noop_factory()),
+			patch(
+				f"{_TIMBRADO_API}.write_pac_response",
+				return_value={"success": True, "fiscal_updated": True, "audit_log_failed": True},
+			),
+		):
+			result = revisar_estatus_cancelacion(ffm)
+
+		self.assertEqual(result.get("status"), "CANCELADO")  # estado conservado
+		self.assertTrue(result.get("audit_warning"))
+		mq.assert_called_once()  # no repite la consulta al PAC
+
+	# 10 — cero referencias al cliente del PAC en este módulo
+	def test_10_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "requests", "get_facturapi_client"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_correlacion_propagacion.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_correlacion_propagacion.py
@@ -1,0 +1,245 @@
+"""Propagación real de FiscalCorrelationError tras respuesta del PAC (Corrección 6A).
+
+Una contradicción de correlación (FFM de otra SI, UUID o facturapi_id contradictorios)
+NO debe degradarse a un resultado ordinario `{success:False}` ni ser absorbida por un
+`except Exception`. Debe propagarse para detener el flujo: sin ejecutar la FASE 3, sin
+re-llamar al PAC, sin reintentos/recovery automáticos, con un mensaje seguro al usuario.
+
+Todo se prueba con respuestas SIMULADAS y mocks de boundary (cliente PAC y el escritor
+de persistencia). Cero tráfico real contra FacturAPI.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.api import (
+	FiscalCorrelationError,
+)
+from facturacion_mexico.facturacion_fiscal.api import (
+	write_pac_response as public_write_pac_response,
+)
+from facturacion_mexico.facturacion_fiscal.timbrado_api import TimbradoAPI, revisar_estatus_cancelacion
+
+_TIMBRADO_API = "facturacion_mexico.facturacion_fiscal.timbrado_api"
+
+
+def _seed_si(*, fiscal_status: str = "", ffm: str | None = None) -> str:
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+			"fm_fiscal_status": fiscal_status or None,
+			"fm_factura_fiscal_mx": ffm,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(sales_invoice: str, status: str, *, uuid: str = "", facturapi_id: str = "") -> str:
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"fm_uuid": uuid or None,
+			"facturapi_id": facturapi_id or None,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+class TestCorrelacionPropagacion(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		has_recovery = frappe.db.exists("DocType", "Fiscal Recovery Task")
+		for si in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		for ffm in self.ffm_names:
+			if has_recovery:
+				frappe.db.delete("Fiscal Recovery Task", {"reference_name": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		frappe.db.commit()
+
+	def _si(self, **kwargs):
+		name = _seed_si(**kwargs)
+		self.si_names.append(name)
+		return name
+
+	def _ffm(self, *args, **kwargs):
+		name = _seed_ffm(*args, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	# ── 1-3: el wrapper público propaga FiscalCorrelationError ───────────────
+
+	def test_01_wrapper_ffm_de_otra_si_propaga(self):
+		si_a = self._si()
+		si_b = self._si()
+		ffm_b = self._ffm(si_b, "TIMBRADO")  # pertenece a si_b
+		with self.assertRaises(FiscalCorrelationError):
+			public_write_pac_response(
+				si_a,  # otra SI
+				json.dumps({}),
+				json.dumps({"success": True, "uuid": "U-OK"}),
+				"timbrado",
+				factura_fiscal_name=ffm_b,
+			)
+
+	def test_02_wrapper_uuid_contradictorio_propaga(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", uuid="UUID-AAA")
+		with self.assertRaises(FiscalCorrelationError):
+			public_write_pac_response(
+				si,
+				json.dumps({}),
+				json.dumps({"success": True, "uuid": "UUID-BBB"}),
+				"timbrado",
+				factura_fiscal_name=ffm,
+			)
+
+	def test_03_wrapper_facturapi_id_contradictorio_propaga(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", facturapi_id="FA-AAA")
+		with self.assertRaises(FiscalCorrelationError):
+			public_write_pac_response(
+				si,
+				json.dumps({}),
+				json.dumps({"success": True, "id": "FA-BBB"}),
+				"timbrado",
+				factura_fiscal_name=ffm,
+			)
+
+	# ── 7: errores ORDINARIOS (no correlación) conservan el comportamiento ───
+
+	def test_07_error_ordinario_no_se_propaga_como_correlacion(self):
+		from facturacion_mexico.facturacion_fiscal.api import PACResponseWriter
+
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		# Un fallo genérico (no de correlación) sigue devolviéndose como {success:False}.
+		with patch.object(PACResponseWriter, "_update_factura_fiscal", side_effect=RuntimeError("boom")):
+			result = public_write_pac_response(
+				si,
+				json.dumps({}),
+				json.dumps({"success": True, "uuid": "U-OK"}),
+				"timbrado",
+				factura_fiscal_name=ffm,
+			)
+		self.assertFalse(result["success"])
+		self.assertIn("boom", result.get("error", ""))
+
+	# ── 4: timbrado — la correlación crítica impide la FASE 3 ────────────────
+
+	def test_04_timbrado_correlacion_detiene_y_no_ejecuta_fase3(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm)
+
+		client = MagicMock()
+		client.create_invoice.return_value = {"uuid": "U", "id": "FA"}
+
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			with (
+				patch.object(TimbradoAPI, "_validate_invoice_for_timbrado"),
+				patch.object(TimbradoAPI, "_prepare_facturapi_data", return_value={}),
+				patch.object(TimbradoAPI, "_get_factura_fiscal", return_value=ffm_doc),
+				patch.object(TimbradoAPI, "_process_timbrado_success") as spy_fase3,
+				patch(f"{_TIMBRADO_API}.write_pac_response", side_effect=FiscalCorrelationError("x")),
+			):
+				with self.assertRaises(FiscalCorrelationError):
+					api.timbrar_factura(si)
+
+			# FASE 3 NO se ejecutó y el PAC se llamó UNA sola vez (sin reintento).
+			spy_fase3.assert_not_called()
+			client.create_invoice.assert_called_once()
+
+	# ── 5: cancelación — la correlación crítica impide FASE 3 y Recovery ─────
+
+	def test_05_cancelacion_correlacion_detiene_sin_recovery(self):
+		ffm = self._ffm(None, "TIMBRADO", facturapi_id="FA-1", uuid="U-1")
+		si = self._si(fiscal_status="TIMBRADO", ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		frappe.db.commit()
+
+		recovery_dt = frappe.db.exists("DocType", "Fiscal Recovery Task")
+		recovery_before = (
+			frappe.db.count("Fiscal Recovery Task", {"reference_name": ffm}) if recovery_dt else 0
+		)
+
+		client = MagicMock()
+		client.cancel_invoice.return_value = {"success": True, "raw_response": {"status": "canceled"}}
+
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			with patch(f"{_TIMBRADO_API}.write_pac_response", side_effect=FiscalCorrelationError("x")):
+				with self.assertRaises(FiscalCorrelationError):
+					api.cancelar_factura(si, "02")
+
+			client.cancel_invoice.assert_called_once()
+
+		# La FASE 3 (donde se crearía el Recovery y se marcaría CANCELADO) NO se ejecutó:
+		# el FFM sigue TIMBRADO y no se creó Recovery Task que repita la operación.
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+		if recovery_dt:
+			self.assertEqual(
+				frappe.db.count("Fiscal Recovery Task", {"reference_name": ffm}), recovery_before
+			)
+
+	# ── 6: consulta — reporta la inconsistencia y no toca OTRO FFM ───────────
+
+	def test_06_consulta_correlacion_reporta_y_no_toca_otro_ffm(self):
+		si = self._si()
+		target = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-T", uuid="U-T")
+		control = self._ffm(si, "TIMBRADO", facturapi_id="FA-C", uuid="U-C")
+		control_status_before = frappe.db.get_value("Factura Fiscal Mexico", control, "status")
+
+		with (
+			patch(
+				"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
+				return_value={"success": True, "data": {"cancellation_status": "accepted"}},
+			),
+			patch(f"{_TIMBRADO_API}.write_pac_response", side_effect=FiscalCorrelationError("x")),
+		):
+			with self.assertRaises(FiscalCorrelationError):
+				revisar_estatus_cancelacion(target)
+
+		# El OTRO FFM (control) no fue tocado.
+		self.assertEqual(
+			frappe.db.get_value("Factura Fiscal Mexico", control, "status"), control_status_before
+		)
+
+	# ── 8: cero tráfico real al PAC ──────────────────────────────────────────
+
+	def test_08_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "requests", "get_facturapi_client"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_correlacion_propagacion.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_correlacion_propagacion.py
@@ -237,6 +237,28 @@ class TestCorrelacionPropagacion(IntegrationTestCase):
 			frappe.db.get_value("Factura Fiscal Mexico", control, "status"), control_status_before
 		)
 
+	# ── M2 (CodeRabbit): write_pac_timeout también propaga la correlación ────
+
+	def test_09_timeout_correlacion_propaga(self):
+		from facturacion_mexico.facturacion_fiscal.api import PACResponseWriter, write_pac_timeout
+
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		# Una contradicción de correlación dentro del writer NO debe absorberse a {success:False}.
+		with patch.object(PACResponseWriter, "write_pac_response", side_effect=FiscalCorrelationError("x")):
+			with self.assertRaises(FiscalCorrelationError):
+				write_pac_timeout(si, json.dumps({}), 30, factura_fiscal_name=ffm)
+
+	def test_10_timeout_error_ordinario_no_propaga(self):
+		from facturacion_mexico.facturacion_fiscal.api import PACResponseWriter, write_pac_timeout
+
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		# Un error genérico sí conserva el comportamiento ordinario {success:False}.
+		with patch.object(PACResponseWriter, "write_pac_response", side_effect=RuntimeError("boom")):
+			result = write_pac_timeout(si, json.dumps({}), 30, factura_fiscal_name=ffm)
+		self.assertFalse(result["success"])
+
 	# ── 8: cero tráfico real al PAC ──────────────────────────────────────────
 
 	def test_08_cero_trafico_pac(self):

--- a/facturacion_mexico/facturacion_fiscal/tests/test_estado_fiscal_independiente_log.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_estado_fiscal_independiente_log.py
@@ -1,0 +1,205 @@
+"""Estado fiscal independiente del FacturAPI Response Log (Corrección 2).
+
+Una respuesta exitosa del PAC debe actualizar y persistir el FFM ANTES e
+independientemente del Response Log. Si el log falla, el estado fiscal ya
+persistido se conserva; no hay rollback fiscal, ni reintento, ni degradación
+a filesystem. Si la actualización del FFM falla, no se presenta como persistido
+y no se crea el log.
+
+Todas las pruebas usan respuestas SIMULADAS y parches locales — cero llamadas al
+PAC y cero tráfico de red.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.api import (
+	FiscalCorrelationError,
+	PACResponseWriter,
+)
+
+
+def _make_ffm(sales_invoice: str, *, status: str = "BORRADOR", uuid: str = "", facturapi_id: str = "") -> str:
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": frappe.defaults.get_global_default("company") or "_Test Company",
+			"fm_uuid": uuid or None,
+			"facturapi_id": facturapi_id or None,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+def _timbrado_response() -> dict:
+	return {
+		"success": True,
+		"status_code": 200,
+		"uuid": "TEST-UUID-OK",
+		"raw_response": {"uuid": "TEST-UUID-OK", "id": "fa-OK", "total": 100},
+	}
+
+
+class TestEstadoFiscalIndependienteLog(IntegrationTestCase):
+	def setUp(self):
+		self.si = "TEST-SI-" + frappe.generate_hash()[:8]
+		self.ffm_names = []
+		self.writer = PACResponseWriter()
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		for name in self.ffm_names:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": name})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": name})
+		frappe.db.commit()
+
+	def _ffm(self, **kwargs):
+		name = _make_ffm(self.si, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	# 1 — éxito completo: FFM actualizado y log guardado
+	def test_exito_completo_ffm_actualizado_y_log_guardado(self):
+		ffm = self._ffm(status="BORRADOR", facturapi_id="fa-OK")
+		result = self.writer.write_pac_response(
+			self.si, {"req": 1}, _timbrado_response(), "timbrado", factura_fiscal_name=ffm
+		)
+		self.assertTrue(result["success"])
+		self.assertTrue(result.get("fiscal_updated"))
+		self.assertIsNotNone(result.get("response_log_name"))
+		self.assertNotIn("audit_log_failed", result)
+
+		d = frappe.db.get_value(
+			"Factura Fiscal Mexico",
+			ffm,
+			["status", "fm_uuid", "facturapi_id", "fm_sync_status", "fm_last_response_log"],
+			as_dict=True,
+		)
+		self.assertEqual(d["status"], "TIMBRADO")
+		self.assertEqual(d["fm_uuid"], "TEST-UUID-OK")
+		self.assertEqual(d["facturapi_id"], "fa-OK")
+		self.assertEqual(d["fm_sync_status"], "synced")
+		self.assertEqual(d["fm_last_response_log"], result["response_log_name"])
+
+	# 2 — éxito fiscal + fallo del Response Log: estado fiscal se conserva
+	def test_fallo_log_conserva_estado_fiscal(self):
+		# facturapi_id igual al de la respuesta (sin contradicción de correlación);
+		# se verifica que se conserva tras el fallo del log.
+		ffm = self._ffm(status="PROCESANDO", facturapi_id="fa-OK")
+
+		# Forzar fallo SOLO en la creación del Response Log (no en la actualización fiscal)
+		with patch.object(PACResponseWriter, "_write_to_database", side_effect=RuntimeError("DB log caído")):
+			result = self.writer.write_pac_response(
+				self.si, {"req": 1}, _timbrado_response(), "timbrado", factura_fiscal_name=ffm
+			)
+
+		# La operación fiscal se procesó (no se relanza, no se revierte)
+		self.assertTrue(result["success"])
+		self.assertTrue(result.get("fiscal_updated"))
+		self.assertTrue(result.get("audit_log_failed"))
+		self.assertIsNone(result.get("response_log_name"))
+
+		# El FFM conserva el estado fiscal confirmado
+		d = frappe.db.get_value(
+			"Factura Fiscal Mexico",
+			ffm,
+			["status", "fm_uuid", "facturapi_id", "fm_sync_status"],
+			as_dict=True,
+		)
+		self.assertEqual(d["status"], "TIMBRADO")
+		self.assertEqual(d["fm_uuid"], "TEST-UUID-OK")
+		self.assertEqual(d["facturapi_id"], "fa-OK")  # facturapi_id no se pierde
+		self.assertEqual(d["fm_sync_status"], "synced")  # sync cerrado, no queda pending
+
+		# No se creó ningún Response Log para este FFM
+		self.assertEqual(frappe.db.count("FacturAPI Response Log", {"factura_fiscal_mexico": ffm}), 0)
+
+	# 3 — fallo de actualización del FFM: no se presenta como persistido, no se crea log
+	def test_fallo_actualizacion_ffm_propaga_y_no_crea_log(self):
+		ffm = self._ffm(status="BORRADOR")
+
+		with patch.object(
+			PACResponseWriter, "_update_factura_fiscal", side_effect=RuntimeError("update FFM caído")
+		):
+			with self.assertRaises(RuntimeError):
+				self.writer.write_pac_response(
+					self.si, {"req": 1}, _timbrado_response(), "timbrado", factura_fiscal_name=ffm
+				)
+
+		# No se creó Response Log: el fallo fiscal no se esconde guardando solo el log
+		self.assertEqual(frappe.db.count("FacturAPI Response Log", {"factura_fiscal_mexico": ffm}), 0)
+
+	# 4 — el fallo del log NO genera archivo de fallback en filesystem
+	def test_fallo_log_no_genera_fallback_filesystem(self):
+		from facturacion_mexico.facturacion_fiscal.api import _get_fallback_dir
+
+		ffm = self._ffm(status="PROCESANDO")
+		fallback_dir = _get_fallback_dir()
+		import os
+
+		antes = set(os.listdir(fallback_dir)) if os.path.isdir(fallback_dir) else set()
+
+		with patch.object(PACResponseWriter, "_write_to_database", side_effect=RuntimeError("DB log caído")):
+			result = self.writer.write_pac_response(
+				self.si, {"req": 1}, _timbrado_response(), "timbrado", factura_fiscal_name=ffm
+			)
+
+		despues = set(os.listdir(fallback_dir)) if os.path.isdir(fallback_dir) else set()
+		self.assertEqual(antes, despues, "El fallo del log no debe escribir archivos de fallback")
+		self.assertTrue(result.get("audit_log_failed"))
+		self.assertIsNone(result.get("fallback_file"))  # no hubo degradación a filesystem
+
+	# 4b — refuerzo: el flujo NO invoca el escritor de filesystem aunque éste falle.
+	#       Verifica que no hay ruta a /tmp ante fallo del log, sin tocar permisos reales.
+	def test_flujo_no_invoca_escritor_filesystem(self):
+		ffm = self._ffm(status="PROCESANDO", facturapi_id="fa-OK")
+
+		# _write_to_filesystem montado para FALLAR si llega a invocarse (no debe).
+		fs_mock = patch.object(
+			PACResponseWriter,
+			"_write_to_filesystem",
+			side_effect=AssertionError("El flujo no debe intentar escribir en filesystem"),
+		)
+		# El log falla → debe aislarse, sin degradar a filesystem.
+		# (no tocamos permisos reales de /tmp; solo simulamos el fallo del log)
+		log_fail = patch.object(
+			PACResponseWriter, "_write_to_database", side_effect=RuntimeError("DB log caído")
+		)
+		with fs_mock as fs_called, log_fail:
+			result = self.writer.write_pac_response(
+				self.si, {"req": 1}, _timbrado_response(), "timbrado", factura_fiscal_name=ffm
+			)
+
+		# El escritor de filesystem NUNCA se invocó
+		self.assertEqual(fs_called.call_count, 0, "No debe intentarse escritura a filesystem")
+		# FFM conserva el estado fiscal; auditoría marcada como fallida; sin excepción de permisos
+		self.assertTrue(result.get("audit_log_failed"))
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_sync_status"), "synced")
+
+	# 5 — la correlación estricta (Corrección 1) sigue vigente
+	def test_correlacion_estricta_sigue_vigente(self):
+		ffm = self._ffm(status="BORRADOR")
+		with self.assertRaises(FiscalCorrelationError):
+			self.writer.write_pac_response(
+				"OTRA-SI", {"req": 1}, _timbrado_response(), "timbrado", factura_fiscal_name=ffm
+			)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "BORRADOR")
+
+	# 6 — cero referencias al cliente del PAC en este módulo
+	def test_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "cancel_invoice", "requests"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_active_ffm.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_active_ffm.py
@@ -1,0 +1,283 @@
+"""Creación centralizada de FFM en servidor (Corrección 3).
+
+La creación del FFM deja de hacerse desde JavaScript (`frappe.client.insert` +
+`set_value`) y se concentra en `get_or_create_active_ffm(sales_invoice)`.
+
+ADVERTENCIA: esta corrección NO agrega lock. La condición de carrera (dos
+llamadas concurrentes con `fm_factura_fiscal_mx` vacío) sigue abierta y será
+resuelta por la Corrección 4. La prueba de concurrencia documenta la ventana,
+no la corrige.
+
+Sin llamadas al PAC. Pruebas en test-facturacion.localhost.
+"""
+
+import os
+import re
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import flt
+
+from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+	get_or_create_active_ffm,
+)
+
+_JS = os.path.join(os.path.dirname(__file__), "..", "..", "public", "js", "sales_invoice.js")
+
+
+def _make_si() -> str:
+	"""Crea una Sales Invoice mínima y submitted en BD (db_insert).
+
+	docstatus=1 porque el FFM exige que la SI esté submitted (igual que el botón real,
+	que solo aparece en SIs submitted). db_insert evita el setup de stock/GL.
+	"""
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _add_tax_rows(si_name: str, rows: list[tuple[str, float]]) -> None:
+	"""Inserta filas hijas de 'Sales Taxes and Charges' para una Sales Invoice.
+
+	Cada fila es (account_head, tax_amount). Se usa db_insert sobre la child table
+	para no disparar el recálculo de ERPNext (probamos solo la clasificación del FFM).
+	"""
+	for i, (account_head, amount) in enumerate(rows, start=1):
+		row = frappe.get_doc(
+			{
+				"doctype": "Sales Taxes and Charges",
+				"parent": si_name,
+				"parenttype": "Sales Invoice",
+				"parentfield": "taxes",
+				"idx": i,
+				"charge_type": "Actual",
+				"account_head": account_head,
+				"description": account_head,
+				"tax_amount": amount,
+			}
+		)
+		row.flags.ignore_validate = True
+		row.flags.ignore_mandatory = True
+		row.flags.ignore_links = True
+		row.db_insert()
+	frappe.db.commit()
+
+
+class TestGetOrCreateActiveFFM(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.user_ids = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for n in self.ffm_names:
+			frappe.db.delete("Factura Fiscal Mexico", {"name": n})
+		for n in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": n})
+		for u in self.user_ids:
+			frappe.db.delete("User", {"name": u})
+		frappe.db.commit()
+
+	def _si(self):
+		name = _make_si()
+		self.si_names.append(name)
+		return name
+
+	def _track_ffm(self, name):
+		if name and name not in self.ffm_names:
+			self.ffm_names.append(name)
+		return name
+
+	# 1 — SI sin FFM: crea, vincula, devuelve nombre
+	def test_si_sin_ffm_crea_vincula_y_devuelve(self):
+		si = self._si()
+		ffm = self._track_ffm(get_or_create_active_ffm(si))
+		self.assertTrue(ffm)
+		# Vinculado en la SI
+		self.assertEqual(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"), ffm)
+		# El FFM apunta a la SI
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "sales_invoice"), si)
+
+	# 2 — SI con fm_factura_fiscal_mx válido: devuelve el mismo, no crea otro
+	def test_si_con_ffm_valido_reutiliza(self):
+		si = self._si()
+		ffm1 = self._track_ffm(get_or_create_active_ffm(si))
+		ffm2 = get_or_create_active_ffm(si)
+		self.assertEqual(ffm1, ffm2)
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+
+	# 3 — dos llamadas secuenciales: mismo FFM, un documento
+	def test_dos_llamadas_secuenciales_mismo_ffm(self):
+		si = self._si()
+		a = self._track_ffm(get_or_create_active_ffm(si))
+		b = self._track_ffm(get_or_create_active_ffm(si))
+		self.assertEqual(a, b)
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+
+	# 4 — Sales Invoice inexistente: error controlado, no crea
+	def test_si_inexistente_error_controlado(self):
+		with self.assertRaises(frappe.ValidationError):
+			get_or_create_active_ffm("SI-QUE-NO-EXISTE-XYZ")
+		self.assertEqual(
+			frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": "SI-QUE-NO-EXISTE-XYZ"}), 0
+		)
+
+	# 5 — usuario sin permisos: error, no crea
+	def test_usuario_sin_permisos_error(self):
+		si = self._si()
+		uid = "test-ffm-create-" + frappe.generate_hash()[:8] + "@test.com"
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": uid,
+				"first_name": "Sin Permisos",
+				"send_welcome_email": 0,
+				# Sin roles: no puede leer Sales Invoice ni crear Factura Fiscal Mexico.
+			}
+		)
+		user.insert(ignore_permissions=True)
+		self.user_ids.append(uid)
+		frappe.db.commit()
+
+		frappe.set_user(uid)
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				get_or_create_active_ffm(si)
+		finally:
+			frappe.set_user("Administrator")
+		# No se creó FFM
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 0)
+
+	# 6 — el JS ya no usa frappe.client.insert para crear el FFM
+	def test_js_sin_client_insert(self):
+		with open(os.path.abspath(_JS), encoding="utf-8") as f:
+			js = f.read()
+		# No debe quedar un insert de Factura Fiscal Mexico vía client.insert
+		self.assertNotIn('method: "frappe.client.insert"', js)
+
+	# 7 — el JS ya no hace un set_value separado para vincular el FFM
+	def test_js_sin_set_value_separado(self):
+		with open(os.path.abspath(_JS), encoding="utf-8") as f:
+			js = f.read()
+		self.assertNotIn('method: "frappe.client.set_value"', js)
+
+	# 8 — el cliente usa la función servidor y su nombre devuelto
+	def test_js_usa_funcion_servidor(self):
+		with open(os.path.abspath(_JS), encoding="utf-8") as f:
+			js = f.read()
+		self.assertIn("get_or_create_active_ffm", js)
+		# usa el nombre devuelto (r.message) para navegar
+		self.assertTrue(re.search(r"const ffm_name = r\.message", js))
+
+	# 9 — cero referencias al cliente del PAC en este módulo de prueba
+	def test_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "cancel_invoice", "requests"):
+			self.assertNotIn(simbolo, g)
+
+	# Concurrencia (documenta la ventana abierta; NO la corrige) —
+	# se prueba que, simulando el campo aún vacío en una segunda lectura, se crearía
+	# un segundo FFM. Esto evidencia que SIN LOCK la carrera sigue posible (Corrección 4).
+	def test_documenta_ventana_concurrente_sin_lock(self):
+		si = self._si()
+		ffm1 = self._track_ffm(get_or_create_active_ffm(si))
+
+		# Simular que una segunda llamada entra antes de que la SI refleje el vínculo:
+		# forzamos el campo a vacío justo antes de la segunda invocación.
+		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", None)
+		frappe.db.commit()
+
+		ffm2 = self._track_ffm(get_or_create_active_ffm(si))
+		# Sin lock, se crea un segundo FFM (ventana abierta — la Corrección 4 lo impedirá).
+		self.assertNotEqual(ffm1, ffm2)
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 2)
+
+	# =========================================================================
+	# REGRESIÓN DEL CÁLCULO DE IMPUESTOS (equivalencia con el comportamiento JS)
+	#
+	# El JS original clasificaba: toda cuenta cuyo account_head contiene "IVA"
+	# (tras .toUpperCase()) suma a si_iva; el resto suma a si_otros_impuestos.
+	# Estas pruebas demuestran que el cálculo en servidor conserva EXACTAMENTE esa
+	# clasificación. Los valores esperados se escriben directamente (sin oráculo).
+	#
+	# NOTA: clasificar cualquier cuenta que contenga "IVA" como IVA — incluido el
+	# "IVA Retenido" — conserva la lógica previa, pero NO constituye una validación
+	# de que esa clasificación fiscal sea la ideal; solo demuestra equivalencia.
+	# =========================================================================
+
+	def _ffm_tax_totals(self, si):
+		# Confirmar que las filas hijas se cargaron al recargar la SI desde servidor.
+		si_doc = frappe.get_doc("Sales Invoice", si)
+		num_rows = len(si_doc.get("taxes") or [])
+		ffm = self._track_ffm(get_or_create_active_ffm(si))
+		d = frappe.db.get_value("Factura Fiscal Mexico", ffm, ["si_iva", "si_otros_impuestos"], as_dict=True)
+		return num_rows, flt(d["si_iva"], 2), flt(d["si_otros_impuestos"], 2)
+
+	# 1 — IVA y otros impuestos combinados
+	# IVA 16% = 160.00 ; IVA retenido = -40.00 ; IEPS = 25.00 ; ISR retenido = -10.00
+	def test_calculo_iva_combinado(self):
+		si = self._si()
+		_add_tax_rows(
+			si,
+			[
+				("IVA 16% - _TC", 160.00),
+				("IVA Retenido - _TC", -40.00),
+				("IEPS - _TC", 25.00),
+				("ISR Retenido - _TC", -10.00),
+			],
+		)
+		num_rows, si_iva, si_otros = self._ffm_tax_totals(si)
+		self.assertEqual(num_rows, 4)  # filas hijas realmente cargadas
+		self.assertEqual(si_iva, 120.00)  # 160.00 + (-40.00)
+		self.assertEqual(si_otros, 15.00)  # 25.00 + (-10.00)
+
+	# 2 — solo IVA
+	def test_calculo_solo_iva(self):
+		si = self._si()
+		_add_tax_rows(si, [("IVA - _TC", 160.00)])
+		num_rows, si_iva, si_otros = self._ffm_tax_totals(si)
+		self.assertEqual(num_rows, 1)
+		self.assertEqual(si_iva, 160.00)
+		self.assertEqual(si_otros, 0.00)
+
+	# 3 — solo otros impuestos
+	def test_calculo_solo_otros(self):
+		si = self._si()
+		_add_tax_rows(si, [("IEPS - _TC", 30.00), ("ISR Retenido - _TC", -10.00)])
+		num_rows, si_iva, si_otros = self._ffm_tax_totals(si)
+		self.assertEqual(num_rows, 2)
+		self.assertEqual(si_iva, 0.00)
+		self.assertEqual(si_otros, 20.00)  # 30.00 + (-10.00)
+
+	# 4 — sin impuestos
+	def test_calculo_sin_impuestos(self):
+		si = self._si()
+		num_rows, si_iva, si_otros = self._ffm_tax_totals(si)
+		self.assertEqual(num_rows, 0)
+		self.assertEqual(si_iva, 0.00)
+		self.assertEqual(si_otros, 0.00)
+
+	# 5 — clasificación insensible a mayúsculas/minúsculas (JS usaba .toUpperCase())
+	def test_calculo_iva_minusculas(self):
+		si = self._si()
+		_add_tax_rows(si, [("iva trasladado - _TC", 80.00), ("ieps - _TC", 12.00)])
+		num_rows, si_iva, si_otros = self._ffm_tax_totals(si)
+		self.assertEqual(num_rows, 2)
+		self.assertEqual(si_iva, 80.00)  # "iva" en minúsculas clasifica como IVA
+		self.assertEqual(si_otros, 12.00)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_active_ffm.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_active_ffm.py
@@ -1,12 +1,12 @@
-"""Creación centralizada de FFM en servidor (Corrección 3).
+"""Creación centralizada de FFM en servidor (Corrección 3, ya con Correcciones 4/5).
 
 La creación del FFM deja de hacerse desde JavaScript (`frappe.client.insert` +
 `set_value`) y se concentra en `get_or_create_active_ffm(sales_invoice)`.
 
-ADVERTENCIA: esta corrección NO agrega lock. La condición de carrera (dos
-llamadas concurrentes con `fm_factura_fiscal_mx` vacío) sigue abierta y será
-resuelta por la Corrección 4. La prueba de concurrencia documenta la ventana,
-no la corrige.
+La ventana de carrera que describía la Corrección 3 YA está cerrada: la Corrección 4
+agrega el lock de fila (`for_update`) sobre la Sales Invoice y la Corrección 5 impone
+la cardinalidad (un solo FFM activo por SI). Estas pruebas validan ese comportamiento
+ya corregido, no una ventana abierta.
 
 Sin llamadas al PAC. Pruebas en test-facturacion.localhost.
 """
@@ -18,6 +18,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import flt
 
+from facturacion_mexico.facturacion_fiscal.api import FiscalCorrelationError
 from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
 	get_or_create_active_ffm,
 )
@@ -284,3 +285,56 @@ class TestGetOrCreateActiveFFM(IntegrationTestCase):
 		self.assertEqual(num_rows, 2)
 		self.assertEqual(si_iva, 80.00)  # "iva" en minúsculas clasifica como IVA
 		self.assertEqual(si_otros, 12.00)
+
+	# --- C1 (CodeRabbit): allow-list de extra_fields ---
+
+	# C1.1 — acepta los dos campos permitidos (nota de crédito / devolución): no lanza y crea el FFM.
+	#        La PERSISTENCIA de esos campos depende del controller del FFM (p. ej. tipo de
+	#        comprobante), no del allow-list; aquí solo se valida que el guard los deja pasar.
+	def test_c1_acepta_campos_permitidos(self):
+		si = self._si()
+		ffm = self._track_ffm(
+			get_or_create_active_ffm(
+				si,
+				extra_fields={
+					"fm_uuid_relacionado": "UUID-REL-1",
+					"fm_tipo_relacion_sat": "03 - Devolución de mercancía sobre facturas o traslados previos",
+				},
+			)
+		)
+		self.assertTrue(ffm)
+		self.assertEqual(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"), ffm)
+
+	# C1.2 — acepta extra_fields vacío
+	def test_c1_acepta_vacio(self):
+		si = self._si()
+		ffm = self._track_ffm(get_or_create_active_ffm(si, extra_fields={}))
+		self.assertTrue(ffm)
+
+	# C1.3 — rechaza intento de fijar status
+	def test_c1_rechaza_status(self):
+		si = self._si()
+		with self.assertRaises(FiscalCorrelationError):
+			get_or_create_active_ffm(si, extra_fields={"status": "TIMBRADO"})
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 0)
+
+	# C1.4 — rechaza intento de inyectar facturapi_id
+	def test_c1_rechaza_facturapi_id(self):
+		si = self._si()
+		with self.assertRaises(FiscalCorrelationError):
+			get_or_create_active_ffm(si, extra_fields={"facturapi_id": "FA-HACK"})
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 0)
+
+	# C1.5 — rechaza intento de reapuntar la sales_invoice
+	def test_c1_rechaza_sales_invoice(self):
+		si = self._si()
+		with self.assertRaises(FiscalCorrelationError):
+			get_or_create_active_ffm(si, extra_fields={"sales_invoice": "OTRA-SI"})
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 0)
+
+	# C1.6 — rechaza cualquier campo desconocido
+	def test_c1_rechaza_campo_desconocido(self):
+		si = self._si()
+		with self.assertRaises(FiscalCorrelationError):
+			get_or_create_active_ffm(si, extra_fields={"campo_que_no_existe": "x"})
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 0)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_active_ffm.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_active_ffm.py
@@ -194,19 +194,22 @@ class TestGetOrCreateActiveFFM(IntegrationTestCase):
 	# Concurrencia (documenta la ventana abierta; NO la corrige) —
 	# se prueba que, simulando el campo aún vacío en una segunda lectura, se crearía
 	# un segundo FFM. Esto evidencia que SIN LOCK la carrera sigue posible (Corrección 4).
-	def test_documenta_ventana_concurrente_sin_lock(self):
+	def test_segunda_llamada_con_vinculo_vaciado_reutiliza_activo(self):
+		# Antes (Corrección 3) esta ventana creaba un segundo FFM. La Corrección 5 la cierra:
+		# aunque el vínculo de la SI esté vacío, la decisión se basa en los FFM activos por
+		# sales_invoice, de modo que la segunda llamada reutiliza el activo y repara el vínculo.
 		si = self._si()
 		ffm1 = self._track_ffm(get_or_create_active_ffm(si))
 
-		# Simular que una segunda llamada entra antes de que la SI refleje el vínculo:
-		# forzamos el campo a vacío justo antes de la segunda invocación.
+		# Vaciar el vínculo justo antes de la segunda invocación (referencia perdida).
 		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", None)
 		frappe.db.commit()
 
 		ffm2 = self._track_ffm(get_or_create_active_ffm(si))
-		# Sin lock, se crea un segundo FFM (ventana abierta — la Corrección 4 lo impedirá).
-		self.assertNotEqual(ffm1, ffm2)
-		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 2)
+		# Se reutiliza el mismo FFM activo; no se crea otro y el vínculo queda reparado.
+		self.assertEqual(ffm1, ffm2)
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+		self.assertEqual(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"), ffm1)
 
 	# =========================================================================
 	# REGRESIÓN DEL CÁLCULO DE IMPUESTOS (equivalencia con el comportamiento JS)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_concurrencia.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_concurrencia.py
@@ -217,13 +217,18 @@ class TestGetOrCreateConcurrencia(IntegrationTestCase):
 	def test_rollback_libera_lock(self):
 		si = self._si()
 
+		# Capturar la función REAL ANTES de parchear: si se captura dentro del `with patch`,
+		# `frappe.get_doc` ya es el mock y la rama "Sales Invoice" recursaría infinitamente
+		# (RecursionError, subclase de RuntimeError) → el test pasaría por la razón equivocada
+		# sin ejercitar el for_update real ni el fallo en creación del FFM.
+		real_get_doc = frappe.get_doc
+
 		# Forzar excepción DESPUÉS de adquirir el for_update (al insertar el FFM).
 		with patch(
 			"facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico."
 			"factura_fiscal_mexico.frappe.get_doc"
 		) as _mock:
 			# Dejamos pasar la lectura for_update real y rompemos en la creación del FFM.
-			real_get_doc = frappe.get_doc
 
 			def _side(*args, **kwargs):
 				if args and args[0] == "Sales Invoice":

--- a/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_concurrencia.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_get_or_create_concurrencia.py
@@ -1,0 +1,248 @@
+"""Concurrencia de get_or_create_active_ffm — lock de fila con FOR UPDATE (Corrección 4).
+
+Dos solicitudes concurrentes para la misma Sales Invoice deben devolver el MISMO FFM
+y persistir un solo documento. Se usa el lock de fila transaccional adquirido por
+`frappe.get_doc("Sales Invoice", name, for_update=True)`: la segunda transacción espera
+al commit de la primera y, al releer bajo el lock, reutiliza el FFM ya vinculado.
+
+La concurrencia se prueba con PROCESOS independientes (multiprocessing, contexto "spawn"),
+cada uno con su propio `frappe.init` + `frappe.connect` + transacción. El commit de cada
+proceso representa el fin de un request simulado — NO es un commit del código productivo.
+
+Coordinación determinista: el proceso "holder" adquiere el lock vía la función bajo prueba
+y lo mantiene unos segundos (su commit se difiere); el proceso "contender" entra a su
+`for_update` mientras el lock está tomado, por lo que necesariamente se serializa. Así la
+prueba no depende del azar de una barrera. Sin sleeps inyectados en el código productivo:
+la espera está SOLO en el proceso de prueba que simula un request en curso.
+
+Sin llamadas al PAC. Pruebas en test-facturacion.localhost.
+"""
+
+import multiprocessing as mp
+import time
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+	get_or_create_active_ffm,
+)
+
+# Segundos que el "holder" mantiene el lock de fila tomado (con su transacción abierta)
+# para garantizar que el "contender" entre a su FOR UPDATE mientras el lock está activo.
+HOLD_SECONDS = 2.0
+# Umbral para considerar que el contender SE SERIALIZÓ (esperó al holder).
+SERIALIZADO_MIN = 1.0
+
+
+def _make_si_committed() -> str:
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _worker_holder(site: str, si_name: str, hold_seconds: float, locked_evt, queue) -> None:
+	"""Proceso independiente que ADQUIERE el lock y lo MANTIENE.
+
+	Abre su transacción, llama a la función bajo prueba (que toma el FOR UPDATE de la SI),
+	avisa que el lock está tomado y difiere su commit `hold_seconds` segundos para forzar
+	la serialización del contender. Su commit representa el fin del request simulado.
+	"""
+	import frappe as fr
+
+	fr.init(site=site)
+	fr.connect()
+	try:
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			get_or_create_active_ffm as _goc,
+		)
+
+		fr.db.begin()
+		name = _goc(si_name)  # adquiere el lock de fila de la SI
+		locked_evt.set()  # avisar: lock tomado, contender puede intentar
+		time.sleep(hold_seconds)  # mantener la transacción (request en curso simulado)
+		fr.db.commit()  # fin del request → libera el lock
+		queue.put(("holder", name, 0.0))
+	except Exception as e:
+		try:
+			fr.db.rollback()
+		except Exception:
+			pass
+		queue.put(("holder-err", repr(e), 0.0))
+	finally:
+		try:
+			fr.destroy()
+		except Exception:
+			pass
+
+
+def _worker_contender(site: str, si_name: str, locked_evt, queue) -> None:
+	"""Proceso independiente que intenta entrar DESPUÉS de que el holder tomó el lock.
+
+	Espera la señal del holder, abre su transacción y llama a la función bajo prueba.
+	Si compite por la misma SI, su `for_update` BLOQUEA hasta el commit del holder; mide
+	cuánto esperó. Al desbloquearse relee bajo el lock y debe reutilizar el FFM vinculado.
+	"""
+	import frappe as fr
+
+	fr.init(site=site)
+	fr.connect()
+	try:
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			get_or_create_active_ffm as _goc,
+		)
+
+		locked_evt.wait(timeout=20)  # esperar a que el holder tenga el lock
+		fr.db.begin()
+		t0 = time.monotonic()
+		name = _goc(si_name)  # bloquea hasta el commit del holder si es la misma SI
+		espera = time.monotonic() - t0
+		fr.db.commit()  # fin del request simulado
+		queue.put(("contender", name, espera))
+	except Exception as e:
+		try:
+			fr.db.rollback()
+		except Exception:
+			pass
+		queue.put(("contender-err", repr(e), 0.0))
+	finally:
+		try:
+			fr.destroy()
+		except Exception:
+			pass
+
+
+class TestGetOrCreateConcurrencia(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for si in self.si_names:
+			for ffm in frappe.get_all("Factura Fiscal Mexico", filters={"sales_invoice": si}, pluck="name"):
+				frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def _si(self):
+		name = _make_si_committed()
+		self.si_names.append(name)
+		return name
+
+	def _run_holder_contender(self, si_holder, si_contender):
+		"""Lanza holder (mantiene el lock) y contender (entra después); devuelve resultados.
+
+		Devuelve un dict con claves de tipo de proceso → (name, espera_segundos).
+		"""
+		site = frappe.local.site
+		ctx = mp.get_context("spawn")
+		locked = ctx.Event()
+		q = ctx.Queue()
+		ph = ctx.Process(target=_worker_holder, args=(site, si_holder, HOLD_SECONDS, locked, q))
+		pc = ctx.Process(target=_worker_contender, args=(site, si_contender, locked, q))
+		ph.start()
+		pc.start()
+		ph.join(60)
+		pc.join(60)
+		out = {}
+		for _ in range(2):
+			tipo, name, espera = q.get(timeout=10)
+			out[tipo] = (name, espera)
+		return out
+
+	# 1 + 2 — dos procesos sobre la MISMA SI: el contender se serializa y reutiliza.
+	#         Un solo FFM, ambos lo devuelven, la SI apunta a él.
+	def test_concurrencia_misma_si_un_solo_ffm(self):
+		si = self._si()
+		out = self._run_holder_contender(si, si)
+
+		self.assertIn("holder", out, f"El holder debe terminar OK: {out}")
+		self.assertIn("contender", out, f"El contender debe terminar OK: {out}")
+		holder_name, _ = out["holder"]
+		contender_name, espera = out["contender"]
+
+		# El contender SE SERIALIZÓ: esperó al commit del holder (lock efectivo entre procesos).
+		self.assertGreaterEqual(
+			espera,
+			SERIALIZADO_MIN,
+			f"El contender debió esperar al holder (~{HOLD_SECONDS}s); esperó {espera:.2f}s",
+		)
+		# Ambos devuelven el MISMO FFM (el contender reutilizó el vinculado por el holder).
+		self.assertEqual(holder_name, contender_name, f"Ambos deben devolver el mismo FFM: {out}")
+		# Solo existe un FFM para esa SI.
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+		# La SI apunta a ese FFM.
+		self.assertEqual(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"), holder_name)
+
+	# 4 — dos SIs distintas NO se bloquean: el contender no espera y cada una obtiene su FFM.
+	def test_sis_distintas_no_se_bloquean(self):
+		si_a = self._si()
+		si_b = self._si()
+		out = self._run_holder_contender(si_a, si_b)
+
+		self.assertIn("holder", out, f"El holder debe terminar OK: {out}")
+		self.assertIn("contender", out, f"El contender debe terminar OK: {out}")
+		_, espera = out["contender"]
+
+		# El contender opera sobre OTRA fila: no se serializa con el holder.
+		self.assertLess(
+			espera,
+			SERIALIZADO_MIN,
+			f"SIs distintas no deben bloquearse; el contender esperó {espera:.2f}s",
+		)
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si_a}), 1)
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si_b}), 1)
+		ffm_a = frappe.db.get_value("Sales Invoice", si_a, "fm_factura_fiscal_mx")
+		ffm_b = frappe.db.get_value("Sales Invoice", si_b, "fm_factura_fiscal_mx")
+		self.assertNotEqual(ffm_a, ffm_b)
+
+	# 3 — una excepción dentro de la sección crítica: el rollback libera el lock,
+	#     una llamada posterior procede normalmente (no queda lock huérfano).
+	def test_rollback_libera_lock(self):
+		si = self._si()
+
+		# Forzar excepción DESPUÉS de adquirir el for_update (al insertar el FFM).
+		with patch(
+			"facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico."
+			"factura_fiscal_mexico.frappe.get_doc"
+		) as _mock:
+			# Dejamos pasar la lectura for_update real y rompemos en la creación del FFM.
+			real_get_doc = frappe.get_doc
+
+			def _side(*args, **kwargs):
+				if args and args[0] == "Sales Invoice":
+					return real_get_doc(*args, **kwargs)  # for_update real
+				raise RuntimeError("fallo simulado en creación de FFM")
+
+			_mock.side_effect = _side
+			with self.assertRaises(RuntimeError):
+				get_or_create_active_ffm(si)
+		frappe.db.rollback()  # rollback del request simulado → libera el lock de fila
+
+		# Una llamada posterior procede sin problema (no hay lock huérfano).
+		ffm = get_or_create_active_ffm(si)
+		frappe.db.commit()
+		self.assertTrue(ffm)
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+
+	# 5 — cero referencias al cliente del PAC en este módulo de prueba
+	def test_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "cancel_invoice", "requests"):
+			self.assertNotIn(simbolo, g)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_pac_response_correlacion.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_pac_response_correlacion.py
@@ -1,0 +1,215 @@
+"""Correlación estricta por FFM.name en la persistencia de respuestas PAC.
+
+Corrección 1 (integridad fiscal): la respuesta del PAC se asocia EXCLUSIVAMENTE
+al FFM que inició la operación, nunca se resuelve por Sales Invoice. Estas pruebas
+ejercen la capa de persistencia (`PACResponseWriter`) con respuestas SIMULADAS —
+no hay ninguna llamada al PAC ni red fiscal.
+
+Cobertura:
+1. Timbrado simulado se aplica al FFM explícito aunque existan 2 FFM para la misma SI.
+2. Cancelación simulada se aplica al FFM explícito.
+3. El Response Log queda vinculado al mismo FFM.
+4. El otro FFM de la misma SI permanece sin cambios.
+5. FFM.name inexistente → no modifica, error controlado.
+6. FFM de otra SI → no modifica, error controlado.
+7. UUID contradictorio → no modifica, alerta.
+8. facturapi_id contradictorio → no modifica, alerta.
+9. (estático) el flujo no resuelve el FFM por {"sales_invoice"}.
+10. Ninguna prueba llama a FacturAPI (no se instancia ni se parchea cliente HTTP).
+"""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.api import (
+	FiscalCorrelationError,
+	PACResponseWriter,
+)
+
+
+def _make_ffm(sales_invoice: str, *, status: str = "BORRADOR", uuid: str = "", facturapi_id: str = "") -> str:
+	"""Crea un FFM de prueba sin pasar por validaciones ni links (sin tocar el PAC)."""
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": frappe.defaults.get_global_default("company") or "_Test Company",
+			"fm_uuid": uuid or None,
+			"facturapi_id": facturapi_id or None,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	return ffm.name
+
+
+def _timbrado_response(uuid: str = "TEST-UUID-A", facturapi_id: str = "facturapi-A") -> dict:
+	return {
+		"success": True,
+		"status_code": 200,
+		"uuid": uuid,
+		"raw_response": {"uuid": uuid, "id": facturapi_id, "total": 100},
+	}
+
+
+def _cancelacion_response() -> dict:
+	return {"success": True, "status_code": 200, "raw_response": {"status": "canceled"}}
+
+
+class TestPACResponseCorrelacion(IntegrationTestCase):
+	def setUp(self):
+		self.si = "TEST-SI-" + frappe.generate_hash()[:8]
+		self.ffm_names = []
+		self.writer = PACResponseWriter()
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		for name in self.ffm_names:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": name})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": name})
+		frappe.db.commit()
+
+	def _ffm(self, **kwargs):
+		name = _make_ffm(self.si, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	# 1 + 3 + 4
+	def test_timbrado_se_aplica_al_ffm_explicito_con_dos_ffm(self):
+		ffm_a = self._ffm(status="BORRADOR")  # el que opera
+		ffm_b = self._ffm(status="BORRADOR")  # el otro, debe quedar intacto
+
+		result = self.writer.write_pac_response(
+			self.si, {"req": 1}, _timbrado_response(), "timbrado", factura_fiscal_name=ffm_a
+		)
+		self.assertTrue(result["success"])
+
+		# Estado aplicado SOLO al FFM explícito (ffm_a)
+		a = frappe.db.get_value(
+			"Factura Fiscal Mexico", ffm_a, ["status", "fm_uuid", "fm_sync_status"], as_dict=True
+		)
+		self.assertEqual(a["status"], "TIMBRADO")
+		self.assertEqual(a["fm_uuid"], "TEST-UUID-A")
+		self.assertEqual(a["fm_sync_status"], "synced")
+
+		# Response Log vinculado a ffm_a, no a ffm_b
+		log_ffm = frappe.db.get_value(
+			"FacturAPI Response Log", result["response_log_name"], "factura_fiscal_mexico"
+		)
+		self.assertEqual(log_ffm, ffm_a)
+
+		# ffm_b permanece sin cambios
+		b = frappe.db.get_value(
+			"Factura Fiscal Mexico", ffm_b, ["status", "fm_uuid", "fm_sync_status"], as_dict=True
+		)
+		self.assertEqual(b["status"], "BORRADOR")
+		self.assertFalse(b["fm_uuid"])
+		# El otro FFM no fue tocado por el writer: nunca quedó 'synced'.
+		self.assertNotEqual(b["fm_sync_status"], "synced")
+		self.assertEqual(frappe.db.count("FacturAPI Response Log", {"factura_fiscal_mexico": ffm_b}), 0)
+
+	# 2
+	def test_cancelacion_se_aplica_al_ffm_explicito(self):
+		ffm_a = self._ffm(status="TIMBRADO", uuid="UUID-A", facturapi_id="fa-A")
+		ffm_b = self._ffm(status="TIMBRADO", uuid="UUID-B", facturapi_id="fa-B")
+
+		result = self.writer.write_pac_response(
+			self.si, {"req": 1}, _cancelacion_response(), "cancelacion", factura_fiscal_name=ffm_a
+		)
+		self.assertTrue(result["success"])
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_a, "status"), "CANCELADO")
+		# ffm_b intacto
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_b, "status"), "TIMBRADO")
+
+	# 5
+	def test_ffm_inexistente_no_modifica_y_error_controlado(self):
+		ffm_a = self._ffm(status="BORRADOR")
+		with self.assertRaises(FiscalCorrelationError):
+			self.writer.write_pac_response(
+				self.si,
+				{"req": 1},
+				_timbrado_response(),
+				"timbrado",
+				factura_fiscal_name="FFM-NO-EXISTE-XYZ",
+			)
+		# Nada cambió en el FFM real
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_a, "status"), "BORRADOR")
+
+	# 5b — sin factura_fiscal_name
+	def test_sin_factura_fiscal_name_no_modifica_y_error_controlado(self):
+		ffm_a = self._ffm(status="BORRADOR")
+		with self.assertRaises(FiscalCorrelationError):
+			self.writer.write_pac_response(
+				self.si, {"req": 1}, _timbrado_response(), "timbrado", factura_fiscal_name=None
+			)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_a, "status"), "BORRADOR")
+
+	# 6
+	def test_ffm_de_otra_si_no_modifica_y_error_controlado(self):
+		ffm_a = self._ffm(status="BORRADOR")
+		with self.assertRaises(FiscalCorrelationError):
+			self.writer.write_pac_response(
+				"OTRA-SI-DISTINTA",
+				{"req": 1},
+				_timbrado_response(),
+				"timbrado",
+				factura_fiscal_name=ffm_a,
+			)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_a, "status"), "BORRADOR")
+
+	# 7
+	def test_uuid_contradictorio_no_modifica_y_alerta(self):
+		ffm_a = self._ffm(status="TIMBRADO", uuid="UUID-EXISTENTE", facturapi_id="fa-A")
+		with self.assertRaises(FiscalCorrelationError):
+			self.writer.write_pac_response(
+				self.si,
+				{"req": 1},
+				_timbrado_response(uuid="UUID-DIFERENTE", facturapi_id="fa-A"),
+				"timbrado",
+				factura_fiscal_name=ffm_a,
+			)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_a, "fm_uuid"), "UUID-EXISTENTE")
+
+	# 8
+	def test_facturapi_id_contradictorio_no_modifica_y_alerta(self):
+		ffm_a = self._ffm(status="TIMBRADO", uuid="UUID-A", facturapi_id="fa-EXISTENTE")
+		with self.assertRaises(FiscalCorrelationError):
+			self.writer.write_pac_response(
+				self.si,
+				{"req": 1},
+				_timbrado_response(uuid="UUID-A", facturapi_id="fa-DIFERENTE"),
+				"timbrado",
+				factura_fiscal_name=ffm_a,
+			)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_a, "facturapi_id"), "fa-EXISTENTE")
+
+	# 9 — estático: la persistencia no resuelve el FFM por sales_invoice
+	def test_persistencia_no_busca_ffm_por_sales_invoice(self):
+		import inspect
+
+		from facturacion_mexico.facturacion_fiscal import api as api_mod
+
+		src = inspect.getsource(api_mod.PACResponseWriter._write_to_database)
+		src += inspect.getsource(api_mod.PACResponseWriter._update_factura_fiscal)
+		self.assertNotIn(
+			'{"sales_invoice"',
+			src,
+			"La persistencia no debe resolver el FFM por {'sales_invoice': ...}",
+		)
+
+	# 10 — ninguna prueba usa el cliente FacturAPI
+	def test_ninguna_llamada_al_pac(self):
+		"""El namespace de este módulo no contiene símbolos del cliente HTTP del PAC.
+
+		La capa probada (PACResponseWriter) trabaja solo con dicts simulados; no se
+		importa, instancia ni parchea ningún cliente FacturAPI.
+		"""
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "cancel_invoice", "requests"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_persistence_recovery.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_persistence_recovery.py
@@ -301,6 +301,47 @@ class TestPersistenceRecovery(IntegrationTestCase):
 		self.assertTrue(result.get("persistence_warning"))
 		mq.assert_called_once()  # consulta al PAC una sola vez
 
+	# --- M3 (CodeRabbit): verificación de persistencia usa el estado derivado (`fiscal_status`) ---
+
+	def _run_cancelacion(self, motivo, raw_response, *, ffm_raises=False):
+		"""Cancelación con writer fallido: dispara la verificación de persistencia (6B2/M3)."""
+		ffm = self._ffm(None, "TIMBRADO", facturapi_id="FA-1", uuid="U-1")
+		si = self._si(fiscal_status="TIMBRADO", ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		frappe.db.commit()
+		client = MagicMock()
+		client.cancel_invoice.return_value = {"success": True, "raw_response": raw_response}
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			with (
+				patch("frappe.set_value", side_effect=_set_value_factory(ffm_raises=ffm_raises)),
+				patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
+			):
+				result = api.cancelar_factura(si, motivo)
+		return result, ffm, client
+
+	# 14 — cancelación RECHAZADA: FASE 3 mantiene TIMBRADO → se reconoce como persistido (recuperado)
+	def test_14_cancelacion_rejected_recuperada_timbrado(self):
+		result, ffm, client = self._run_cancelacion("02", {"cancellation_status": "rejected"})
+		self.assertTrue(result["success"])
+		self.assertEqual(result.get("persistence_status"), "recovered_by_phase3")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+		client.cancel_invoice.assert_called_once()
+
+	# 15 — cancelación PENDIENTE: conserva el comportamiento existente (PENDIENTE_CANCELACION recuperado)
+	def test_15_cancelacion_pending_recuperada(self):
+		result, ffm, _ = self._run_cancelacion("02", {"cancellation_status": "pending"})
+		self.assertTrue(result["success"])
+		self.assertEqual(result.get("persistence_status"), "recovered_by_phase3")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "PENDIENTE_CANCELACION")
+
+	# 16 — cancelación ACEPTADA pero FASE 3 no persiste (queda en TIMBRADO) → NO recuperada
+	def test_16_cancelacion_accepted_pero_timbrado_no_recuperada(self):
+		result, ffm, _ = self._run_cancelacion("02", {"status": "canceled"}, ffm_raises=True)
+		self.assertFalse(result["success"])
+		self.assertEqual(result.get("persistence_status"), "unresolved")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+
 	# 13 — cero referencias al cliente del PAC en este módulo
 	def test_13_cero_trafico_pac(self):
 		g = globals()

--- a/facturacion_mexico/facturacion_fiscal/tests/test_persistence_recovery.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_persistence_recovery.py
@@ -1,0 +1,308 @@
+"""Fallo de la persistencia principal tras PAC exitoso (Corrección 6B2).
+
+Cuando `write_pac_response` devuelve `success=False` (el PASO 1 del writer no persistió el
+estado fiscal) pero el PAC SÍ respondió bien, el flujo no trata esto como operación fallida:
+ejecuta la FASE 3 una sola vez, verifica con lectura NUEVA de BD el estado persistido y
+distingue entre recuperación local (success=True + advertencia crítica) y persistencia aún
+no resuelta (success=False + intervención manual, retry_allowed=False). Nunca re-llama al PAC.
+
+Distinto de: auditoría incompleta (6B1), FiscalCorrelationError (6A) y error real del PAC.
+
+Todo con mocks de boundary. Cero llamadas reales al PAC.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.api import FiscalCorrelationError
+from facturacion_mexico.facturacion_fiscal.timbrado_api import TimbradoAPI, revisar_estatus_cancelacion
+
+_TIMBRADO_API = "facturacion_mexico.facturacion_fiscal.timbrado_api"
+
+
+def _seed_si(*, fiscal_status: str = "", ffm: str | None = None) -> str:
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+			"fm_fiscal_status": fiscal_status or None,
+			"fm_factura_fiscal_mx": ffm,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(sales_invoice, status: str, *, facturapi_id: str = "", uuid: str = "") -> str:
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"facturapi_id": facturapi_id or None,
+			"fm_uuid": uuid or None,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+def _set_value_factory(*, ffm_raises=False):
+	"""SI: no-op (mínima). FFM: db.set_value (sin hooks) o lanza si ffm_raises."""
+	orig = frappe.set_value
+
+	def _fake(dt, dn, *args, **kwargs):
+		if dt == "Sales Invoice":
+			return None
+		if dt == "Factura Fiscal Mexico":
+			if ffm_raises:
+				raise RuntimeError("frappe down (FASE 3)")
+			return frappe.db.set_value(dt, dn, *args, **kwargs)
+		return orig(dt, dn, *args, **kwargs)
+
+	return _fake
+
+
+class TestPersistenceRecovery(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		has_recovery = frappe.db.exists("DocType", "Fiscal Recovery Task")
+		for ffm in self.ffm_names:
+			if has_recovery:
+				frappe.db.delete("Fiscal Recovery Task", {"reference_name": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def _si(self, **kwargs):
+		name = _seed_si(**kwargs)
+		self.si_names.append(name)
+		return name
+
+	def _ffm(self, *args, **kwargs):
+		name = _seed_ffm(*args, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	def _run_timbrado(self, si, ffm, *, writer_return=None, writer_side_effect=None, fase3="real"):
+		ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm)
+		client = MagicMock()
+		client.create_invoice.return_value = {"uuid": "U-1", "id": "FA-1", "total": 116}
+
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			stack = [
+				patch.object(TimbradoAPI, "_validate_invoice_for_timbrado"),
+				patch.object(TimbradoAPI, "_prepare_facturapi_data", return_value={}),
+				patch.object(TimbradoAPI, "_get_factura_fiscal", return_value=ffm_doc),
+				patch("frappe.set_value", side_effect=_set_value_factory()),
+			]
+			wpr = patch(f"{_TIMBRADO_API}.write_pac_response")
+			if fase3 == "real":
+				stack += [
+					patch.object(TimbradoAPI, "_validate_amount_discrepancies"),
+					patch.object(TimbradoAPI, "_download_fiscal_files"),
+					patch.object(TimbradoAPI, "_send_fiscal_email"),
+				]
+			elif fase3 == "fail":
+				stack.append(
+					patch.object(TimbradoAPI, "_process_timbrado_success", side_effect=RuntimeError("down"))
+				)
+			elif fase3 == "wrong_uuid":
+
+				def _wrong(self_, si_, ffm_, resp_):
+					frappe.db.set_value(
+						"Factura Fiscal Mexico", ffm_.name, {"status": "TIMBRADO", "fm_uuid": "OTRO-UUID"}
+					)
+
+				stack.append(
+					patch.object(TimbradoAPI, "_process_timbrado_success", autospec=True, side_effect=_wrong)
+				)
+
+			with ExitStack() as es:
+				for p in stack:
+					es.enter_context(p)
+				mock_wpr = es.enter_context(wpr)
+				if writer_side_effect is not None:
+					mock_wpr.side_effect = writer_side_effect
+				else:
+					mock_wpr.return_value = writer_return
+				result = api.timbrar_factura(si)
+		return result, client
+
+	# 1 — timbrado: writer falla, FASE 3 recupera, verificación OK
+	def test_01_timbrado_recuperado_por_fase3(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		result, client = self._run_timbrado(si, ffm, writer_return={"success": False, "error": "boom"})
+		self.assertTrue(result["success"])
+		self.assertEqual(result.get("persistence_status"), "recovered_by_phase3")
+		self.assertEqual(result.get("persistence_recovery_source"), "phase3")
+		self.assertTrue(result.get("persistence_warning"))
+		self.assertFalse(result.get("retry_allowed"))
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+		client.create_invoice.assert_called_once()
+
+	# 2 — timbrado: writer falla y FASE 3 también falla → no resuelto
+	def test_02_timbrado_no_resuelto(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		result, client = self._run_timbrado(si, ffm, writer_return={"success": False}, fase3="fail")
+		self.assertFalse(result["success"])
+		self.assertEqual(result.get("persistence_status"), "unresolved")
+		self.assertFalse(result.get("retry_allowed"))
+		self.assertTrue(result.get("operation_may_be_processed"))
+		self.assertIn("No repita la operación", result.get("message", ""))
+		client.create_invoice.assert_called_once()
+
+	# 3 — timbrado: FASE 3 "termina" pero el UUID persistido no coincide → no resuelto
+	def test_03_timbrado_uuid_no_coincide_no_resuelto(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		result, _ = self._run_timbrado(si, ffm, writer_return={"success": False}, fase3="wrong_uuid")
+		self.assertFalse(result.get("success"))  # nunca éxito limpio
+		self.assertEqual(result.get("persistence_status"), "unresolved")
+
+	# 10 — writer exitoso: sin metadata de 6B2
+	def test_10_writer_exitoso_sin_metadata(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		result, _ = self._run_timbrado(si, ffm, writer_return={"success": True, "fiscal_updated": True})
+		self.assertTrue(result["success"])
+		self.assertNotIn("persistence_warning", result)
+		self.assertNotIn("persistence_status", result)
+
+	# 8 — audit_log_failed sigue siendo 6B1 (no 6B2)
+	def test_08_audit_log_failed_es_6b1(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		result, _ = self._run_timbrado(
+			si, ffm, writer_return={"success": True, "fiscal_updated": True, "audit_log_failed": True}
+		)
+		self.assertTrue(result["success"])
+		self.assertTrue(result.get("audit_warning"))
+		self.assertNotIn("persistence_warning", result)
+
+	# 9 — FiscalCorrelationError sigue deteniendo (6A)
+	def test_09_correlacion_detiene(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		with self.assertRaises(FiscalCorrelationError):
+			self._run_timbrado(si, ffm, writer_side_effect=FiscalCorrelationError("x"))
+
+	# 7 — error real del PAC: comportamiento existente, sin advertencia de recuperación
+	def test_07_error_real_pac(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm)
+		client = MagicMock()
+		client.create_invoice.side_effect = RuntimeError("PAC 500")
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			with (
+				patch.object(TimbradoAPI, "_validate_invoice_for_timbrado"),
+				patch.object(TimbradoAPI, "_prepare_facturapi_data", return_value={}),
+				patch.object(TimbradoAPI, "_get_factura_fiscal", return_value=ffm_doc),
+				patch("frappe.set_value", side_effect=_set_value_factory()),
+				patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
+			):
+				result = api.timbrar_factura(si)
+		self.assertNotIn("persistence_warning", result)
+
+	# 4 — cancelación: writer falla, FASE 3 recupera a CANCELADO
+	def test_04_cancelacion_recuperada(self):
+		ffm = self._ffm(None, "TIMBRADO", facturapi_id="FA-1", uuid="U-1")
+		si = self._si(fiscal_status="TIMBRADO", ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		frappe.db.commit()
+		client = MagicMock()
+		client.cancel_invoice.return_value = {"success": True, "raw_response": {"status": "canceled"}}
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			with (
+				patch("frappe.set_value", side_effect=_set_value_factory()),
+				patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
+			):
+				result = api.cancelar_factura(si, "02")
+		self.assertTrue(result["success"])
+		self.assertEqual(result.get("persistence_status"), "recovered_by_phase3")
+		self.assertEqual(result.get("persistence_recovery_source"), "phase3")
+		client.cancel_invoice.assert_called_once()
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "CANCELADO")
+
+	# 5 — cancelación: writer y FASE 3 fallan → no resuelto, sin Recovery Task, sin 2ª cancelación
+	def test_05_cancelacion_no_resuelta_sin_recovery(self):
+		ffm = self._ffm(None, "TIMBRADO", facturapi_id="FA-1", uuid="U-1")
+		si = self._si(fiscal_status="TIMBRADO", ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		frappe.db.commit()
+		recovery_dt = frappe.db.exists("DocType", "Fiscal Recovery Task")
+		client = MagicMock()
+		client.cancel_invoice.return_value = {"success": True, "raw_response": {"status": "canceled"}}
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			with (
+				patch("frappe.set_value", side_effect=_set_value_factory(ffm_raises=True)),
+				patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
+			):
+				result = api.cancelar_factura(si, "02")
+		self.assertFalse(result["success"])
+		self.assertEqual(result.get("persistence_status"), "unresolved")
+		client.cancel_invoice.assert_called_once()  # sin segunda cancelación
+		if recovery_dt:
+			self.assertEqual(frappe.db.count("Fiscal Recovery Task", {"reference_name": ffm}), 0)
+
+	# 6 — consulta: writer falla, el estado ya persistido queda verificado
+	def test_06_consulta_recuperada(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1", uuid="U-1")
+		mock_query = patch(
+			"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
+			return_value={"success": True, "data": {"cancellation_status": "accepted"}},
+		)
+		with (
+			mock_query as mq,
+			patch("frappe.set_value", side_effect=_set_value_factory()),
+			patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
+		):
+			result = revisar_estatus_cancelacion(ffm)
+		self.assertTrue(result.get("success", True))  # éxito con advertencia
+		self.assertEqual(result.get("status"), "CANCELADO")  # estado previamente persistido y verificado
+		self.assertNotEqual(result.get("persistence_status"), "recovered_by_phase3")
+		self.assertEqual(result.get("persistence_status"), "state_verified_after_writer_failure")
+		self.assertEqual(result.get("persistence_recovery_source"), "pre_writer_state_update")
+		self.assertTrue(result.get("persistence_warning"))
+		mq.assert_called_once()  # consulta al PAC una sola vez
+
+	# 13 — cero referencias al cliente del PAC en este módulo
+	def test_13_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "requests", "get_facturapi_client"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_refacturar_guard.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_refacturar_guard.py
@@ -1,0 +1,150 @@
+"""Guard de refacturación 02/03/04 tras eliminar el bloqueo por fm_sync_status (Corrección 7A2).
+
+refacturar_misma_si DESVINCULA el FFM CANCELADO de la Sales Invoice (no timbra ni crea FFM).
+Tras 7A2, fm_sync_status='pending' ya NO bloquea: los controles vigentes son docstatus==1,
+FFM en CANCELADO y motivo 02/03/04, más la idempotencia cuando la SI ya está desvinculada.
+
+Sin stock, sin PAC. Solo test-facturacion.localhost.
+"""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.api.fiscal_operations import refacturar_misma_si
+
+
+def _seed_si(*, docstatus: int = 1, ffm: str | None = None) -> str:
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": docstatus,
+			"fm_factura_fiscal_mx": ffm,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(sales_invoice, status: str, *, sync: str = "pending", motivo: str = "") -> str:
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"fm_sync_status": sync,
+			"fm_motivo_cancelacion": motivo or None,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+class TestRefacturarGuard(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for ffm in self.ffm_names:
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def _si(self, **kwargs):
+		name = _seed_si(**kwargs)
+		self.si_names.append(name)
+		return name
+
+	def _ffm(self, *args, **kwargs):
+		name = _seed_ffm(*args, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	# 1 — CANCELADO + pending + motivo 02 → permite desvincular (ya no bloquea por pending)
+	def test_01_cancelado_pending_motivo02_permite(self):
+		si = self._si()
+		ffm = self._ffm(si, "CANCELADO", sync="pending", motivo="02")
+		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", ffm)
+		frappe.db.commit()
+		result = refacturar_misma_si(si)
+		self.assertTrue(result.get("ok"))
+		self.assertFalse(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"))
+
+	# 2 — CANCELADO + synced + motivo 03 → sigue permitiendo
+	def test_02_cancelado_synced_motivo03_permite(self):
+		si = self._si()
+		ffm = self._ffm(si, "CANCELADO", sync="synced", motivo="03")
+		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", ffm)
+		frappe.db.commit()
+		result = refacturar_misma_si(si)
+		self.assertTrue(result.get("ok"))
+
+	# 3 — TIMBRADO + pending → sigue bloqueado por estado (no por pending)
+	def test_03_timbrado_pending_bloqueado_por_estado(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending", motivo="02")
+		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", ffm)
+		frappe.db.commit()
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			refacturar_misma_si(si)
+		self.assertIn("CANCELADA", str(ctx.exception))
+
+	# 4 — PENDIENTE_CANCELACION + synced → bloqueado por estado
+	def test_04_pendiente_cancelacion_bloqueado(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", sync="synced", motivo="02")
+		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", ffm)
+		frappe.db.commit()
+		with self.assertRaises(frappe.ValidationError):
+			refacturar_misma_si(si)
+
+	# 5 — motivo 01 → bloqueado por motivo
+	def test_05_motivo_01_bloqueado(self):
+		si = self._si()
+		ffm = self._ffm(si, "CANCELADO", sync="synced", motivo="01")
+		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", ffm)
+		frappe.db.commit()
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			refacturar_misma_si(si)
+		self.assertIn("02/03/04", str(ctx.exception))
+
+	# 6 — Sales Invoice no enviada (docstatus=0) → bloqueada por precondición
+	def test_06_si_no_enviada_bloqueada(self):
+		si = self._si(docstatus=0)
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			refacturar_misma_si(si)
+		self.assertIn("enviada", str(ctx.exception))
+
+	# 7 — SI ya desvinculada → respuesta idempotente
+	def test_07_ya_desvinculada_idempotente(self):
+		si = self._si()  # sin fm_factura_fiscal_mx
+		result = refacturar_misma_si(si)
+		self.assertTrue(result.get("ok"))
+		self.assertTrue(result.get("already_unlinked"))
+
+	# 10 — cero referencias al cliente del PAC en este módulo
+	def test_10_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "cancel_invoice", "requests"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_sync_status_semantics.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_sync_status_semantics.py
@@ -218,6 +218,35 @@ class TestSyncStatusSemantics(IntegrationTestCase):
 		)
 		self.assertEqual(self._sync(ffm), "synced")  # sin cambio
 
+	# --- M1 (CodeRabbit): fm_last_pac_sync solo se refresca con respuesta PAC real ---
+
+	# M1.1 — un evento interno (fiscal_event_*) NO refresca fm_last_pac_sync
+	def test_16_fiscal_event_no_actualiza_last_pac_sync(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="synced")  # fm_last_pac_sync nace None
+		antes = frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_last_pac_sync")
+		self._write(
+			si,
+			ffm,
+			{"sales_invoice": si, "company": "_Test Company", "status": "TIMBRADO"},
+			"fiscal_event_create",
+		)
+		despues = frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_last_pac_sync")
+		self.assertEqual(antes, despues)  # no se tocó
+
+	# M1.2 — una respuesta PAC real SÍ refresca fm_last_pac_sync
+	def test_17_respuesta_pac_real_actualiza_last_pac_sync(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		self.assertIsNone(frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_last_pac_sync"))
+		self._write(
+			si,
+			ffm,
+			{"success": True, "status_code": 200, "raw_response": {"uuid": "U", "id": "FA"}},
+			"timbrado",
+		)
+		self.assertIsNotNone(frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_last_pac_sync"))
+
 	# ── 6B2: recuperación y no resuelto actualizan sync ──────────────────────
 
 	def _run_timbrado(self, si, ffm, *, writer_return, fase3="real"):

--- a/facturacion_mexico/facturacion_fiscal/tests/test_sync_status_semantics.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_sync_status_semantics.py
@@ -1,0 +1,296 @@
+"""Semántica y escritura coherente de fm_sync_status (Corrección 7A1).
+
+fm_sync_status indica si el FFM local refleja de forma verificable la última respuesta
+conocida del PAC. NO se confunde con el estado fiscal: una cancelación aceptada pero
+fiscalmente PENDIENTE_CANCELACION es 'synced' (la respuesta ya se reflejó localmente).
+
+- synced: hubo respuesta concluyente del PAC (éxito, rechazo conocido o estado de cancelación).
+- pending: respuesta realmente inconclusa (timeout / sin información).
+- error: la persistencia/verificación no se pudo confirmar (unresolved de 6B2).
+- el fallback no-PAC (fiscal_event_*) NO altera fm_sync_status.
+
+Todo con mocks de boundary. Cero llamadas reales al PAC. Solo test-facturacion.localhost.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.api import PACResponseWriter
+from facturacion_mexico.facturacion_fiscal.timbrado_api import TimbradoAPI, revisar_estatus_cancelacion
+
+_TIMBRADO_API = "facturacion_mexico.facturacion_fiscal.timbrado_api"
+
+
+def _seed_si(*, fiscal_status: str = "", ffm: str | None = None) -> str:
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+			"fm_fiscal_status": fiscal_status or None,
+			"fm_factura_fiscal_mx": ffm,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(
+	sales_invoice, status: str, *, facturapi_id: str = "", uuid: str = "", sync: str = "pending"
+) -> str:
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"facturapi_id": facturapi_id or None,
+			"fm_uuid": uuid or None,
+			"fm_sync_status": sync,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+def _set_value_factory(*, ffm_raises=False):
+	orig = frappe.set_value
+
+	def _fake(dt, dn, *args, **kwargs):
+		if dt == "Sales Invoice":
+			return None
+		if dt == "Factura Fiscal Mexico":
+			if ffm_raises:
+				raise RuntimeError("frappe down (FASE 3)")
+			return frappe.db.set_value(dt, dn, *args, **kwargs)
+		return orig(dt, dn, *args, **kwargs)
+
+	return _fake
+
+
+class TestSyncStatusSemantics(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.writer = PACResponseWriter()
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for ffm in self.ffm_names:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def _si(self, **kwargs):
+		name = _seed_si(**kwargs)
+		self.si_names.append(name)
+		return name
+
+	def _ffm(self, *args, **kwargs):
+		name = _seed_ffm(*args, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	def _sync(self, ffm):
+		return frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_sync_status")
+
+	def _write(self, si, ffm, response_data, op):
+		self.writer.write_pac_response(si, {"req": 1}, response_data, op, factura_fiscal_name=ffm)
+
+	# 1 — FFM recién creado conserva pending (default, sin pasar por el writer)
+	def test_01_recien_creado_pending(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR", sync="pending")
+		self.assertEqual(self._sync(ffm), "pending")
+
+	# 2 — timbrado exitoso → synced
+	def test_02_timbrado_exitoso_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		self._write(
+			si,
+			ffm,
+			{"success": True, "status_code": 200, "raw_response": {"uuid": "U", "id": "FA"}},
+			"timbrado",
+		)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# 3 — timbrado rechazado y registrado como ERROR → synced (rechazo conocido reflejado)
+	def test_03_timbrado_rechazado_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		self._write(
+			si,
+			ffm,
+			{"success": False, "status_code": 400, "error": "rechazo PAC", "raw_response": {}},
+			"timbrado",
+		)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "ERROR")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# 4 — cancelación inmediata (raw sin 'success', con id) → synced
+	def test_04_cancelacion_inmediata_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "CANCELADO", facturapi_id="FA-1")
+		self._write(si, ffm, {"status": "canceled", "id": "FA-1"}, "cancelacion")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# 5 — cancelación pendiente de aceptación → synced (la respuesta ya se reflejó)
+	def test_05_cancelacion_pendiente_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1")
+		self._write(si, ffm, {"cancellation_status": "pending", "id": "FA-1"}, "cancelacion")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "PENDIENTE_CANCELACION")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# 6 — cancelación rechazada y registrada → synced
+	def test_06_cancelacion_rechazada_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", facturapi_id="FA-1")
+		self._write(si, ffm, {"cancellation_status": "rejected", "id": "FA-1"}, "cancelacion")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# 7 — consulta con respuesta concluyente → synced
+	def test_07_consulta_concluyente_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION")
+		self._write(
+			si, ffm, {"success": True, "status_code": 200, "raw_response": {"status": "pending"}}, "consulta"
+		)
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# 11 — fallo exclusivo de auditoría no cambia sync (estado fiscal correcto)
+	def test_11_audit_fail_no_cambia_sync(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR")
+		with patch.object(PACResponseWriter, "_write_to_database", side_effect=RuntimeError("log caído")):
+			result = self.writer.write_pac_response(
+				si,
+				{"req": 1},
+				{"success": True, "status_code": 200, "raw_response": {"uuid": "U", "id": "FA"}},
+				"timbrado",
+				factura_fiscal_name=ffm,
+			)
+		self.assertTrue(result.get("audit_log_failed"))
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# 12 — respuesta realmente inconclusa → pending (no se marca falsamente synced)
+	def test_12_inconcluso_pending(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", sync="pending")
+		# Consulta sin información concluyente (timeout). El status no cambia (consulta→None).
+		self._write(si, ffm, {"timeout_flag": 1, "status_code": 0}, "consulta")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "PENDIENTE_CANCELACION")
+		self.assertEqual(self._sync(ffm), "pending")
+
+	# 13 — fallback no-PAC (fiscal_event_*) NO altera fm_sync_status
+	def test_13_fallback_no_pac_no_altera_sync(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="synced")
+		self._write(
+			si,
+			ffm,
+			{"sales_invoice": si, "company": "_Test Company", "status": "TIMBRADO"},
+			"fiscal_event_create",
+		)
+		self.assertEqual(self._sync(ffm), "synced")  # sin cambio
+
+	# ── 6B2: recuperación y no resuelto actualizan sync ──────────────────────
+
+	def _run_timbrado(self, si, ffm, *, writer_return, fase3="real"):
+		ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm)
+		client = MagicMock()
+		client.create_invoice.return_value = {"uuid": "U-1", "id": "FA-1", "total": 116}
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			stack = [
+				patch.object(TimbradoAPI, "_validate_invoice_for_timbrado"),
+				patch.object(TimbradoAPI, "_prepare_facturapi_data", return_value={}),
+				patch.object(TimbradoAPI, "_get_factura_fiscal", return_value=ffm_doc),
+				patch("frappe.set_value", side_effect=_set_value_factory(ffm_raises=(fase3 == "fail"))),
+				patch(f"{_TIMBRADO_API}.write_pac_response", return_value=writer_return),
+			]
+			if fase3 == "real":
+				stack += [
+					patch.object(TimbradoAPI, "_validate_amount_discrepancies"),
+					patch.object(TimbradoAPI, "_download_fiscal_files"),
+					patch.object(TimbradoAPI, "_send_fiscal_email"),
+				]
+			with ExitStack() as es:
+				for p in stack:
+					es.enter_context(p)
+				result = api.timbrar_factura(si)
+		return result
+
+	# 8 — writer falla y FASE 3 recupera → synced
+	def test_08_recuperado_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR", sync="pending")
+		self._run_timbrado(si, ffm, writer_return={"success": False}, fase3="real")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# 10 — writer y FASE 3 no resuelven → error
+	def test_10_no_resuelto_error(self):
+		si = self._si()
+		ffm = self._ffm(si, "BORRADOR", sync="pending")
+		result = self._run_timbrado(si, ffm, writer_return={"success": False}, fase3="fail")
+		self.assertEqual(result.get("persistence_status"), "unresolved")
+		self.assertEqual(self._sync(ffm), "error")
+
+	# 9 — consulta con writer fallido pero estado verificado → synced
+	def test_09_consulta_recuperada_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1", uuid="U-1", sync="pending")
+		mock_query = patch(
+			"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
+			return_value={"success": True, "data": {"cancellation_status": "accepted"}},
+		)
+		with (
+			mock_query,
+			patch("frappe.set_value", side_effect=_set_value_factory()),
+			patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
+		):
+			revisar_estatus_cancelacion(ffm)
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# 14 — HTTP 5xx / status_code=0 NO se clasifican como concluyentes solo por el código
+	def test_14_http_5xx_no_synced(self):
+		si = self._si()
+		# 5xx sin otra señal concluyente
+		ffm_a = self._ffm(si, "PENDIENTE_CANCELACION", sync="pending")
+		self._write(si, ffm_a, {"status_code": 503}, "consulta")
+		self.assertEqual(self._sync(ffm_a), "pending")
+		# success=False con 5xx (timeout/transporte) tampoco es synced
+		ffm_b = self._ffm(si, "PENDIENTE_CANCELACION", sync="pending")
+		self._write(si, ffm_b, {"success": False, "status_code": 500}, "consulta")
+		self.assertEqual(self._sync(ffm_b), "pending")
+
+	# 15 — cero referencias al cliente del PAC en este módulo
+	def test_15_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "requests", "get_facturapi_client"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_unico_ffm_activo.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_unico_ffm_activo.py
@@ -1,0 +1,326 @@
+"""Un solo FFM activo/no resuelto por Sales Invoice — Regla B (Corrección 5).
+
+Una Sales Invoice puede tener varios FFM históricos, pero solo UN FFM activo o no
+resuelto. Estados activos (bloquean otra creación): BORRADOR, PROCESANDO, TIMBRADO,
+ERROR, PENDIENTE_CANCELACION. Estados terminales (no bloquean): CANCELADO, ARCHIVADO.
+La decisión usa `status` del FFM (no `docstatus`) y se basa en los FFM activos cuyo
+`sales_invoice` es la SI, no solo en `Sales Invoice.fm_factura_fiscal_mx`.
+
+Dos protecciones:
+- `get_or_create_active_ffm`: resuelve crear/reutilizar bajo el lock de fila de la SI.
+- `Factura Fiscal Mexico.before_insert`: impide insertar un segundo FFM activo por cualquier
+  vía (Desk, API, scripts, `.insert()` directo), sin afectar documentos ya existentes.
+
+Sin llamadas al PAC. Pruebas en test-facturacion.localhost.
+"""
+
+import multiprocessing as mp
+import time
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.config.fiscal_states_config import FiscalStates
+from facturacion_mexico.facturacion_fiscal.api import FiscalCorrelationError
+from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+	get_or_create_active_ffm,
+)
+
+HOLD_SECONDS = 1.0
+
+
+def _make_si_committed() -> str:
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(sales_invoice: str, status: str, *, docstatus: int = 1) -> str:
+	"""Siembra un FFM con un status dado vía db_insert (sin disparar before_insert/validate)."""
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"docstatus": docstatus,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+def _build_ffm_doc(fr, sales_invoice: str):
+	"""Construye (sin insertar) un FFM mínimo; insert() ejecutará before_insert (la guarda)."""
+	ffm = fr.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": "BORRADOR",
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	return ffm
+
+
+def _worker_insert_holder(site, si_name, hold_seconds, locked_evt, queue):
+	"""Inserta un FFM (before_insert toma el lock de la SI) y difiere su commit."""
+	import frappe as fr
+
+	fr.init(site=site)
+	fr.connect()
+	try:
+		fr.db.begin()
+		ffm = _build_ffm_doc(fr, si_name)
+		ffm.insert(ignore_permissions=True)  # before_insert adquiere el lock de fila de la SI
+		locked_evt.set()
+		time.sleep(hold_seconds)
+		fr.db.commit()
+		queue.put(("holder", ffm.name, 0.0))
+	except Exception as e:
+		try:
+			fr.db.rollback()
+		except Exception:
+			pass
+		queue.put(("holder-err", repr(e), 0.0))
+	finally:
+		try:
+			fr.destroy()
+		except Exception:
+			pass
+
+
+def _worker_insert_contender(site, si_name, locked_evt, queue):
+	"""Tras la señal, intenta insertar otro FFM activo: su before_insert debe bloquear y luego fallar."""
+	import frappe as fr
+
+	fr.init(site=site)
+	fr.connect()
+	try:
+		locked_evt.wait(timeout=20)
+		fr.db.begin()
+		t0 = time.monotonic()
+		try:
+			ffm = _build_ffm_doc(fr, si_name)
+			ffm.insert(ignore_permissions=True)
+			fr.db.commit()
+			queue.put(("contender-ok", ffm.name, time.monotonic() - t0))
+		except Exception as e:
+			espera = time.monotonic() - t0
+			fr.db.rollback()
+			queue.put(("contender-err", repr(e), espera))
+	finally:
+		try:
+			fr.destroy()
+		except Exception:
+			pass
+
+
+class TestUnicoFFMActivo(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for si in self.si_names:
+			for ffm in frappe.get_all("Factura Fiscal Mexico", filters={"sales_invoice": si}, pluck="name"):
+				frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def _si(self):
+		name = _make_si_committed()
+		self.si_names.append(name)
+		return name
+
+	def _link(self, si, ffm):
+		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", ffm)
+
+	# ── Resolución vía get_or_create_active_ffm ──────────────────────────────
+
+	def _reutiliza_activo(self, status):
+		si = self._si()
+		ffm = _seed_ffm(si, status)
+		self._link(si, ffm)
+		result = get_or_create_active_ffm(si)
+		self.assertEqual(result, ffm, f"Debe reutilizar el FFM {status}")
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+
+	def test_01_borrador_reutiliza(self):
+		self._reutiliza_activo("BORRADOR")
+
+	def test_02_error_reutiliza(self):
+		self._reutiliza_activo("ERROR")
+
+	def test_03_procesando_reutiliza(self):
+		self._reutiliza_activo("PROCESANDO")
+
+	def test_04_timbrado_reutiliza_no_crea_otro(self):
+		self._reutiliza_activo("TIMBRADO")
+
+	def test_05_pendiente_cancelacion_reutiliza(self):
+		self._reutiliza_activo("PENDIENTE_CANCELACION")
+
+	def test_06_cancelado_permite_crear_nuevo(self):
+		si = self._si()
+		cancelado = _seed_ffm(si, "CANCELADO")
+		self._link(si, cancelado)
+		nuevo = get_or_create_active_ffm(si)
+		self.assertNotEqual(nuevo, cancelado, "Tras CANCELADO debe crear uno nuevo")
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 2)
+		# El nuevo es activo (no terminal) y la SI apunta a él. El status inicial exacto del
+		# nuevo depende del entorno (en test, el fallback de eventos puede dejarlo en ERROR;
+		# en producción nace BORRADOR). Lo relevante para Regla B es que sea activo.
+		nuevo_status = frappe.db.get_value("Factura Fiscal Mexico", nuevo, "status")
+		self.assertIn(nuevo_status, FiscalStates.ACTIVE_STATES)
+		self.assertEqual(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"), nuevo)
+
+	def test_07_archivado_permite_crear_nuevo(self):
+		si = self._si()
+		archivado = _seed_ffm(si, "ARCHIVADO")
+		self._link(si, archivado)
+		nuevo = get_or_create_active_ffm(si)
+		self.assertNotEqual(nuevo, archivado, "ARCHIVADO es terminal: debe crear uno nuevo")
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 2)
+		self.assertEqual(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"), nuevo)
+
+	def test_08_ref_vacia_un_activo_repara_y_reutiliza(self):
+		si = self._si()
+		ffm = _seed_ffm(si, "TIMBRADO")
+		# referencia vacía a propósito (no se vincula)
+		self.assertFalse(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"))
+		result = get_or_create_active_ffm(si)
+		self.assertEqual(result, ffm)
+		# vínculo reparado
+		self.assertEqual(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"), ffm)
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+
+	def test_09_ref_rota_un_activo_reutiliza(self):
+		si = self._si()
+		ffm = _seed_ffm(si, "BORRADOR")
+		self._link(si, "FFMX-INEXISTENTE-999")  # referencia a FFM que no existe
+		result = get_or_create_active_ffm(si)
+		self.assertEqual(result, ffm)
+		self.assertEqual(frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx"), ffm)
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+
+	def test_10_ref_a_ffm_de_otra_si_error_integridad(self):
+		si_a = self._si()
+		si_b = self._si()
+		ffm_b = _seed_ffm(si_b, "TIMBRADO")  # pertenece a si_b
+		self._link(si_a, ffm_b)  # si_a apunta a un FFM de si_b (corrupción)
+		with self.assertRaises(FiscalCorrelationError):
+			get_or_create_active_ffm(si_a)
+		# no creó nada para si_a, no tocó el FFM de si_b
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si_a}), 0)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_b, "status"), "TIMBRADO")
+
+	def test_11_dos_activos_alerta_y_no_selecciona(self):
+		si = self._si()
+		a1 = _seed_ffm(si, "BORRADOR")
+		a2 = _seed_ffm(si, "TIMBRADO")
+		with self.assertRaises(FiscalCorrelationError):
+			get_or_create_active_ffm(si)
+		# no creó otro, no modificó estados
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 2)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", a1, "status"), "BORRADOR")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", a2, "status"), "TIMBRADO")
+
+	def test_14_cancelado_y_activo_coexisten(self):
+		si = self._si()
+		cancelado = _seed_ffm(si, "CANCELADO")
+		activo = _seed_ffm(si, "TIMBRADO")
+		self._link(si, activo)
+		result = get_or_create_active_ffm(si)
+		self.assertEqual(result, activo, "Debe reutilizar el único activo; el cancelado coexiste")
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 2)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", cancelado, "status"), "CANCELADO")
+
+	# ── Protección en before_insert (toda vía de inserción) ──────────────────
+
+	def test_12_insercion_directa_segundo_activo_bloqueada(self):
+		si = self._si()
+		_seed_ffm(si, "BORRADOR")  # ya hay un activo
+		ffm2 = _build_ffm_doc(frappe, si)
+		with self.assertRaises(frappe.ValidationError):
+			ffm2.insert(ignore_permissions=True)
+		# el segundo no persistió
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+
+	def test_15_modificacion_de_existentes_no_bloqueada(self):
+		# Dos activos preexistentes (duplicados de producción). Guardar uno NO debe bloquearse:
+		# before_insert solo corre en inserción, no en actualización.
+		si = self._si()
+		a1 = _seed_ffm(si, "BORRADOR")
+		_seed_ffm(si, "TIMBRADO")
+		doc = frappe.get_doc("Factura Fiscal Mexico", a1)
+		doc.flags.ignore_validate = True
+		doc.fm_uuid = "UUID-EDIT-15"
+		doc.save(ignore_permissions=True)  # no debe lanzar "FFM activo ya existe"
+		frappe.db.commit()
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", a1, "fm_uuid"), "UUID-EDIT-15")
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 2)
+
+	# ── Concurrencia de inserción directa (procesos/conexiones independientes) ─
+
+	def test_13_insercion_concurrente_directa_solo_uno_persiste(self):
+		si = self._si()
+		site = frappe.local.site
+		ctx = mp.get_context("spawn")
+		locked = ctx.Event()
+		q = ctx.Queue()
+		ph = ctx.Process(target=_worker_insert_holder, args=(site, si, HOLD_SECONDS, locked, q))
+		pc = ctx.Process(target=_worker_insert_contender, args=(site, si, locked, q))
+		ph.start()
+		pc.start()
+		ph.join(60)
+		pc.join(60)
+		out = {}
+		for _ in range(2):
+			tipo, val, espera = q.get(timeout=10)
+			out[tipo] = (val, espera)
+
+		# Outcome determinista: el holder inserta y el contender (que corre tras la señal,
+		# con el FFM del holder ya visible) es bloqueado por la guarda before_insert.
+		# La serialización por for_update se prueba de forma determinista en la Corrección 4;
+		# aquí lo esencial es que la inserción directa concurrente deje UN solo FFM.
+		self.assertIn("holder", out, f"El holder debe insertar OK: {out}")
+		self.assertIn("contender-err", out, f"El contender debe fallar (no insertar): {out}")
+		self.assertIn("ya tiene un FFM activo", out["contender-err"][0])
+		# Solo un FFM persistió.
+		self.assertEqual(frappe.db.count("Factura Fiscal Mexico", {"sales_invoice": si}), 1)
+
+	# ── Cero tráfico PAC ─────────────────────────────────────────────────────
+
+	def test_16_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "cancel_invoice", "requests"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_writer_timbrado_uuid.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_writer_timbrado_uuid.py
@@ -1,0 +1,255 @@
+"""Persistencia fiscal correcta del timbrado en write_pac_response (Corrección 6B0).
+
+El UUID de un timbrado exitoso llega dentro de `raw_response`, no a nivel superior.
+Antes, `_derive_status_from_response` solo lo buscaba arriba y derivaba `ERROR`, que se
+commiteaba temporalmente hasta que la FASE 3 lo corregía. Ahora el writer usa el extractor
+normalizado `_extract_response_identifiers` y persiste `TIMBRADO` + UUID + facturapi_id
+directamente, sin pasar por `ERROR`.
+
+Todo con respuestas SIMULADAS. Cero llamadas reales al PAC.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.api import PACResponseWriter
+
+_TIMBRADO_API = "facturacion_mexico.facturacion_fiscal.timbrado_api"
+
+
+def _seed_si() -> str:
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(sales_invoice: str, status: str = "BORRADOR") -> str:
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+class TestWriterTimbradoUUID(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.writer = PACResponseWriter()
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for ffm in self.ffm_names:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def _si(self):
+		name = _seed_si()
+		self.si_names.append(name)
+		return name
+
+	def _ffm(self, si, status="BORRADOR"):
+		name = _seed_ffm(si, status)
+		self.ffm_names.append(name)
+		return name
+
+	def _ffm_row(self, ffm):
+		return frappe.db.get_value(
+			"Factura Fiscal Mexico",
+			ffm,
+			["status", "fm_uuid", "facturapi_id", "fm_sync_status"],
+			as_dict=True,
+		)
+
+	# 1 — timbrado exitoso con UUID a nivel superior
+	def test_01_uuid_top_level_deja_timbrado(self):
+		si = self._si()
+		ffm = self._ffm(si)
+		self.writer.write_pac_response(
+			si,
+			{"req": 1},
+			{"success": True, "status_code": 200, "uuid": "UUID-TOP"},
+			"timbrado",
+			factura_fiscal_name=ffm,
+		)
+		d = self._ffm_row(ffm)
+		self.assertEqual(d["status"], "TIMBRADO")
+		self.assertEqual(d["fm_uuid"], "UUID-TOP")
+		self.assertEqual(d["fm_sync_status"], "synced")
+
+	# 2 — timbrado exitoso con UUID SOLO dentro de raw_response (el caso real)
+	def test_02_uuid_en_raw_response_deja_timbrado_nunca_error(self):
+		si = self._si()
+		ffm = self._ffm(si)
+		self.writer.write_pac_response(
+			si,
+			{"req": 1},
+			{"success": True, "status_code": 200, "raw_response": {"uuid": "UUID-RAW", "id": "FA-RAW"}},
+			"timbrado",
+			factura_fiscal_name=ffm,
+		)
+		d = self._ffm_row(ffm)
+		self.assertEqual(d["status"], "TIMBRADO", "Nunca debe quedar ERROR en un timbrado exitoso")
+		self.assertEqual(d["fm_uuid"], "UUID-RAW")
+		self.assertEqual(d["fm_sync_status"], "synced")
+
+	# 3 — facturapi_id dentro de raw_response queda guardado
+	def test_03_facturapi_id_en_raw_response_se_guarda(self):
+		si = self._si()
+		ffm = self._ffm(si)
+		self.writer.write_pac_response(
+			si,
+			{"req": 1},
+			{"success": True, "status_code": 200, "raw_response": {"uuid": "UUID-RAW", "id": "FA-123"}},
+			"timbrado",
+			factura_fiscal_name=ffm,
+		)
+		d = self._ffm_row(ffm)
+		self.assertEqual(d["facturapi_id"], "FA-123")
+		self.assertEqual(d["status"], "TIMBRADO")
+
+	# 4 — éxito declarado pero SIN UUID en ningún nivel: comportamiento seguro documentado.
+	#     Se mantiene el comportamiento existente: NO marca TIMBRADO (deriva ERROR). No se
+	#     inventa UUID ni se presenta como éxito limpio.
+	def test_04_sin_uuid_no_marca_timbrado(self):
+		si = self._si()
+		ffm = self._ffm(si)
+		self.writer.write_pac_response(
+			si,
+			{"req": 1},
+			{"success": True, "status_code": 200, "raw_response": {}},
+			"timbrado",
+			factura_fiscal_name=ffm,
+		)
+		d = self._ffm_row(ffm)
+		self.assertNotEqual(d["status"], "TIMBRADO")
+		self.assertEqual(d["status"], "ERROR")  # comportamiento seguro existente, documentado
+		self.assertFalse(d["fm_uuid"])
+
+	# 5 — si la FASE 3 NO se ejecuta, el estado dejado por el writer ya es correcto.
+	#     (Se invoca SOLO write_pac_response, sin la FASE 3 del orquestador.)
+	def test_05_estado_correcto_sin_fase3(self):
+		si = self._si()
+		ffm = self._ffm(si)
+		self.writer.write_pac_response(
+			si,
+			{"req": 1},
+			{"success": True, "status_code": 200, "raw_response": {"uuid": "UUID-RAW", "id": "FA-RAW"}},
+			"timbrado",
+			factura_fiscal_name=ffm,
+		)
+		# Sin ejecutar nada más, el FFM ya es fiscalmente correcto.
+		d = self._ffm_row(ffm)
+		self.assertEqual(d["status"], "TIMBRADO")
+		self.assertEqual(d["fm_uuid"], "UUID-RAW")
+		self.assertEqual(d["facturapi_id"], "FA-RAW")
+
+	# 6 — la FASE 3 posterior NO degrada el TIMBRADO ya correcto.
+	def test_06_fase3_posterior_no_degrada_timbrado(self):
+		si = self._si()
+		ffm = self._ffm(si)
+		pac_response = {"uuid": "UUID-RAW", "id": "FA-RAW", "total": 116}
+		self.writer.write_pac_response(
+			si,
+			{"req": 1},
+			{"success": True, "status_code": 200, "raw_response": pac_response},
+			"timbrado",
+			factura_fiscal_name=ffm,
+		)
+		self.assertEqual(self._ffm_row(ffm)["status"], "TIMBRADO")
+
+		# Ejecutar la FASE 3 real con sus boundaries de IO neutralizados.
+		from facturacion_mexico.facturacion_fiscal.timbrado_api import TimbradoAPI
+
+		si_doc = frappe.get_doc("Sales Invoice", si)
+		ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm)
+
+		# Neutralizar SOLO la escritura sobre la Sales Invoice mínima (validación mandatory);
+		# la escritura sobre el FFM (lo que se prueba) se deja real.
+		_orig_set_value = frappe.set_value
+
+		def _set_value_si_noop(dt, dn, *args, **kwargs):
+			if dt == "Sales Invoice":
+				return None
+			return _orig_set_value(dt, dn, *args, **kwargs)
+
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=MagicMock()):
+			api = TimbradoAPI(company="_Test Company")
+			with (
+				patch.object(TimbradoAPI, "_validate_amount_discrepancies"),
+				patch.object(TimbradoAPI, "_download_fiscal_files"),
+				patch.object(TimbradoAPI, "_send_fiscal_email"),
+				patch("frappe.set_value", side_effect=_set_value_si_noop),
+			):
+				api._process_timbrado_success(si_doc, ffm_doc, pac_response)
+
+		# Sigue TIMBRADO (la FASE 3 no lo cambió a un estado incorrecto).
+		self.assertEqual(self._ffm_row(ffm)["status"], "TIMBRADO")
+		self.assertEqual(self._ffm_row(ffm)["fm_uuid"], "UUID-RAW")
+
+	# 7 — cancelación y consulta conservan su semántica (no cambian status vía el writer)
+	def test_07_cancelacion_y_consulta_sin_cambio_de_semantica(self):
+		# Cancelación: el raw del PAC no trae "success" → ok=False → new_status=None → el writer
+		# NO cambia el status (lo fija la FASE 3). Se incluye status_code para no depender del
+		# parser de error (comportamiento de cancelación sin cambios en esta corrección).
+		si_c = self._si()
+		ffm_c = self._ffm(si_c, status="TIMBRADO")
+		self.writer.write_pac_response(
+			si_c,
+			{"req": 1},
+			{"status_code": 200, "raw_response": {"status": "canceled"}},
+			"cancelacion",
+			factura_fiscal_name=ffm_c,
+		)
+		self.assertEqual(self._ffm_row(ffm_c)["status"], "TIMBRADO")  # el writer NO lo cambió
+
+		# Consulta: tampoco cambia el status vía el writer.
+		si_q = self._si()
+		ffm_q = self._ffm(si_q, status="PENDIENTE_CANCELACION")
+		self.writer.write_pac_response(
+			si_q,
+			{"req": 1},
+			{"success": True, "status_code": 200, "raw_response": {"status": "pending"}},
+			"consulta",
+			factura_fiscal_name=ffm_q,
+		)
+		self.assertEqual(self._ffm_row(ffm_q)["status"], "PENDIENTE_CANCELACION")
+
+	# 9 — cero referencias al cliente del PAC en este módulo
+	def test_09_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "requests", "get_facturapi_client"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -206,6 +206,21 @@ def _alert_persistence_incident(flujo: str, ffm: str, sales_invoice: str, recove
 		pass
 
 
+def _set_sync_status_best_effort(ffm_name: str, value: str) -> None:
+	"""Actualizar fm_sync_status de MEJOR ESFUERZO (Corrección 7A1).
+
+	Usado por los caminos de 6B2: 'synced' cuando la FASE 3 recuperó y se verificó el estado;
+	'error' cuando queda 'unresolved'. No lanza: si no puede actualizarse, registra y continúa
+	para NO tapar el incidente principal ni convertir un unresolved en éxito limpio.
+	"""
+	try:
+		frappe.db.set_value("Factura Fiscal Mexico", ffm_name, "fm_sync_status", value)
+	except Exception as e:
+		frappe.log_error(
+			f"No se pudo actualizar fm_sync_status={value} en {ffm_name}: {e}", "Sync Status 7A1"
+		)
+
+
 def _persistence_recovered_result(
 	base_result, *, status: str = "recovered_by_phase3", source: str = "phase3"
 ):
@@ -467,6 +482,8 @@ class TimbradoAPI:
 					_alert_persistence_incident(
 						"timbrado", factura_fiscal.name, sales_invoice_name, recovered
 					)
+					# 7A1: sync='synced' si el estado quedó verificado; 'error' si no resuelto.
+					_set_sync_status_best_effort(factura_fiscal.name, "synced" if recovered else "error")
 					return (
 						_persistence_recovered_result(base_result)
 						if recovered
@@ -485,6 +502,7 @@ class TimbradoAPI:
 					_alert_persistence_incident(
 						"timbrado", factura_fiscal.name, sales_invoice_name, recovered=False
 					)
+					_set_sync_status_best_effort(factura_fiscal.name, "error")  # 7A1
 					return _persistence_unresolved_result()
 
 				# PAC exitoso pero Frappe falló al actualizar
@@ -1623,6 +1641,9 @@ class TimbradoAPI:
 					_alert_persistence_incident(
 						"cancelacion", factura_fiscal.name, sales_invoice_name, recovered
 					)
+					_set_sync_status_best_effort(
+						factura_fiscal.name, "synced" if recovered else "error"
+					)  # 7A1
 					return (
 						_persistence_recovered_result(base_result)
 						if recovered
@@ -1643,6 +1664,7 @@ class TimbradoAPI:
 					_alert_persistence_incident(
 						"cancelacion", factura_fiscal.name, sales_invoice_name, recovered=False
 					)
+					_set_sync_status_best_effort(factura_fiscal.name, "error")  # 7A1
 					return _persistence_unresolved_result()
 
 				# PAC canceló exitosamente pero Frappe falló - CREAR RECOVERY TASK
@@ -3530,6 +3552,7 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 	if _writer_persistence_failed(writer_result):
 		recovered = _verify_estado_persisted(ffm_name, nuevo_estado)
 		_alert_persistence_incident("consulta", ffm_name, ffm.sales_invoice, recovered)
+		_set_sync_status_best_effort(ffm_name, "synced" if recovered else "error")  # 7A1
 		return (
 			_persistence_recovered_result(
 				base_result,

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -40,7 +40,10 @@ def _log_payload_checkpoint(tag, payload: dict):
 
 from facturacion_mexico.config.fiscal_states_config import FiscalStates, OperationTypes
 
-from .api import write_pac_response  # PAC Response Writer - Arquitectura resiliente activada
+from .api import (  # PAC Response Writer - Arquitectura resiliente activada
+	FiscalCorrelationError,
+	write_pac_response,
+)
 from .api_client import get_facturapi_client
 from .doctype.facturapi_response_log.facturapi_response_log import FacturAPIResponseLog
 
@@ -88,6 +91,27 @@ def _validate_items_clave_sat_for_timbrado(sales_invoice):
 			frappe.ValidationError,
 			title=_("Claves SAT Faltantes — Timbrado Bloqueado"),
 		)
+
+
+def _raise_correlation_incident() -> None:
+	"""Detener el flujo ante una correlación fiscal crítica (Corrección 6A).
+
+	Una `FiscalCorrelationError` después de una operación con el PAC significa que la
+	respuesta no se pudo asociar de forma inequívoca al documento fiscal de origen.
+	El flujo local se detiene SIN continuar a la FASE 3, sin re-llamar al PAC y sin
+	reintentos automáticos. La evidencia técnica (FFM, UUID, facturapi_id, SI) ya quedó
+	registrada en la alerta crítica del writer; aquí solo se comunica un mensaje seguro,
+	sin revelar datos fiscales sensibles, instruyendo a NO repetir la operación.
+	"""
+	frappe.throw(
+		_(
+			"No repita la operación. El PAC pudo haberla procesado, pero el sistema detectó "
+			"una inconsistencia al relacionar la respuesta con el documento fiscal. "
+			"Se requiere revisión administrativa."
+		),
+		title=_("Intervención requerida"),
+		exc=FiscalCorrelationError,
+	)
 
 
 class TimbradoAPI:
@@ -187,6 +211,11 @@ class TimbradoAPI:
 					factura_fiscal_name=factura_fiscal.name,
 				)
 
+			except FiscalCorrelationError:
+				# Corrección 6A: una correlación crítica al persistir la respuesta del PAC NO es
+				# un error de comunicación. No re-llamar al PAC ni continuar; propagar para que
+				# se detenga el flujo (no se ejecuta la FASE 3).
+				raise
 			except Exception as pac_error:
 				# Error DURANTE comunicación con PAC
 				# Construir respuesta de error con datos RAW
@@ -279,6 +308,9 @@ class TimbradoAPI:
 					"message": "Factura timbrada exitosamente",  # Mensaje para UI
 				}
 
+			except FiscalCorrelationError:
+				# Corrección 6A: propagar la correlación crítica sin degradarla a error ordinario.
+				raise
 			except Exception as frappe_error:
 				# PAC exitoso pero Frappe falló al actualizar
 				# Response Log YA tiene la respuesta correcta del PAC
@@ -303,6 +335,10 @@ class TimbradoAPI:
 					"user_error": "La factura se timbró correctamente pero hubo un error actualizando el sistema. Contacte soporte con el UUID mostrado.",
 				}
 
+		except FiscalCorrelationError:
+			# Corrección 6A: incidente de correlación crítica. No se ejecutó la FASE 3, no se
+			# tocó otro FFM, no se re-llamó al PAC. Mensaje seguro y resultado inequívoco.
+			_raise_correlation_incident()
 		except Exception as e:
 			# Error ANTES del PAC o error del PAC ya manejado arriba
 			if not pac_response:
@@ -1284,6 +1320,10 @@ class TimbradoAPI:
 					factura_fiscal_name=factura_fiscal.name,
 				)
 
+			except FiscalCorrelationError:
+				# Corrección 6A: correlación crítica al persistir la respuesta de cancelación.
+				# No tratar como error de comunicación ni re-llamar al PAC; propagar.
+				raise
 			except Exception as pac_error:
 				# Error DURANTE comunicación con PAC
 				pac_response = {
@@ -1402,6 +1442,10 @@ class TimbradoAPI:
 					"message": "Solicitud de cancelación procesada exitosamente",
 				}
 
+			except FiscalCorrelationError:
+				# Corrección 6A: propagar la correlación crítica; no crear Recovery Task que
+				# pueda repetir la operación.
+				raise
 			except Exception as frappe_error:
 				# PAC canceló exitosamente pero Frappe falló - CREAR RECOVERY TASK
 				frappe.log_error(
@@ -1450,6 +1494,10 @@ class TimbradoAPI:
 					"user_error": "La factura se canceló correctamente en el SAT. El sistema se corregirá automáticamente en unos minutos.",
 				}
 
+		except FiscalCorrelationError:
+			# Corrección 6A: incidente de correlación crítica en cancelación. No se ejecutó la
+			# FASE 3, no se creó Recovery Task, no se re-llamó al PAC. Mensaje seguro.
+			_raise_correlation_incident()
 		except Exception as e:
 			# Error ANTES del PAC o error del PAC ya manejado
 			if not pac_response:
@@ -3263,6 +3311,10 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 			operation_type="consulta",
 			factura_fiscal_name=ffm_name,
 		)
+	except FiscalCorrelationError:
+		# Corrección 6A: la inconsistencia de correlación en la consulta NO se traga; se reporta.
+		# El cambio de estado escrito sobre ESTE FFM se revierte al propagar (no se hace commit).
+		_raise_correlation_incident()
 	except Exception as log_err:
 		frappe.logger().warning(f"No se pudo registrar log de consulta estatus {ffm_name}: {log_err}")
 

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -184,6 +184,7 @@ class TimbradoAPI:
 					json.dumps(pac_request),
 					json.dumps(response_data),
 					"timbrado",
+					factura_fiscal_name=factura_fiscal.name,
 				)
 
 			except Exception as pac_error:
@@ -207,6 +208,7 @@ class TimbradoAPI:
 					json.dumps(pac_request),
 					json.dumps(pac_response),  # ✅ Error REAL del PAC
 					"timbrado",
+					factura_fiscal_name=factura_fiscal.name,
 				)
 
 				# Re-lanzar para manejo de UI
@@ -1279,6 +1281,7 @@ class TimbradoAPI:
 					json.dumps(pac_request),
 					json.dumps(pac_response),  # ✅ Respuesta REAL del PAC
 					"cancelacion",
+					factura_fiscal_name=factura_fiscal.name,
 				)
 
 			except Exception as pac_error:
@@ -1301,6 +1304,7 @@ class TimbradoAPI:
 					json.dumps(pac_request),
 					json.dumps(pac_response),  # ✅ Error REAL del PAC
 					"cancelacion",
+					factura_fiscal_name=factura_fiscal.name,
 				)
 
 				# Re-lanzar para manejo de UI
@@ -3257,6 +3261,7 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 				default=str,
 			),
 			operation_type="consulta",
+			factura_fiscal_name=ffm_name,
 		)
 	except Exception as log_err:
 		frappe.logger().warning(f"No se pudo registrar log de consulta estatus {ffm_name}: {log_err}")

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -271,12 +271,6 @@ def _verify_timbrado_persisted(ffm_name: str, response_data: dict) -> bool:
 	return True
 
 
-def _verify_cancelacion_persisted(ffm_name: str) -> bool:
-	"""Lectura NUEVA de BD: el FFM quedó en un estado legítimo del flujo de cancelación."""
-	status = frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "status")
-	return status in (FiscalStates.CANCELADO, FiscalStates.PENDIENTE_CANCELACION)
-
-
 def _verify_estado_persisted(ffm_name: str, expected_status: str) -> bool:
 	"""Lectura NUEVA de BD: el estado persistido coincide con el ya determinado por el flujo."""
 	return frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "status") == expected_status
@@ -1635,9 +1629,15 @@ class TimbradoAPI:
 					"message": "Solicitud de cancelación procesada exitosamente",
 				}
 				# Corrección 6B2: persistencia principal del writer fallida (PAC OK) → verificar si
-				# la FASE 3 dejó un estado legítimo de cancelación. No se re-llama al PAC.
+				# la FASE 3 dejó persistido EXACTAMENTE el estado que el flujo ya derivó del PAC.
+				# M3 (CodeRabbit): se compara contra `fiscal_status` (el destino legítimo:
+				# CANCELADO si aceptada, PENDIENTE_CANCELACION si pendiente, TIMBRADO si rechazada),
+				# en vez de exigir solo CANCELADO/PENDIENTE_CANCELACION. Así una cancelación
+				# RECHAZADA que dejó el FFM en TIMBRADO se reconoce como persistencia correcta, y
+				# una aceptada que quedó en TIMBRADO se sigue detectando como inconsistente.
+				# No se re-llama al PAC.
 				if _writer_persistence_failed(writer_result):
-					recovered = _verify_cancelacion_persisted(factura_fiscal.name)
+					recovered = _verify_estado_persisted(factura_fiscal.name, fiscal_status)
 					_alert_persistence_incident(
 						"cancelacion", factura_fiscal.name, sales_invoice_name, recovered
 					)

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -42,6 +42,7 @@ from facturacion_mexico.config.fiscal_states_config import FiscalStates, Operati
 
 from .api import (  # PAC Response Writer - Arquitectura resiliente activada
 	FiscalCorrelationError,
+	_extract_response_identifiers,
 	write_pac_response,
 )
 from .api_client import get_facturapi_client
@@ -153,6 +154,117 @@ def _apply_audit_warning(writer_result, user_result):
 		user_result["audit_detail"] = detail
 		user_result["audit_warning_message"] = _audit_warning_message()
 	return user_result
+
+
+# ── Corrección 6B2: fallo de la persistencia PRINCIPAL (PASO 1 del writer) tras PAC OK ──
+
+
+def _writer_persistence_failed(writer_result) -> bool:
+	"""True si el writer NO logró persistir el estado fiscal (PASO 1 lanzó → success=False).
+
+	Distinto de la auditoría incompleta (6B1, success sigue True) y de FiscalCorrelationError
+	(6A, se propaga). Solo aplica en caminos donde el PAC respondió exitosamente.
+	"""
+	return isinstance(writer_result, dict) and writer_result.get("success") is False
+
+
+def _persistence_warning_message() -> str:
+	return _(
+		"La operación fiscal fue procesada y el estado local pudo recuperarse, pero falló la "
+		"persistencia principal de la respuesta. No repita la operación. Se requiere revisión "
+		"administrativa."
+	)
+
+
+def _persistence_unresolved_message() -> str:
+	return _(
+		"No repita la operación. El PAC pudo haberla procesado, pero el sistema no pudo confirmar "
+		"la persistencia local del estado fiscal. Se requiere revisión administrativa inmediata."
+	)
+
+
+def _alert_persistence_incident(flujo: str, ffm: str, sales_invoice: str, recovered: bool) -> None:
+	"""Alerta estructurada de orquestación (Corrección 6B2). No duplica el payload técnico
+	que el writer ya registró; solo correlaciona el incidente y deja constancia de que el PAC
+	NO debe llamarse nuevamente."""
+	try:
+		frappe.log_error(
+			message=json.dumps(
+				{
+					"flujo": flujo,
+					"ffm": ffm,
+					"sales_invoice": sales_invoice,
+					"fase3_recupero": recovered,
+					"no_reintentar_pac": True,
+				},
+				default=str,
+				indent=2,
+			),
+			title="PAC Persistencia Principal Falló",
+		)
+	except Exception:
+		pass
+
+
+def _persistence_recovered_result(
+	base_result, *, status: str = "recovered_by_phase3", source: str = "phase3"
+):
+	"""Caso 1: el estado fiscal quedó verificado pese al fallo de la persistencia principal.
+
+	Para timbrado/cancelación, la FASE 3 lo recuperó (`recovered_by_phase3`/`phase3`). Para
+	consulta NO hay FASE 3 que recupere: el estado se escribe ANTES del writer y solo se
+	verifica que siga correcto; por eso el caller usa un `status`/`source` explícitos.
+	success=True + advertencia crítica; no cambia manual_review_required ni retry_allowed.
+	"""
+	frappe.msgprint(_persistence_warning_message(), title=_("Persistencia recuperada"), indicator="orange")
+	if isinstance(base_result, dict):
+		base_result.setdefault("success", True)
+		base_result["persistence_warning"] = True
+		base_result["persistence_status"] = status
+		base_result["persistence_recovery_source"] = source
+		base_result["manual_review_required"] = True
+		base_result["retry_allowed"] = False
+		base_result["persistence_warning_message"] = _persistence_warning_message()
+	return base_result
+
+
+def _persistence_unresolved_result(base_result=None):
+	"""Caso 2: ni el writer ni la FASE 3 confirmaron la persistencia. Intervención manual."""
+	frappe.msgprint(_persistence_unresolved_message(), title=_("Intervención requerida"), indicator="red")
+	result = base_result if isinstance(base_result, dict) else {}
+	result["success"] = False
+	result["operation_may_be_processed"] = True
+	result["manual_review_required"] = True
+	result["retry_allowed"] = False
+	result["persistence_status"] = "unresolved"
+	result["message"] = _persistence_unresolved_message()
+	return result
+
+
+def _verify_timbrado_persisted(ffm_name: str, response_data: dict) -> bool:
+	"""Lectura NUEVA de BD: el FFM quedó TIMBRADO con UUID (y facturapi_id) coincidentes."""
+	uuid, facturapi_id = _extract_response_identifiers(response_data)
+	row = frappe.db.get_value(
+		"Factura Fiscal Mexico", ffm_name, ["status", "fm_uuid", "facturapi_id"], as_dict=True
+	)
+	if not row or row.get("status") != FiscalStates.TIMBRADO:
+		return False
+	if uuid and row.get("fm_uuid") != uuid:
+		return False
+	if facturapi_id and row.get("facturapi_id") and row.get("facturapi_id") != facturapi_id:
+		return False
+	return True
+
+
+def _verify_cancelacion_persisted(ffm_name: str) -> bool:
+	"""Lectura NUEVA de BD: el FFM quedó en un estado legítimo del flujo de cancelación."""
+	status = frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "status")
+	return status in (FiscalStates.CANCELADO, FiscalStates.PENDIENTE_CANCELACION)
+
+
+def _verify_estado_persisted(ffm_name: str, expected_status: str) -> bool:
+	"""Lectura NUEVA de BD: el estado persistido coincide con el ya determinado por el flujo."""
+	return frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "status") == expected_status
 
 
 class TimbradoAPI:
@@ -340,22 +452,41 @@ class TimbradoAPI:
 					},
 				)
 
-				return _apply_audit_warning(
-					writer_result,
-					{
-						"success": True,
-						"status_code": 200,
-						"raw_response": pac_response,
-						"uuid": uuid,
-						"factura_fiscal": factura_fiscal.name,
-						"message": "Factura timbrada exitosamente",  # Mensaje para UI
-					},
-				)
+				base_result = {
+					"success": True,
+					"status_code": 200,
+					"raw_response": pac_response,
+					"uuid": uuid,
+					"factura_fiscal": factura_fiscal.name,
+					"message": "Factura timbrada exitosamente",  # Mensaje para UI
+				}
+				# Corrección 6B2: si la persistencia principal del writer falló (PAC OK), verificar
+				# con lectura nueva de BD si la FASE 3 recuperó el estado. No se re-llama al PAC.
+				if _writer_persistence_failed(writer_result):
+					recovered = _verify_timbrado_persisted(factura_fiscal.name, response_data)
+					_alert_persistence_incident(
+						"timbrado", factura_fiscal.name, sales_invoice_name, recovered
+					)
+					return (
+						_persistence_recovered_result(base_result)
+						if recovered
+						else _persistence_unresolved_result(base_result)
+					)
+				return _apply_audit_warning(writer_result, base_result)
 
 			except FiscalCorrelationError:
 				# Corrección 6A: propagar la correlación crítica sin degradarla a error ordinario.
 				raise
 			except Exception as frappe_error:
+				# Corrección 6B2: si la persistencia principal del writer también falló, el estado
+				# fiscal no quedó confirmado por ninguna vía → intervención manual (no reintentar,
+				# no re-llamar al PAC). Si el writer SÍ persistió, se conserva el manejo existente.
+				if _writer_persistence_failed(writer_result):
+					_alert_persistence_incident(
+						"timbrado", factura_fiscal.name, sales_invoice_name, recovered=False
+					)
+					return _persistence_unresolved_result()
+
 				# PAC exitoso pero Frappe falló al actualizar
 				# Response Log YA tiene la respuesta correcta del PAC
 				frappe.log_error(
@@ -1472,28 +1603,48 @@ class TimbradoAPI:
 				# Obtener estados actualizados para response coherente
 				si_doc = frappe.get_doc("Sales Invoice", sales_invoice_name)
 
-				return _apply_audit_warning(
-					writer_result,
-					{
-						"ok": True,  # Para consistencia con propuesta UX
-						"success": True,  # Backward compatibility
-						"ffm": factura_fiscal.name,
-						"sales_invoice": sales_invoice_name,
-						"status_ffm": fiscal_status,  # Estado correcto basado en respuesta PAC
-						"status_si": si_doc.fm_fiscal_status,
-						"uuid": factura_fiscal.fm_uuid,
-						"cancellation_date": cancellation_date.strftime("%Y-%m-%d %H:%M:%S")
-						if cancellation_date
-						else None,
-						"message": "Solicitud de cancelación procesada exitosamente",
-					},
-				)
+				base_result = {
+					"ok": True,  # Para consistencia con propuesta UX
+					"success": True,  # Backward compatibility
+					"ffm": factura_fiscal.name,
+					"sales_invoice": sales_invoice_name,
+					"status_ffm": fiscal_status,  # Estado correcto basado en respuesta PAC
+					"status_si": si_doc.fm_fiscal_status,
+					"uuid": factura_fiscal.fm_uuid,
+					"cancellation_date": cancellation_date.strftime("%Y-%m-%d %H:%M:%S")
+					if cancellation_date
+					else None,
+					"message": "Solicitud de cancelación procesada exitosamente",
+				}
+				# Corrección 6B2: persistencia principal del writer fallida (PAC OK) → verificar si
+				# la FASE 3 dejó un estado legítimo de cancelación. No se re-llama al PAC.
+				if _writer_persistence_failed(writer_result):
+					recovered = _verify_cancelacion_persisted(factura_fiscal.name)
+					_alert_persistence_incident(
+						"cancelacion", factura_fiscal.name, sales_invoice_name, recovered
+					)
+					return (
+						_persistence_recovered_result(base_result)
+						if recovered
+						else _persistence_unresolved_result(base_result)
+					)
+				return _apply_audit_warning(writer_result, base_result)
 
 			except FiscalCorrelationError:
 				# Corrección 6A: propagar la correlación crítica; no crear Recovery Task que
 				# pueda repetir la operación.
 				raise
 			except Exception as frappe_error:
+				# Corrección 6B2: si la persistencia principal del writer también falló, el estado
+				# fiscal no quedó confirmado por ninguna vía → intervención manual. NO se crea
+				# Recovery Task ni se re-llama al PAC. Si el writer SÍ persistió, se conserva el
+				# manejo existente.
+				if _writer_persistence_failed(writer_result):
+					_alert_persistence_incident(
+						"cancelacion", factura_fiscal.name, sales_invoice_name, recovered=False
+					)
+					return _persistence_unresolved_result()
+
 				# PAC canceló exitosamente pero Frappe falló - CREAR RECOVERY TASK
 				frappe.log_error(
 					f"Error post-cancelación actualizando Frappe: {frappe_error}", "Post-Cancelación Error"
@@ -3368,15 +3519,27 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 
 	frappe.db.commit()  # nosemgrep: frappe-manual-commit - Required to persist status transition immediately after PAC response
 
-	return _apply_audit_warning(
-		writer_result,
-		{
-			"status": nuevo_estado,
-			"message": msg,
-			"indicator": indicator,
-			"cancellation_status": cancel_status,
-		},
-	)
+	base_result = {
+		"status": nuevo_estado,
+		"message": msg,
+		"indicator": indicator,
+		"cancellation_status": cancel_status,
+	}
+	# Corrección 6B2: si la persistencia principal del writer falló (PAC OK), verificar que el
+	# estado ya determinado por el flujo quedó persistido. No se repite la consulta al PAC.
+	if _writer_persistence_failed(writer_result):
+		recovered = _verify_estado_persisted(ffm_name, nuevo_estado)
+		_alert_persistence_incident("consulta", ffm_name, ffm.sales_invoice, recovered)
+		return (
+			_persistence_recovered_result(
+				base_result,
+				status="state_verified_after_writer_failure",
+				source="pre_writer_state_update",
+			)
+			if recovered
+			else _persistence_unresolved_result(base_result)
+		)
+	return _apply_audit_warning(writer_result, base_result)
 
 
 _ALLOWED_PDF_TEMPLATE_KEYS = frozenset({"company", "total", "due_date"})

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -114,6 +114,47 @@ def _raise_correlation_incident() -> None:
 	)
 
 
+def _audit_warning_message() -> str:
+	"""Mensaje visible NO bloqueante de auditoría incompleta (Corrección 6B1)."""
+	return _(
+		"La operación fiscal fue procesada correctamente, pero su registro de auditoría quedó "
+		"incompleto. No repita la operación. Se requiere revisión administrativa."
+	)
+
+
+def _apply_audit_warning(writer_result, user_result):
+	"""Adjuntar una advertencia NO bloqueante si la auditoría quedó incompleta (Corrección 6B1).
+
+	`write_pac_response` puede reportar `audit_log_failed` (no se creó el Response Log) o
+	`audit_log_ref_failed` (el log existe pero no quedó enlazado al FFM). En AMBOS casos la
+	operación fiscal SÍ se procesó: no se altera `success`, no se re-llama al PAC, no se crea
+	Recovery Task ni se reintenta. Se muestra una sola advertencia visible y se conserva la
+	diferencia técnica en el resultado (`audit_detail`). La evidencia detallada ya la registró
+	el writer; aquí NO se duplica esa alerta.
+	"""
+	if not isinstance(writer_result, dict):
+		return user_result
+
+	audit_failed = bool(writer_result.get("audit_log_failed"))
+	audit_ref_failed = bool(writer_result.get("audit_log_ref_failed"))
+	if not (audit_failed or audit_ref_failed):
+		return user_result
+
+	# Diferenciación técnica: el log no se creó vs. el log existe pero no se enlazó.
+	detail = "audit_log_failed" if audit_failed else "audit_log_ref_failed"
+
+	# Advertencia visible (no bloqueante). No revela UUID/facturapi_id/payload.
+	frappe.msgprint(_audit_warning_message(), title=_("Auditoría incompleta"), indicator="orange")
+
+	if isinstance(user_result, dict):
+		user_result.setdefault("success", True)
+		user_result["audit_warning"] = True
+		user_result["audit_status"] = "incomplete"
+		user_result["audit_detail"] = detail
+		user_result["audit_warning_message"] = _audit_warning_message()
+	return user_result
+
+
 class TimbradoAPI:
 	"""API para timbrado de facturas usando FacturAPI.io."""
 
@@ -203,7 +244,7 @@ class TimbradoAPI:
 				}
 
 				# Guardar Response Log INMEDIATAMENTE con respuesta REAL del PAC
-				write_pac_response(
+				writer_result = write_pac_response(
 					sales_invoice_name,
 					json.dumps(pac_request),
 					json.dumps(response_data),
@@ -299,14 +340,17 @@ class TimbradoAPI:
 					},
 				)
 
-				return {
-					"success": True,
-					"status_code": 200,
-					"raw_response": pac_response,
-					"uuid": uuid,
-					"factura_fiscal": factura_fiscal.name,
-					"message": "Factura timbrada exitosamente",  # Mensaje para UI
-				}
+				return _apply_audit_warning(
+					writer_result,
+					{
+						"success": True,
+						"status_code": 200,
+						"raw_response": pac_response,
+						"uuid": uuid,
+						"factura_fiscal": factura_fiscal.name,
+						"message": "Factura timbrada exitosamente",  # Mensaje para UI
+					},
+				)
 
 			except FiscalCorrelationError:
 				# Corrección 6A: propagar la correlación crítica sin degradarla a error ordinario.
@@ -1312,7 +1356,7 @@ class TimbradoAPI:
 				)
 
 				# Guardar Response Log INMEDIATAMENTE con respuesta REAL del PAC
-				write_pac_response(
+				writer_result = write_pac_response(
 					sales_invoice_name,
 					json.dumps(pac_request),
 					json.dumps(pac_response),  # ✅ Respuesta REAL del PAC
@@ -1428,19 +1472,22 @@ class TimbradoAPI:
 				# Obtener estados actualizados para response coherente
 				si_doc = frappe.get_doc("Sales Invoice", sales_invoice_name)
 
-				return {
-					"ok": True,  # Para consistencia con propuesta UX
-					"success": True,  # Backward compatibility
-					"ffm": factura_fiscal.name,
-					"sales_invoice": sales_invoice_name,
-					"status_ffm": fiscal_status,  # Estado correcto basado en respuesta PAC
-					"status_si": si_doc.fm_fiscal_status,
-					"uuid": factura_fiscal.fm_uuid,
-					"cancellation_date": cancellation_date.strftime("%Y-%m-%d %H:%M:%S")
-					if cancellation_date
-					else None,
-					"message": "Solicitud de cancelación procesada exitosamente",
-				}
+				return _apply_audit_warning(
+					writer_result,
+					{
+						"ok": True,  # Para consistencia con propuesta UX
+						"success": True,  # Backward compatibility
+						"ffm": factura_fiscal.name,
+						"sales_invoice": sales_invoice_name,
+						"status_ffm": fiscal_status,  # Estado correcto basado en respuesta PAC
+						"status_si": si_doc.fm_fiscal_status,
+						"uuid": factura_fiscal.fm_uuid,
+						"cancellation_date": cancellation_date.strftime("%Y-%m-%d %H:%M:%S")
+						if cancellation_date
+						else None,
+						"message": "Solicitud de cancelación procesada exitosamente",
+					},
+				)
 
 			except FiscalCorrelationError:
 				# Corrección 6A: propagar la correlación crítica; no crear Recovery Task que
@@ -3293,8 +3340,9 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 		frappe.db.set_value("Sales Invoice", ffm.sales_invoice, {"fm_fiscal_status": nuevo_estado})
 
 	# Registrar consulta en FacturAPI Response Log para trazabilidad
+	writer_result = None
 	try:
-		write_pac_response(
+		writer_result = write_pac_response(
 			sales_invoice_name=ffm.sales_invoice or "",
 			request_data=json.dumps(
 				{"action": "consulta_estatus", "ffm": ffm_name, "facturapi_id": ffm.facturapi_id}
@@ -3320,12 +3368,15 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 
 	frappe.db.commit()  # nosemgrep: frappe-manual-commit - Required to persist status transition immediately after PAC response
 
-	return {
-		"status": nuevo_estado,
-		"message": msg,
-		"indicator": indicator,
-		"cancellation_status": cancel_status,
-	}
+	return _apply_audit_warning(
+		writer_result,
+		{
+			"status": nuevo_estado,
+			"message": msg,
+			"indicator": indicator,
+			"cancellation_status": cancel_status,
+		},
+	)
 
 
 _ALLOWED_PDF_TEMPLATE_KEYS = frozenset({"company", "total", "due_date"})

--- a/facturacion_mexico/public/js/sales_invoice.js
+++ b/facturacion_mexico/public/js/sales_invoice.js
@@ -220,73 +220,42 @@ function _show_uuid_dialog(frm, callback) {
 }
 
 function _do_create_ffm(frm, extra_fields) {
-	let iva_total = 0;
-	let otros_impuestos = 0;
-
-	if (frm.doc.taxes && frm.doc.taxes.length > 0) {
-		frm.doc.taxes.forEach(function (tax) {
-			if (tax.account_head && tax.account_head.toUpperCase().includes("IVA")) {
-				iva_total += tax.tax_amount || 0;
-			} else {
-				otros_impuestos += tax.tax_amount || 0;
-			}
-		});
-	}
-
-	const doc = Object.assign(
-		{
-			doctype: "Factura Fiscal Mexico",
-			sales_invoice: frm.doc.name,
-			company: frm.doc.company,
-			customer: frm.doc.customer,
-			fm_fiscal_status: FISCAL_STATES ? FISCAL_STATES.states.BORRADOR : "BORRADOR",
-			si_total_antes_iva: frm.doc.net_total || 0,
-			si_total_neto: frm.doc.grand_total || 0,
-			si_iva: iva_total,
-			si_otros_impuestos: otros_impuestos,
-		},
-		extra_fields
-	);
-
+	// Corrección 3: la creación del FFM se centraliza en servidor mediante
+	// get_or_create_active_ffm. El cliente ya NO usa frappe.client.insert ni un
+	// set_value separado para vincular; el servidor crea (o reutiliza) el FFM,
+	// lo vincula a la Sales Invoice y devuelve su nombre.
 	frappe.call({
-		method: "frappe.client.insert",
-		args: { doc: doc },
+		method: "facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico.get_or_create_active_ffm",
+		args: {
+			sales_invoice: frm.doc.name,
+			extra_fields: extra_fields || {},
+		},
 		callback: function (r) {
 			if (r.message) {
-				frappe.call({
-					method: "frappe.client.set_value",
-					args: {
-						doctype: "Sales Invoice",
-						name: frm.doc.name,
-						fieldname: "fm_factura_fiscal_mx",
-						value: r.message.name,
+				const ffm_name = r.message;
+				frappe.show_alert(
+					{
+						message: __("Documento fiscal listo"),
+						indicator: "green",
 					},
-					callback: function () {
-						frappe.show_alert(
-							{
-								message: __("Documento fiscal creado exitosamente"),
-								indicator: "green",
-							},
-							3
-						);
+					3
+				);
 
-						setTimeout(() => {
-							window.location.href = `/app/factura-fiscal-mexico/${r.message.name}`;
-						}, 1000);
-					},
-				});
+				setTimeout(() => {
+					window.location.href = `/app/factura-fiscal-mexico/${ffm_name}`;
+				}, 1000);
 			} else {
 				frappe.msgprint({
 					title: __("Error"),
-					message: __("No se pudo crear el documento fiscal"),
+					message: __("No se pudo preparar el documento fiscal"),
 					indicator: "red",
 				});
 			}
 		},
 		error: function (r) {
 			frappe.msgprint({
-				title: __("Error al Crear Documento"),
-				message: r.message || __("Error desconocido al crear Factura Fiscal Mexico"),
+				title: __("Error al preparar documento"),
+				message: r.message || __("Error desconocido al preparar Factura Fiscal Mexico"),
 				indicator: "red",
 			});
 		},

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - adr/0031-migracion-settings-por-company.md
       - adr/0032-ereceipts-facturapi-arquitectura.md
       - adr/0033-factura-global-hardcodes.md
+      - adr/0034-integridad-correlacion-ffm.md
   - Referencia:
     - referencia/index.md
     - DocTypes: referencia/doctypes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,4 +59,4 @@ indent-style = "tab"
 
 [tool.interrogate]
 fail-under = 80
-exclude = ["facturacion_mexico/cfdi_recibidos/tests"]
+exclude = ["facturacion_mexico/cfdi_recibidos/tests", "facturacion_mexico/facturacion_fiscal/tests"]


### PR DESCRIPTION
## Objetivo

Corregir de raíz el incidente de integridad fiscal en que una Sales Invoice (SI) terminó con
dos Factura Fiscal Mexico (FFM) y una cancelación se aplicó al FFM equivocado. El bloque previene
la repetición del incidente y los defectos estructurales que lo permitieron. Documentado en ADR-0034.

## Cambios principales

11 correcciones de código (1 commit c/u) + 2 commits de documentación:

- `9d7353d` correlación estricta: la respuesta del PAC se asocia solo al FFM explícito (FFM.name).
- `13bdd97` estado fiscal persistido independiente del Response Log (savepoint aislado).
- `caed009` creación de FFM centralizada en servidor (`get_or_create_active_ffm`), elimina la creación en JS con `client.insert`.
- `d0b97ea` lock de fila sobre la SI (`for_update`) — serializa solicitudes concurrentes.
- `0bb8caf` Regla B (cardinalidad): un solo FFM activo por SI + guard `before_insert`.
- `c0c5e97` propagación de `FiscalCorrelationError` (detiene el flujo con mensaje seguro).
- `503bf15` persistencia correcta de TIMBRADO (UUID también en raw_response; persiste facturapi_id).
- `3430fae` advertencia no bloqueante ante auditoría incompleta.
- `2a92aea` manejo explícito del fallo de persistencia tras PAC OK (recuperación vía FASE 3, sin re-PAC).
- `2ac44ac` semántica coherente de `fm_sync_status` (synced/pending/error).
- `52676d7` refacturación 02/03/04 ya no se bloquea por `fm_sync_status='pending'`.
- `dde8203` + `c3f9d42` documentación: ADR-0034 + docs de usuario.

6 archivos productivos; +11 suites de prueba.

El flujo real de creación del FFM es el botón **"Timbrar Factura"** en el Sales Invoice, que llama
`get_or_create_active_ffm` en el servidor (crea o reutiliza; un solo FFM activo por SI).

## Documentación actualizada

- `docs/adr/0034-integridad-correlacion-ffm.md` (nuevo) — decisión arquitectónica completa.
- `docs/usuario/emitir-cfdi.md` — flujo real de creación del FFM (botón "Timbrar Factura").
- `docs/usuario/troubleshooting.md` — mensajes de excepción de correlación/auditoría/persistencia.
- `docs/adr/index.md`, `mkdocs.yml` — alta de la entrada 0034.

## Validaciones realizadas

- 127 pruebas automáticas OK sobre `dde8203` (110 del bloque + test_ffm_cancel_permissions 6, test_ffm_js_multisucursal_cleanup 6, test_layer1_double_facturation_prevention 5). Incluye concurrencia con multiprocessing.
- Cero tráfico PAC real: `FacturAPIClient` no es instanciable sin Company Settings; `test-facturacion.localhost` no las tiene. Suites corridas offline.
- `ruff check` + `ruff format --check`: limpio (16 .py).
- `prettier@2.7.1 --check`: limpio (sales_invoice.js).
- `mkdocs build --strict`: limpio.
- NO ejecutado: smoke test GUI en navegador (limitación CLI) — ver Riesgos.

## Fuera de alcance

- NO incluye motor automático de reconciliación FFM↔SAT (no existe; declarado en ADR-0034 §8). Feature separada.
- NO repara los 77 FFM `pending`.
- NO repara los 6 grupos con 2 FFM activos por SI.
- NO repara el caso incidente.
- NO despliega ni modifica producción.
- Bug menor preexistente: mensajes que citan un botón inexistente 'Generar Factura Fiscal' (`fiscal_operations.py`, `si_post_fiscal_actions.js`).
- `TypeError` defensivo en `_derive_status_from_response` (raw_response dict sin status_code).

## Riesgos / pendientes

- Cero cambios de esquema, patches o fixtures: la rama no requiere `migrate` por sí misma. Un `bench migrate` dispararía `after_migrate` (escribe datos) — evaluar por separado.
- Requiere `bench build` (assets JS) al desplegar.
- Smoke GUI en navegador **pendiente y obligatorio antes del despliegue** (no bloquea la revisión del PR).
- Los datos históricos divergentes siguen sin reparar (el bloque previene nuevos, no repara viejos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified FFM lifecycle: created on the first **“Timbrar Factura”** click, with **only one active FFM per Sales Invoice**.
  * Added troubleshooting guidance for fiscal integrity/correlation issues and recovery steps.
  * Published ADR **0034** on FFM↔PAC integrity and correlation.
* **New Features**
  * Added centralized, idempotent server-side creation/reuse of the active FFM.
  * Enforced strict PAC↔FFM correlation by explicit FFM name.
* **Bug Fixes**
  * Improved handling of PAC response persistence failures and recovery behavior.
  * Strengthened `fm_sync_status` semantics and timbrado UUID/facturapi ID persistence.
* **Tests**
  * Added extensive integration coverage for correlation, concurrency, and recovery scenarios.
* **Chores**
  * Updated code analysis exclusions for test modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->