### PR TITLE
feat(fiscal): motor de reconciliación FFM ↔ FacturAPI (GET-only) + verificación manual

### DIFF
--- a/docs/adr/0035-motor-reconciliacion-ffm.md
+++ b/docs/adr/0035-motor-reconciliacion-ffm.md
@@ -1,0 +1,146 @@
+# ADR-0035 — Motor de reconciliación FFM ↔ FacturAPI
+
+- **Estado:** Propuesto
+- **Fecha:** 2026-06-21
+- **Rama:** `feat/motor-reconciliacion-ffm`
+- **Relacionado:** [[0034-integridad-correlacion-ffm]] (integridad y correlación del FFM)
+
+---
+
+## 1. Contexto y problema
+
+Tras el bloque de integridad (ADR-0034), el estado local de una `Factura Fiscal Mexico` (FFM)
+puede **divergir** del estado real en FacturAPI/SAT por causas históricas o respuestas inconclusas:
+
+- ~70 FFM `TIMBRADO` con `fm_sync_status="pending"` (residuo del bug de doble FFM): ya tienen
+  `fm_uuid` y `facturapi_id` —están timbrados ante el PAC— pero el flag local quedó en `pending`.
+- Cancelaciones en `PENDIENTE_CANCELACION` cuyo desenlace (aceptación/rechazo/expiración) ocurre
+  más tarde y nadie vuelve a consultar.
+
+No existía un proceso que **consultara el PAC y alineara el estado local**. ADR-0034 declaró
+expresamente que el motor de reconciliación NO formaba parte de ese bloque.
+
+## 2. Decisión
+
+Implementar un motor que **consulta** FacturAPI por **GET** y reconcilia el estado local del FFM,
+reutilizando la infraestructura de ADR-0034 (correlación estricta, writer, Response Log).
+
+**Principio rector:** el PAC es la fuente de verdad. El motor **solo lee**. Nunca timbra, cancela
+ni sustituye CFDI, y nunca cancela la Sales Invoice.
+
+### 2.1 Alcance inicial
+Selector acotado a los FFM que necesitan seguimiento:
+
+```
+facturapi_id != ''  AND  (fm_sync_status = 'pending'  OR  status = 'PENDIENTE_CANCELACION')
+```
+
+Fuera de alcance: barrido del histórico completo, `fm_sync_status='error'`, reparación de
+duplicados, archivado de huérfanos.
+
+### 2.2 Operación contra el PAC
+Exclusivamente `GET /invoices/{facturapi_id}`, vía `FacturAPIClient.get_invoice(ffm.facturapi_id)`.
+**Prohibido:** `create_invoice`, `cancel_invoice`, cualquier POST/DELETE, timbrado o sustitución.
+El cliente se construye con la compañía del FFM: `get_facturapi_client(company=ffm.company)`.
+
+### 2.3 Identidad y correlación estricta
+La reconciliación inicia con un `FFM.name` explícito; nunca se busca otro FFM por Sales Invoice,
+UUID, folio o serie. Antes de decidir si hay cambios, se valida la correlación (reutilizando
+`_resolve_validated_ffm` de ADR-0034): `response.id == ffm.facturapi_id` y `response.uuid ==
+ffm.fm_uuid` (UUID normalizado). Ante contradicción → no se toca el estado fiscal, `fm_sync_status
+= error`, y se preserva/registra `FiscalCorrelationError`.
+
+### 2.4 Helper único de mapeo
+`derive_pac_reconciliation(remote_status, cancellation_status) -> (estado_fiscal | None, fm_sync_status)`
+en `facturacion_mexico/config/fiscal_states_config.py`. Es la **única fuente de verdad** del mapeo,
+compartida por `cancelar_factura` (FASE 3), `revisar_estatus_cancelacion` y el motor.
+
+| Estado remoto | Estado local | `fm_sync_status` |
+|---|---|---|
+| `valid` + sin cancelación | `TIMBRADO` (vigente) | `synced` |
+| `valid` + `pending`/`verifying` | `PENDIENTE_CANCELACION` | `synced` |
+| `valid` + `rejected`/`expired` | `TIMBRADO` | `synced` |
+| `accepted` / `canceled` | `CANCELADO` | `synced` |
+| `pending` (remoto no definitivo) | sin transición | `pending` |
+| `draft`/desconocido | sin transición | `error` |
+
+Precedencia: `status==canceled` manda sobre cualquier `cancellation_status` contradictorio.
+
+### 2.5 Semántica de campos
+- **`fm_sync_status`:** `synced` (respuesta concluyente reflejada) · `pending` (inconclusa:
+  timeout/429/5xx/remoto pending) · `error` (no reintentable: 4xx, identidad contradictoria,
+  estado desconocido).
+- **`fm_last_pac_sync`** (Datetime): se actualiza **exclusivamente** cuando el GET fue exitoso y
+  correlacionado con el mismo FFM (cambio o no-op). En **cualquier fallo de consulta** se conserva
+  el valor anterior.
+
+### 2.6 Persistencia y Response Log
+- **Cambio** de `status`/`fm_sync_status` → `write_pac_response(operation_type="reconciliacion")`:
+  persiste el FFM y crea Response Log correlacionado.
+- **Sin cambios (no-op)** → solo se sella `fm_last_pac_sync`; **no** se crea Response Log.
+- **Error/contradicción** → se registra (Response Log para errores HTTP; alerta crítica para
+  contradicción de identidad) y se fija `fm_sync_status`, conservando `fm_last_pac_sync`.
+
+### 2.7 Selector, lote y scheduler
+- `BATCH_SIZE = 100`. Prioridad: `PENDIENTE_CANCELACION`, luego `pending`, luego `fm_last_pac_sync`
+  más antiguo, luego `name`.
+- Scheduler: una tarea en **`hourly_long`** → `run_auto_reconciliation`. Un FFM fallido no detiene
+  el lote.
+
+### 2.8 Verificación manual
+Botón **"Verificar estado en FacturAPI"** (grupo **Comprobantes**) en el FFM, visible solo cuando
+el documento está guardado y tiene `facturapi_id`. Llama al mismo núcleo (`reconcile_ffm` →
+`_reconcile_ffm`). El JavaScript no contiene lógica fiscal: solo consulta, muestra el resultado y
+recarga. El endpoint `reconcile_ffm` está whitelisted y exige el **mismo permiso fiscal que la
+cancelación** (`frappe.only_for(System Manager / Facturacion Mexico System Manager / Manager)`).
+
+### 2.9 Concurrencia (locks)
+Locks de cache (Redis), no bloqueantes, con TTL, liberados en `finally`:
+- Lote: `facturacion_mexico:ffm_auto_reconciliation` (TTL 2 h).
+- Por-FFM: `facturacion_mexico:ffm_reconciliation:<name>` (TTL 5 min) — evita la carrera
+  scheduler/botón sobre el mismo FFM.
+
+Liberación con **compare-and-delete atómico** (script Lua): solo se borra la clave si su valor
+sigue siendo el token del dueño, evitando que un proceso cuyo lock expiró borre el lock de otro.
+
+### 2.10 Sin configuración, campos ni DocTypes nuevos
+No se agrega campo de activación, ni nuevos campos, ni DocTypes, ni patches, ni fixtures, ni
+cambios de esquema. El único cambio de despliegue es registrar el evento `hourly_long`.
+
+## 3. Consecuencias
+
+- Los ~70 FFM `TIMBRADO+pending` se reconcilian a `synced` al confirmar `valid` con el PAC.
+- Las cancelaciones `PENDIENTE_CANCELACION` se resuelven solas hasta su estado terminal.
+- **`expired` quedó unificado a `TIMBRADO`** en los tres flujos (antes la cancelación caía a
+  `PENDIENTE_CANCELACION`). `accepted → CANCELADO` se conserva.
+- El refactor de unificación toca `timbrado_api.py` (flujo de cancelación productivo): la suite de
+  regresión de ADR-0034 es la red de seguridad.
+
+## 4. Riesgos operativos y despliegue
+
+`bench migrate` registra `hourly_long`; con el scheduler habilitado, **el motor empieza a correr
+solo (cada hora) y a hacer GET reales contra FacturAPI**. Por eso el despliegue y la habilitación
+del scheduler deben hacerse **únicamente cuando se autorice iniciar ese tráfico GET**. La primera
+prueba será local y controlada en `llantascs-v16.dev` (backup de producción). `hourly_long` corre
+para todas las companies con FFM pendientes; si una no tiene credenciales, el aislamiento por-FFM
+evita que rompa el lote.
+
+## 5. Alternativas descartadas
+
+- **Modo dry-run:** descartado; el botón individual + el flag por respuesta concluyente cubren la
+  necesidad de verificación previa sin un modo separado.
+- **Nuevo DocType de log:** descartado; se reutiliza `FacturAPI Response Log`.
+- **Búsqueda del FFM por Sales Invoice:** descartado; viola la correlación estricta de ADR-0034.
+- **Barrido completo de todos los FFM:** descartado; el alcance se acota a los que necesitan
+  seguimiento.
+- **Botones con lógica fiscal en JavaScript:** descartado; toda la decisión fiscal y la seguridad
+  viven en el servidor.
+
+## 6. Despliegue (resumen)
+```
+bench --site <site> migrate            # registra hourly_long (a partir de aquí el motor puede correr solo)
+bench build --app facturacion_mexico   # compila el asset JS del botón
+bench --site <site> clear-cache
+```
+Habilitar el scheduler solo cuando se autorice el tráfico GET. No ejecutar una corrida PAC real
+durante el desarrollo de esta feature.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -38,3 +38,4 @@ Registro permanente de decisiones de arquitectura. Un ADR nunca se modifica — 
 | [0032](0032-ereceipts-facturapi-arquitectura.md) | Arquitectura E-Receipts — FacturAPI como motor fiscal, ERPNext como trazabilidad |
 | [0033](0033-factura-global-hardcodes.md) | Eliminación de defaults fiscales silenciosos en Factura Global |
 | [0034](0034-integridad-correlacion-ffm.md) | Integridad y correlación de Factura Fiscal Mexico |
+| [0035](0035-motor-reconciliacion-ffm.md) | Motor de reconciliación FFM ↔ FacturAPI |

--- a/docs/usuario/verificar-estado-facturapi.md
+++ b/docs/usuario/verificar-estado-facturapi.md
@@ -1,0 +1,65 @@
+# Verificar estado en FacturAPI
+
+El sistema mantiene sincronizado el estado de cada **Factura Fiscal Mexico (FFM)** con FacturAPI
+de dos formas: **automáticamente** (una revisión periódica) y **manualmente** (un botón en el FFM).
+En ambos casos el sistema **solo consulta** a FacturAPI: nunca timbra, cancela ni modifica la venta.
+
+---
+
+## Verificación manual (botón)
+
+1. Abre la **Factura Fiscal Mexico** que quieres revisar.
+2. En la barra de botones, entra al grupo **Comprobantes**.
+3. Pulsa **"Verificar estado en FacturAPI"**.
+
+El botón **solo aparece** cuando la FFM ya está **guardada** y tiene un comprobante en FacturAPI
+(`facturapi_id`). Al pulsarlo, el sistema consulta el estado real en FacturAPI, actualiza la FFM si
+corresponde y **recarga el documento** para mostrar el estado al día.
+
+> El botón **no cancela la Sales Invoice**. Si la verificación confirma que el CFDI quedó
+> **CANCELADO**, después puedes cancelar la Sales Invoice con el procedimiento normal.
+
+### Resultados posibles
+
+| Mensaje | Significa |
+|---|---|
+| **Sin cambios** | El estado local ya coincidía con FacturAPI. |
+| **Estado actualizado** | La FFM se actualizó con el estado real del PAC. |
+| **Cancelación pendiente** | La cancelación sigue en proceso (esperando al receptor). |
+| **Cancelación aceptada** | El CFDI quedó cancelado. |
+| **Cancelación rechazada** | El receptor rechazó la cancelación; el CFDI sigue vigente. |
+| **Cancelación expirada** | La cancelación no procedió; el CFDI sigue vigente. |
+| **Verificación ya en proceso** | Otra revisión (manual o automática) ya está consultando esta FFM. Espera un momento. |
+| **Error de reconciliación** | No se pudo confirmar el estado (problema de conexión o de validación). Reintenta más tarde o reporta a soporte. |
+
+---
+
+## Verificación automática
+
+El sistema revisa periódicamente las FFM que necesitan seguimiento (las que tienen sincronización
+**pendiente** o una **cancelación en curso**) y las pone al día sin intervención. No requiere acción
+del usuario.
+
+---
+
+## Despliegue (administradores)
+
+La verificación automática se registra al desplegar la app:
+
+```bash
+bench --site <site> migrate
+bench build --app facturacion_mexico
+bench --site <site> clear-cache
+```
+
+⚠️ **Advertencia importante:**
+
+- `migrate` **registra la tarea automática** (`hourly_long`).
+- Con el **scheduler habilitado**, el motor puede **empezar a ejecutar consultas reales (GET)
+  contra FacturAPI**.
+- Por eso, **desplegar y habilitar el scheduler solo cuando se autorice iniciar ese tráfico** hacia
+  FacturAPI.
+- **No ejecutar una corrida real contra FacturAPI durante tareas de desarrollo o pruebas.**
+
+`bench build` es necesario para que el botón **"Verificar estado en FacturAPI"** quede disponible
+en la interfaz.

--- a/facturacion_mexico/config/fiscal_states_config.py
+++ b/facturacion_mexico/config/fiscal_states_config.py
@@ -229,6 +229,65 @@ def get_state_from_facturapi(facturapi_status):
 	return FACTURAPI_STATE_MAPPING.get(facturapi_status, FiscalStates.ERROR)
 
 
+def derive_pac_reconciliation(remote_status, cancellation_status):
+	"""Mapeo ÚNICO de la respuesta del PAC a (estado_fiscal, fm_sync_status).
+
+	Fuente única de verdad usada por: cancelar_factura FASE 3, revisar_estatus_cancelacion y el
+	motor de reconciliación. Los flujos de cancelación consumen solo el estado fiscal ([0]); el
+	motor usa ambos.
+
+	Args:
+	    remote_status: campo `status` del invoice en FacturAPI (valid/canceled/pending/draft...).
+	    cancellation_status: campo `cancellation_status` (none/pending/verifying/accepted/rejected/expired).
+
+	Returns:
+	    tuple (estado_fiscal | None, fm_sync_status):
+	    - estado_fiscal None significa "no cambiar el estado fiscal".
+	    - fm_sync_status es uno de SyncStates (synced/pending/error).
+
+	Precedencia OBLIGATORIA (un CFDI `canceled` manda sobre cualquier `cancellation_status`
+	contradictorio, p. ej. `canceled + rejected` -> CANCELADO):
+
+	    1. status == canceled                      -> (CANCELADO, synced)
+	    2. cancellation_status == accepted         -> (CANCELADO, synced)   # incl. status ausente
+	    3. status == valid + pending/verifying     -> (PENDIENTE_CANCELACION, synced)
+	    4. status == valid + rejected/expired      -> (TIMBRADO, synced)
+	    5. status == valid + none/vacío            -> (TIMBRADO, synced)
+	    6. status == pending                       -> (None, pending)
+	    7. cualquier otra combinación              -> (None, error)
+
+	Las respuestas reales de FacturAPI (get_invoice / query_pac_status) siempre traen `status`.
+	"""
+	rs = (remote_status or "").strip().lower()
+	cs = (cancellation_status or "").strip().lower()
+
+	# 1. CFDI cancelado de forma definitiva: manda sobre cualquier cancellation_status.
+	if rs == "canceled":
+		return FiscalStates.CANCELADO, SyncStates.SYNCED
+
+	# 2. Cancelación aceptada por el receptor (incl. status ausente): conserva el comportamiento
+	#    productivo (query_pac_status / FASE 3) y test_06_consulta_recuperada.
+	if cs == "accepted":
+		return FiscalStates.CANCELADO, SyncStates.SYNCED
+
+	# 3-5. CFDI vigente: el desenlace depende del estado de la cancelación.
+	if rs == "valid":
+		if cs in ("pending", "verifying"):
+			return FiscalStates.PENDIENTE_CANCELACION, SyncStates.SYNCED
+		if cs in ("rejected", "expired"):
+			return FiscalStates.TIMBRADO, SyncStates.SYNCED
+		if cs in ("", "none"):
+			return FiscalStates.TIMBRADO, SyncStates.SYNCED
+		return None, SyncStates.ERROR
+
+	# 6. Estado remoto aún no definitivo (sigue procesándose en el PAC): reintentar.
+	if rs == "pending":
+		return None, SyncStates.PENDING
+
+	# 7. Cualquier otra combinación (draft, status ausente con cancelación no concluyente, etc.).
+	return None, SyncStates.ERROR
+
+
 def get_complete_config():
 	"""
 	Retorna configuración completa para uso en APIs.

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -17,6 +17,8 @@ import frappe
 from frappe import _
 from frappe.utils import add_to_date, now, now_datetime
 
+from facturacion_mexico.config.fiscal_states_config import derive_pac_reconciliation
+
 # Directorio fallback para respuestas PAC cuando DB no disponible
 # Usar directorio sites para compatibilidad multi-sitio
 FALLBACK_DIR = None  # Se calcula dinámicamente por sitio
@@ -78,6 +80,17 @@ def _extract_response_identifiers(response_data: dict) -> tuple[str, str]:
 	return uuid, facturapi_id
 
 
+def _extract_reconciliation_states(response_data: dict) -> tuple[str, str]:
+	"""Extraer (status, cancellation_status) de una respuesta de get_invoice (top-level o raw_response)."""
+	if not isinstance(response_data, dict):
+		return "", ""
+	raw = response_data.get("raw_response")
+	raw = raw if isinstance(raw, dict) else {}
+	status = response_data.get("status") or raw.get("status") or ""
+	cancellation = response_data.get("cancellation_status") or raw.get("cancellation_status") or ""
+	return status, cancellation
+
+
 def _derive_sync_status_from_response(response_data: dict, operation_type: str) -> str | None:
 	"""Derivar fm_sync_status según si el PAC dio una respuesta CONCLUYENTE persistida (7A1).
 
@@ -96,6 +109,23 @@ def _derive_sync_status_from_response(response_data: dict, operation_type: str) 
 	# del PAC. operation_type viene como "fiscal_event_*". No tocar fm_sync_status.
 	if isinstance(operation_type, str) and operation_type.startswith("fiscal_event_"):
 		return None
+
+	# Reconciliación: ante respuesta PAC exitosa, el sync lo decide el helper único (no se duplica
+	# la matriz). Si la respuesta NO es exitosa (error/timeout) cae a la lógica genérica de abajo,
+	# conservando su semántica existente.
+	if (
+		operation_type == "reconciliacion"
+		and isinstance(response_data, dict)
+		and response_data.get("success") is True
+	):
+		sc = response_data.get("status_code")
+		try:
+			code = int(sc) if sc is not None else 0
+		except (TypeError, ValueError):
+			code = 0
+		if code in (200, 201):
+			rs, cs = _extract_reconciliation_states(response_data)
+			return derive_pac_reconciliation(rs, cs)[1]
 
 	if not isinstance(response_data, dict):
 		return "pending"
@@ -446,6 +476,9 @@ class PACResponseWriter:
 			"cancelacion": "Solicitud Cancelación",
 			"consulta": "Consulta Estado",
 			"timeout_recovery": "Consulta Estado",
+			# La reconciliación es una consulta de estado; se registra como tal en el Select del
+			# Response Log (no hay opción dedicada y este paso no modifica esquema).
+			"reconciliacion": "Consulta Estado",
 		}
 
 		# Helper para extraer código de estado del mensaje de error
@@ -619,6 +652,7 @@ class PACResponseWriter:
 				"cancelacion": "Solicitud Cancelación",
 				"consulta": "Consulta Estado",
 				"timeout_recovery": "Consulta Estado",
+				"reconciliacion": "Reconciliacion",
 			}.get(operation_type, operation_type)
 			new_status, _status_code, uuid = self._derive_status_from_response(response_data, _normalized_op)
 
@@ -755,6 +789,19 @@ class PACResponseWriter:
 			if ok and status_code in (200, 201):
 				return "CANCELADO", status_code, ""
 			# ERROR EN CANCELACIÓN: NO cambiar estado fiscal (return None = no update)
+			return None, status_code or 500, ""
+
+		elif operation_type == "Reconciliacion":
+			# Motor de reconciliación: SOLO ante respuesta PAC exitosa se delega en el helper único
+			# derive_pac_reconciliation (no se duplica la matriz de estados aquí). Errores HTTP,
+			# timeout y contradicciones conservan su semántica (esta rama no los reinterpreta).
+			if ok and status_code in (200, 201):
+				rs, cs = _extract_reconciliation_states(resp)
+				fiscal_status, _sync = derive_pac_reconciliation(rs, cs)
+				# fiscal_status None => no se cambia el estado fiscal. No se toca fm_uuid (el FFM ya
+				# lo tiene y la correlación estricta lo validó antes de llegar aquí).
+				return fiscal_status, status_code, ""
+			# Respuesta no exitosa: no cambiar estado fiscal (el sync lo decide la lógica existente).
 			return None, status_code or 500, ""
 
 		else:

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -795,14 +795,19 @@ class PACResponseWriter:
 			# Motor de reconciliación: SOLO ante respuesta PAC exitosa se delega en el helper único
 			# derive_pac_reconciliation (no se duplica la matriz de estados aquí). Errores HTTP,
 			# timeout y contradicciones conservan su semántica (esta rama no los reinterpreta).
-			if ok and status_code in (200, 201):
+			# status_code se normaliza a int (puede llegar como "200") para no caer fuera del rango.
+			try:
+				code = int(status_code) if status_code is not None else 0
+			except (TypeError, ValueError):
+				code = 0
+			if ok and code in (200, 201):
 				rs, cs = _extract_reconciliation_states(resp)
 				fiscal_status, _sync = derive_pac_reconciliation(rs, cs)
 				# fiscal_status None => no se cambia el estado fiscal. No se toca fm_uuid (el FFM ya
 				# lo tiene y la correlación estricta lo validó antes de llegar aquí).
-				return fiscal_status, status_code, ""
+				return fiscal_status, code, ""
 			# Respuesta no exitosa: no cambiar estado fiscal (el sync lo decide la lógica existente).
-			return None, status_code or 500, ""
+			return None, code or 500, ""
 
 		else:
 			# Otras operaciones (consulta, etc): no cambian estado fiscal

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -2712,6 +2712,51 @@ function validate_billing_data_visual(frm) {
 					__("Acciones")
 				);
 			}
+
+			// Paso 5: verificación manual de estado contra FacturAPI (reconciliación).
+			// Visible para cualquier FFM guardado con identidad remota (facturapi_id), sin importar
+			// su estado de sync/cancelación. La seguridad real está en el servidor: reconcile_ffm
+			// exige el permiso fiscal. El JS SOLO consulta, muestra el resultado y recarga; no
+			// interpreta status/cancellation_status, no decide estados ni escribe campos.
+			if (!frm.is_new() && frm.doc.facturapi_id) {
+				frm.add_custom_button(
+					__("Verificar estado en FacturAPI"),
+					async () => {
+						// freeze: true congela la interfaz e impide el doble clic durante la consulta.
+						const r = await frappe.call({
+							method: "facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.reconcile_ffm",
+							args: { ffm_name: frm.doc.name },
+							freeze: true,
+							freeze_message: __("Consultando FacturAPI..."),
+						});
+						const res = (r && r.message) || {};
+						// Mensajes según el `outcome` que ya devuelve el servidor (no se duplica la
+						// matriz fiscal; solo se traduce el resultado a un texto breve).
+						const MENSAJES = {
+							changed: __("Estado actualizado."),
+							unchanged: __("Sin cambios."),
+							locked: __("Verificación ya en proceso."),
+							pending: __("Pendiente de nueva consulta."),
+							error: __("Error de reconciliación."),
+						};
+						const indicador =
+							res.outcome === "changed"
+								? "green"
+								: res.outcome === "error"
+								? "red"
+								: "blue";
+						frappe.show_alert(
+							{
+								message: MENSAJES[res.outcome] || __("Verificación completada."),
+								indicator: indicador,
+							},
+							ALERT_DURATION_DEFAULT
+						);
+						frm.reload_doc();
+					},
+					__("Comprobantes")
+				);
+			}
 		},
 	});
 })(); // Cierre del IIFE

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -1598,11 +1598,12 @@
 			"fm_serie_folio", // Serie y Folio custom field (si existe)
 		];
 
-		// Campos de archivos fiscales
-		const fiscal_files_fields = [
-			"pdf_file", // Archivo PDF
-			"xml_file", // Archivo XML
-		];
+		// Campos de archivos fiscales.
+		// pdf_file/xml_file quedan ocultos siempre vía hidden:1 en el DocType: son
+		// ligas redundantes al adjunto. El archivo real sigue accesible por el panel
+		// de Adjuntos y el botón "Descargar PDF+XML". Por eso esta lista va vacía:
+		// la visibilidad por estado ya no debe re-exponer esos campos.
+		const fiscal_files_fields = [];
 
 		// Campos y sección de cancelación (Punto 9)
 		const cancellation_fields = [

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -329,6 +329,28 @@
 		frm.dashboard.set_headline_alert(primary.text, level_color[primary.level] || "grey");
 	}
 
+	function render_sync_badge(frm) {
+		// Semáforo inline para fm_sync_status: resalta 'pending'.
+		// Pinta una indicator-pill nativa de Frappe en el campo HTML fm_sync_status_badge.
+		const field = frm.fields_dict && frm.fields_dict.fm_sync_status_badge;
+		if (!field) return;
+		const map = {
+			synced: { color: "green", label: __("Sincronizado") },
+			pending: { color: "orange", label: __("Pendiente") },
+			error: { color: "red", label: __("Error de sincronización") },
+		};
+		const cfg = map[frm.doc.fm_sync_status];
+		if (!cfg) {
+			field.$wrapper.html("");
+			return;
+		}
+		field.$wrapper.html(
+			`<span class="indicator-pill ${cfg.color}">${frappe.utils.escape_html(
+				cfg.label
+			)}</span>`
+		);
+	}
+
 	function freeze_fiscal_fields_after_submit(frm) {
 		/**
 		 * Bloquear campos fiscales críticos después de Submit
@@ -390,6 +412,9 @@
 		refresh: function (frm) {
 			// Controlar visibilidad del checkbox Venta Mostrador según el customer
 			_update_venta_mostrador_visibility(frm);
+
+			// Semáforo de sincronización (badge inline)
+			render_sync_badge(frm);
 
 			// Poblar opciones SAT desde el servidor
 			if (!frm._sat_opts_loaded) {

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -32,6 +32,7 @@
   "fm_direccion_principal_display",
   "column_break_basic",
   "fecha_timbrado",
+  "fm_pdf_custom_section",
   "section_break_facturapi",
   "facturapi_id",
   "fm_cfdi_use",
@@ -50,20 +51,20 @@
   "si_otros_impuestos",
   "si_total_neto",
   "section_break_archivos",
-  "pdf_file",
-  "xml_file",
   "section_break_cancelacion",
   "cancellation_reason",
   "cancellation_date",
-  "fm_last_pac_sync",
-  "fm_sync_status",
-  "fm_sync_error",
   "section_break_urls_archivos",
-  "fm_xml_url",
-  "fm_pdf_url",
+  "fm_sync_status",
+  "fm_last_pac_sync",
+  "fm_sync_error",
+  "column_break_sincronizacion",
   "fm_last_response_log",
   "fm_creation_source",
-  "fm_pdf_custom_section"
+  "pdf_file",
+  "xml_file",
+  "fm_pdf_url",
+  "fm_xml_url"
  ],
  "fields": [
   {
@@ -304,6 +305,7 @@
    "description": "Archivo PDF de la factura",
    "fieldname": "pdf_file",
    "fieldtype": "Attach",
+   "hidden": 1,
    "label": "Archivo PDF",
    "read_only": 1
   },
@@ -311,6 +313,7 @@
    "description": "Archivo XML de la factura",
    "fieldname": "xml_file",
    "fieldtype": "Attach",
+   "hidden": 1,
    "label": "Archivo XML",
    "read_only": 1
   },
@@ -418,9 +421,13 @@
    "read_only": 1
   },
   {
+   "fieldname": "column_break_sincronizacion",
+   "fieldtype": "Column Break"
+  },
+  {
    "fieldname": "section_break_urls_archivos",
    "fieldtype": "Section Break",
-   "label": "URLs y Referencias"
+   "label": "Sincronización y Referencias"
   },
   {
    "fieldname": "fm_xml_url",
@@ -428,6 +435,7 @@
    "label": "URL del XML",
    "description": "Link directo al archivo XML o URL de verificación SAT",
    "allow_on_submit": 1,
+   "hidden": 1,
    "read_only": 1
   },
   {
@@ -436,6 +444,7 @@
    "label": "URL del PDF",
    "description": "Link directo al archivo PDF",
    "allow_on_submit": 1,
+   "hidden": 1,
    "read_only": 1
   },
   {

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -56,6 +56,7 @@
   "cancellation_date",
   "section_break_urls_archivos",
   "fm_sync_status",
+  "fm_sync_status_badge",
   "fm_last_pac_sync",
   "fm_sync_error",
   "column_break_sincronizacion",
@@ -411,6 +412,12 @@
    "allow_on_submit": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "fm_sync_status_badge",
+   "fieldtype": "HTML",
+   "label": "Semáforo de Sincronización",
+   "allow_on_submit": 1
   },
   {
    "fieldname": "fm_sync_error",

--- a/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
@@ -1,0 +1,270 @@
+"""Motor de reconciliación FFM ↔ FacturAPI (Paso 3).
+
+Consulta FacturAPI por GET (solo lectura) y reconcilia el estado local del FFM con el estado
+real del PAC, reutilizando: derive_pac_reconciliation (mapeo único), la correlación estricta del
+writer (_resolve_validated_ffm) y write_pac_response (persistencia + Response Log independientes).
+
+Garantías: nunca create_invoice / cancel_invoice; nunca busca otro FFM por Sales Invoice; nunca
+cancela ni guarda la Sales Invoice; sin scheduler/hooks/JS/botón en este paso.
+
+Entradas:
+    run_auto_reconciliation(limit=None)  -> scheduler / ejecución manual por lote.
+    reconcile_ffm(ffm_name)              -> whitelisted (futuro botón), con permiso fiscal.
+    _reconcile_ffm(ffm_name)             -> núcleo común (manual y lote ejecutan exactamente esto).
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import now_datetime
+
+from facturacion_mexico.config.fiscal_states_config import SyncStates, derive_pac_reconciliation
+from facturacion_mexico.facturacion_fiscal.api import (
+	FiscalCorrelationError,
+	PACResponseWriter,
+	_extract_reconciliation_states,
+)
+from facturacion_mexico.facturacion_fiscal.api_client import get_facturapi_client
+
+
+def _write_pac_response(sales_invoice_name, request_data, response_data, factura_fiscal_name):
+	"""Persistir vía el writer (método, acepta dicts) con operation_type='reconciliacion'.
+
+	Se usa el método del writer y NO la función whitelisted pública (que exige str por type-hints).
+	"""
+	return PACResponseWriter().write_pac_response(
+		sales_invoice_name,
+		request_data,
+		response_data,
+		"reconciliacion",
+		factura_fiscal_name=factura_fiscal_name,
+	)
+
+
+BATCH_SIZE = 100
+
+# Locks de cache (Redis), no bloqueantes, con TTL. Liberados siempre en finally.
+LOCK_BATCH = "facturacion_mexico:ffm_auto_reconciliation"
+LOCK_BATCH_TTL = 2 * 60 * 60  # 2 horas
+LOCK_FFM_PREFIX = "facturacion_mexico:ffm_reconciliation:"
+LOCK_FFM_TTL = 5 * 60  # 5 minutos
+
+# Roles autorizados a cancelar/reconciliar fiscalmente (idénticos a cancel_ffm_keep_si — PR #197).
+FISCAL_ROLES = ("System Manager", "Facturacion Mexico System Manager", "Facturacion Mexico Manager")
+
+
+def _lock_key(key: str) -> str:
+	"""Namespacing por sitio para evitar colisiones en benches multi-sitio."""
+	return f"{frappe.local.site}:{key}"
+
+
+# Compare-and-delete atómico: solo borra la clave si su valor sigue siendo el token del dueño.
+# Evita que un proceso cuyo lock expiró borre el lock que otro proceso ya adquirió.
+_RELEASE_LUA = (
+	"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+
+def _acquire_lock(key: str, ttl: int) -> str | None:
+	"""Adquisición atómica no bloqueante (Redis SET NX EX). Devuelve el token si se obtuvo el lock,
+	o None si ya estaba ocupado. El token identifica al dueño para una liberación segura."""
+	token = frappe.generate_hash(length=16)
+	if frappe.cache().set(_lock_key(key), token, nx=True, ex=ttl):
+		return token
+	return None
+
+
+def _release_lock(key: str, token: str | None) -> None:
+	"""Libera el lock SOLO si su valor actual coincide con `token` (compare-and-delete atómico)."""
+	if not token:
+		return
+	frappe.cache().eval(_RELEASE_LUA, 1, _lock_key(key), token)
+
+
+def _classify_http_error(status_code: int) -> str:
+	"""Transitorio (reintentable) -> pending; permanente -> error."""
+	if status_code == 429 or status_code >= 500:
+		return SyncStates.PENDING
+	return SyncStates.ERROR  # 401/403/404 y demás 4xx
+
+
+def _log_and_set_sync(ffm, response_data: dict, sync_status: str) -> None:
+	"""Registra el GET (Response Log, vía writer) y fija fm_sync_status al valor clasificado.
+
+	Se reutiliza write_pac_response para no duplicar la creación del log ni la correlación. En una
+	respuesta de error no hay identificadores, por lo que no dispara FiscalCorrelationError. El
+	estado fiscal NO cambia (el branch 'reconciliacion' del writer devuelve None salvo 2xx).
+	"""
+	_write_pac_response(
+		ffm.sales_invoice or "",
+		{"action": "reconciliacion", "facturapi_id": ffm.facturapi_id},
+		response_data,
+		ffm.name,
+	)
+	# El writer deriva fm_sync_status con su lógica genérica para no-2xx; aquí se impone la
+	# clasificación de reconciliación (p. ej. 404 -> error, no 'synced').
+	frappe.db.set_value("Factura Fiscal Mexico", ffm.name, "fm_sync_status", sync_status)
+
+
+def _reconcile_ffm(ffm_name: str) -> dict:
+	"""Núcleo: consulta el PAC para UN FFM y reconcilia. No hace búsquedas alternativas."""
+	ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
+
+	lock = LOCK_FFM_PREFIX + ffm_name
+	token = _acquire_lock(lock, LOCK_FFM_TTL)
+	if not token:
+		return {"ffm": ffm_name, "outcome": "locked"}
+
+	try:
+		if not ffm.facturapi_id:
+			return {"ffm": ffm_name, "outcome": "skipped", "reason": "sin_facturapi_id"}
+
+		# Cliente de la compañía del FFM (puede lanzar si la company no tiene credenciales).
+		client = get_facturapi_client(company=ffm.company)
+
+		# Única operación contra el PAC: GET por facturapi_id.
+		try:
+			response = client.get_invoice(ffm.facturapi_id)
+		except frappe.ValidationError as exc:
+			# FacturAPIClient adjunta la respuesta HTTP a la excepción (.response.status_code).
+			status_code = getattr(getattr(exc, "response", None), "status_code", None) or 500
+			sync = _classify_http_error(status_code)
+			_log_and_set_sync(
+				ffm,
+				{"success": False, "status_code": status_code, "error": str(exc), "raw_response": None},
+				sync,
+			)
+			return {"ffm": ffm_name, "outcome": "pending" if sync == SyncStates.PENDING else "error"}
+
+		# Timeout / conexión: el cliente devuelve success=False (transitorio).
+		if not (isinstance(response, dict) and response.get("success")):
+			status_code = (response or {}).get("status_code", 500) if isinstance(response, dict) else 500
+			_log_and_set_sync(
+				ffm, response if isinstance(response, dict) else {"success": False}, SyncStates.PENDING
+			)
+			return {"ffm": ffm_name, "outcome": "pending"}
+
+		# Respuesta exitosa: validar correlación ANTES de decidir si hay cambios (reutiliza la
+		# correlación estricta del writer; no se duplican sus reglas).
+		try:
+			PACResponseWriter()._resolve_validated_ffm(
+				ffm.name, ffm.sales_invoice or "", response, "reconciliacion"
+			)
+		except FiscalCorrelationError:
+			# Identidad contradictoria: no se toca el estado fiscal; se marca error. La alerta
+			# crítica ya quedó registrada por _resolve_validated_ffm. Se preserva el tipo de error.
+			frappe.db.set_value("Factura Fiscal Mexico", ffm.name, "fm_sync_status", SyncStates.ERROR)
+			frappe.db.commit()
+			return {"ffm": ffm_name, "outcome": "error", "error_type": "correlacion"}
+
+		remote_status, cancellation_status = _extract_reconciliation_states(response)
+		fiscal_status, sync_status = derive_pac_reconciliation(remote_status, cancellation_status)
+
+		cambia_estado = fiscal_status is not None and fiscal_status != ffm.status
+		cambia_sync = sync_status != ffm.fm_sync_status
+
+		if cambia_estado or cambia_sync:
+			# Cambio real: el writer persiste estado/sync y crea Response Log correlacionado.
+			_write_pac_response(
+				ffm.sales_invoice or "",
+				{"action": "reconciliacion", "facturapi_id": ffm.facturapi_id},
+				response,
+				ffm.name,
+			)
+			return {
+				"ffm": ffm_name,
+				"outcome": "changed",
+				"status": fiscal_status if fiscal_status is not None else ffm.status,
+				"sync": sync_status,
+			}
+
+		# Sin cambios: NO se crea Response Log; solo se sella la última consulta exitosa.
+		frappe.db.set_value("Factura Fiscal Mexico", ffm.name, "fm_last_pac_sync", now_datetime())
+		return {"ffm": ffm_name, "outcome": "unchanged"}
+	finally:
+		_release_lock(lock, token)
+
+
+@frappe.whitelist()
+def reconcile_ffm(ffm_name: str) -> dict:
+	"""Reconciliación manual de un FFM (futuro botón). Aplica el permiso fiscal de cancelación."""
+	if not frappe.db.exists("Factura Fiscal Mexico", ffm_name):
+		frappe.throw(_("El documento fiscal {0} no existe.").format(ffm_name))
+	# Mismo permiso que cancel_ffm_keep_si (PR #197): no se inventan roles nuevos.
+	frappe.only_for(FISCAL_ROLES)
+	return _reconcile_ffm(ffm_name)
+
+
+def _select_candidates(limit=None) -> list[str]:
+	"""FFM con facturapi_id y (pending o PENDIENTE_CANCELACION). Prioridad: cancelación, pending,
+	fm_last_pac_sync más antiguo (NULL primero), name.
+
+	Se usa SQL de SOLO LECTURA porque el ORDER BY con CASE (prioridad por estado) no es expresable
+	en frappe.get_all (valida nombres de campo). No modifica datos.
+	"""
+	return frappe.db.sql(
+		"""
+		SELECT name FROM `tabFactura Fiscal Mexico`
+		WHERE facturapi_id IS NOT NULL AND facturapi_id != ''
+		  AND (fm_sync_status = 'pending' OR status = 'PENDIENTE_CANCELACION')
+		ORDER BY
+		  CASE WHEN status = 'PENDIENTE_CANCELACION' THEN 0 ELSE 1 END ASC,
+		  CASE WHEN fm_sync_status = 'pending' THEN 0 ELSE 1 END ASC,
+		  fm_last_pac_sync ASC, name ASC
+		LIMIT %(limit)s
+		""",
+		{"limit": limit or BATCH_SIZE},
+		pluck="name",
+	)
+
+
+def run_auto_reconciliation(limit=None) -> dict:
+	"""Lote automático: lock global, selección, procesamiento aislado por FFM, resumen."""
+	token = _acquire_lock(LOCK_BATCH, LOCK_BATCH_TTL)
+	if not token:
+		return {
+			"selected": 0,
+			"processed": 0,
+			"changed": 0,
+			"unchanged": 0,
+			"pending": 0,
+			"errors": 0,
+			"locked": 1,
+			"batch_locked": True,
+		}
+
+	summary = {
+		"selected": 0,
+		"processed": 0,
+		"changed": 0,
+		"unchanged": 0,
+		"pending": 0,
+		"errors": 0,
+		"locked": 0,
+	}
+	try:
+		candidates = _select_candidates(limit=limit)
+		summary["selected"] = len(candidates)
+		for name in candidates:
+			try:
+				res = _reconcile_ffm(name)
+				outcome = res.get("outcome")
+			except Exception:
+				frappe.log_error(
+					f"Reconciliación falló para FFM {name}", "FFM Reconciliation"
+				)  # un fallo no detiene el lote
+				outcome = "error"
+			summary["processed"] += 1
+			if outcome == "changed":
+				summary["changed"] += 1
+			elif outcome == "unchanged":
+				summary["unchanged"] += 1
+			elif outcome == "pending":
+				summary["pending"] += 1
+			elif outcome == "locked":
+				summary["locked"] += 1
+			else:  # error / skipped
+				summary["errors"] += 1
+	finally:
+		_release_lock(LOCK_BATCH, token)
+
+	return summary

--- a/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
@@ -88,21 +88,28 @@ def _classify_http_error(status_code: int) -> str:
 
 
 def _log_and_set_sync(ffm, response_data: dict, sync_status: str) -> None:
-	"""Registra el GET (Response Log, vía writer) y fija fm_sync_status al valor clasificado.
+	"""Registra el GET de error (Response Log, vía writer) y fija fm_sync_status, CONSERVANDO
+	fm_last_pac_sync.
 
-	Se reutiliza write_pac_response para no duplicar la creación del log ni la correlación. En una
-	respuesta de error no hay identificadores, por lo que no dispara FiscalCorrelationError. El
-	estado fiscal NO cambia (el branch 'reconciliacion' del writer devuelve None salvo 2xx).
+	Un error de consulta (timeout/4xx/5xx) NO es una consulta exitosa y correlacionada: fm_last_pac_sync
+	debe quedar con su valor anterior. Como write_pac_response (por M1) sella fm_last_pac_sync, se
+	captura el valor previo y se restaura. El estado fiscal NO cambia (el branch 'reconciliacion'
+	del writer devuelve None salvo 2xx).
 	"""
+	prev_last_sync = ffm.get("fm_last_pac_sync")
 	_write_pac_response(
 		ffm.sales_invoice or "",
 		{"action": "reconciliacion", "facturapi_id": ffm.facturapi_id},
 		response_data,
 		ffm.name,
 	)
-	# El writer deriva fm_sync_status con su lógica genérica para no-2xx; aquí se impone la
-	# clasificación de reconciliación (p. ej. 404 -> error, no 'synced').
-	frappe.db.set_value("Factura Fiscal Mexico", ffm.name, "fm_sync_status", sync_status)
+	# Se impone la clasificación de reconciliación (p. ej. 404 -> error, no 'synced') y se RESTAURA
+	# fm_last_pac_sync al valor previo (el error no cuenta como última consulta exitosa).
+	frappe.db.set_value(
+		"Factura Fiscal Mexico",
+		ffm.name,
+		{"fm_sync_status": sync_status, "fm_last_pac_sync": prev_last_sync},
+	)
 
 
 def _reconcile_ffm(ffm_name: str) -> dict:

--- a/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
@@ -110,6 +110,9 @@ def _log_and_set_sync(ffm, response_data: dict, sync_status: str) -> None:
 		ffm.name,
 		{"fm_sync_status": sync_status, "fm_last_pac_sync": prev_last_sync},
 	)
+	# Estas escrituras finales corren DESPUÉS del commit del writer; sin un commit propio se
+	# descartan al cerrar la request (p. ej. botón vía frappe.call). Un solo commit al final.
+	frappe.db.commit()
 
 
 def _reconcile_ffm(ffm_name: str) -> dict:
@@ -185,7 +188,10 @@ def _reconcile_ffm(ffm_name: str) -> dict:
 			}
 
 		# Sin cambios: NO se crea Response Log; solo se sella la última consulta exitosa.
+		# Commit explícito: este write no pasa por el writer (que sí commitea) y se descartaría
+		# al cerrar la request (botón vía frappe.call) sin él.
 		frappe.db.set_value("Factura Fiscal Mexico", ffm.name, "fm_last_pac_sync", now_datetime())
+		frappe.db.commit()
 		return {"ffm": ffm_name, "outcome": "unchanged"}
 	finally:
 		_release_lock(lock, token)

--- a/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
@@ -68,7 +68,9 @@ def _acquire_lock(key: str, ttl: int) -> str | None:
 	"""Adquisición atómica no bloqueante (Redis SET NX EX). Devuelve el token si se obtuvo el lock,
 	o None si ya estaba ocupado. El token identifica al dueño para una liberación segura."""
 	token = frappe.generate_hash(length=16)
-	if frappe.cache().set(_lock_key(key), token, nx=True, ex=ttl):
+	# Lock distribuido atómico (SET NX EX): set_value/get_value no soportan NX/TTL. La multitenancia
+	# queda cubierta por _lock_key (namespace por frappe.local.site).
+	if frappe.cache().set(_lock_key(key), token, nx=True, ex=ttl):  # nosemgrep
 		return token
 	return None
 
@@ -112,7 +114,7 @@ def _log_and_set_sync(ffm, response_data: dict, sync_status: str) -> None:
 	)
 	# Estas escrituras finales corren DESPUÉS del commit del writer; sin un commit propio se
 	# descartan al cerrar la request (p. ej. botón vía frappe.call). Un solo commit al final.
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep
 
 
 def _reconcile_ffm(ffm_name: str) -> dict:
@@ -163,16 +165,16 @@ def _reconcile_ffm(ffm_name: str) -> dict:
 			# Identidad contradictoria: no se toca el estado fiscal; se marca error. La alerta
 			# crítica ya quedó registrada por _resolve_validated_ffm. Se preserva el tipo de error.
 			frappe.db.set_value("Factura Fiscal Mexico", ffm.name, "fm_sync_status", SyncStates.ERROR)
-			frappe.db.commit()
+			frappe.db.commit()  # nosemgrep
 			return {"ffm": ffm_name, "outcome": "error", "error_type": "correlacion"}
 
 		remote_status, cancellation_status = _extract_reconciliation_states(response)
 		fiscal_status, sync_status = derive_pac_reconciliation(remote_status, cancellation_status)
 
-		cambia_estado = fiscal_status is not None and fiscal_status != ffm.status
-		cambia_sync = sync_status != ffm.fm_sync_status
+		status_changed = fiscal_status is not None and fiscal_status != ffm.status
+		sync_changed = sync_status != ffm.fm_sync_status
 
-		if cambia_estado or cambia_sync:
+		if status_changed or sync_changed:
 			# Cambio real: el writer persiste estado/sync y crea Response Log correlacionado.
 			_write_pac_response(
 				ffm.sales_invoice or "",
@@ -191,7 +193,7 @@ def _reconcile_ffm(ffm_name: str) -> dict:
 		# Commit explícito: este write no pasa por el writer (que sí commitea) y se descartaría
 		# al cerrar la request (botón vía frappe.call) sin él.
 		frappe.db.set_value("Factura Fiscal Mexico", ffm.name, "fm_last_pac_sync", now_datetime())
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep
 		return {"ffm": ffm_name, "outcome": "unchanged"}
 	finally:
 		_release_lock(lock, token)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_derive_pac_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_derive_pac_reconciliation.py
@@ -1,0 +1,211 @@
+"""Helper único de mapeo PAC -> (estado_fiscal, fm_sync_status) y su unificación (Paso 1 del motor).
+
+`derive_pac_reconciliation` es la ÚNICA fuente de verdad del mapeo de respuestas de cancelación,
+consumida por: cancelar_factura FASE 3, revisar_estatus_cancelacion y (después) el motor.
+
+Decisiones fijadas:
+- accepted -> CANCELADO (con o sin `status`), conserva el comportamiento productivo y test_06.
+- expired  -> TIMBRADO (nuevo, unificado en los tres flujos; antes caía a PENDIENTE_CANCELACION).
+
+Matriz del helper SIN red ni BD. Las dos pruebas de flujo mockean el boundary del PAC. Cero PAC real.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.config.fiscal_states_config import FiscalStates, SyncStates, derive_pac_reconciliation
+from facturacion_mexico.facturacion_fiscal.timbrado_api import TimbradoAPI, revisar_estatus_cancelacion
+
+_TIMBRADO_API = "facturacion_mexico.facturacion_fiscal.timbrado_api"
+
+
+class TestDerivePacReconciliation(IntegrationTestCase):
+	"""Matriz pura del helper (sin red ni BD)."""
+
+	def _assert(self, remote, cancel, estado, sync):
+		self.assertEqual(derive_pac_reconciliation(remote, cancel), (estado, sync))
+
+	# --- canceled / accepted -> CANCELADO ---
+	def test_canceled_cualquiera(self):
+		self._assert("canceled", "", FiscalStates.CANCELADO, SyncStates.SYNCED)
+		self._assert("canceled", "accepted", FiscalStates.CANCELADO, SyncStates.SYNCED)
+
+	# Precedencia: un CFDI `canceled` manda sobre un cancellation_status contradictorio.
+	def test_canceled_precede_a_cancellation_contradictoria(self):
+		self._assert("canceled", "rejected", FiscalStates.CANCELADO, SyncStates.SYNCED)
+		self._assert("canceled", "expired", FiscalStates.CANCELADO, SyncStates.SYNCED)
+		self._assert("canceled", "pending", FiscalStates.CANCELADO, SyncStates.SYNCED)
+
+	def test_accepted_sin_status(self):
+		# Caso de query_pac_status / test_06: accepted sin `status` sigue siendo CANCELADO.
+		self._assert("", "accepted", FiscalStates.CANCELADO, SyncStates.SYNCED)
+
+	def test_accepted_con_valid(self):
+		self._assert("valid", "accepted", FiscalStates.CANCELADO, SyncStates.SYNCED)
+
+	# --- valid + cancellation ---
+	def test_valid_pending(self):
+		self._assert("valid", "pending", FiscalStates.PENDIENTE_CANCELACION, SyncStates.SYNCED)
+
+	def test_valid_verifying(self):
+		self._assert("valid", "verifying", FiscalStates.PENDIENTE_CANCELACION, SyncStates.SYNCED)
+
+	def test_valid_rejected(self):
+		self._assert("valid", "rejected", FiscalStates.TIMBRADO, SyncStates.SYNCED)
+
+	def test_valid_expired(self):
+		# NUEVO comportamiento unificado.
+		self._assert("valid", "expired", FiscalStates.TIMBRADO, SyncStates.SYNCED)
+
+	def test_valid_none_o_vacio(self):
+		self._assert("valid", "none", FiscalStates.TIMBRADO, SyncStates.SYNCED)
+		self._assert("valid", "", FiscalStates.TIMBRADO, SyncStates.SYNCED)
+
+	# --- no definitivo / error ---
+	def test_remote_pending(self):
+		self._assert("pending", "", None, SyncStates.PENDING)
+
+	def test_draft_desconocido(self):
+		self._assert("draft", "", None, SyncStates.ERROR)
+		self._assert("loquesea", "", None, SyncStates.ERROR)
+
+	def test_valid_cancellation_desconocida(self):
+		self._assert("valid", "no_existe", None, SyncStates.ERROR)
+
+	# --- normalización ---
+	def test_normaliza_mayusculas_y_espacios(self):
+		self._assert("  CANCELED ", "", FiscalStates.CANCELADO, SyncStates.SYNCED)
+		self._assert("Valid", "EXPIRED", FiscalStates.TIMBRADO, SyncStates.SYNCED)
+		self._assert(None, None, None, SyncStates.ERROR)
+
+
+def _seed_si(*, fiscal_status="", ffm=None):
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+			"fm_fiscal_status": fiscal_status or None,
+			"fm_factura_fiscal_mx": ffm,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(sales_invoice, status, *, facturapi_id="", uuid=""):
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"facturapi_id": facturapi_id or None,
+			"fm_uuid": uuid or None,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+def _set_value_factory():
+	orig = frappe.set_value
+
+	def _fake(dt, dn, *args, **kwargs):
+		if dt == "Sales Invoice":
+			return None
+		if dt == "Factura Fiscal Mexico":
+			return frappe.db.set_value(dt, dn, *args, **kwargs)
+		return orig(dt, dn, *args, **kwargs)
+
+	return _fake
+
+
+class TestExpiredUnificado(IntegrationTestCase):
+	"""expired -> TIMBRADO en los flujos reales de cancelación (boundary PAC mockeado)."""
+
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for ffm in self.ffm_names:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def _si(self, **kwargs):
+		name = _seed_si(**kwargs)
+		self.si_names.append(name)
+		return name
+
+	def _ffm(self, *args, **kwargs):
+		name = _seed_ffm(*args, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	# FASE 3 de cancelar_factura: una cancelación EXPIRED deja el FFM en TIMBRADO (antes PENDIENTE).
+	def test_fase3_expired_timbrado(self):
+		ffm = self._ffm(None, "TIMBRADO", facturapi_id="FA-1", uuid="U-1")
+		si = self._si(fiscal_status="TIMBRADO", ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		frappe.db.commit()
+		client = MagicMock()
+		client.cancel_invoice.return_value = {
+			"success": True,
+			"raw_response": {"status": "valid", "cancellation_status": "expired"},
+		}
+		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
+			api = TimbradoAPI(company="_Test Company")
+			with (
+				patch("frappe.set_value", side_effect=_set_value_factory()),
+				patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": True}),
+			):
+				api.cancelar_factura(si, "02")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+
+	# revisar_estatus_cancelacion: EXPIRED resuelve a TIMBRADO (antes quedaba PENDIENTE_CANCELACION).
+	def test_revisar_expired_timbrado(self):
+		si = self._si(fiscal_status="PENDIENTE_CANCELACION")
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1", uuid="U-1")
+		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", ffm)
+		frappe.db.commit()
+		with (
+			patch(
+				"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
+				return_value={"success": True, "data": {"status": "valid", "cancellation_status": "expired"}},
+			),
+			patch("frappe.set_value", side_effect=_set_value_factory()),
+			patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": True}),
+		):
+			result = revisar_estatus_cancelacion(ffm)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
+		self.assertEqual(result.get("nuevo_estado", "TIMBRADO"), "TIMBRADO")
+
+	# cero referencias al cliente PAC importadas en el módulo de prueba
+	def test_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "requests", "get_facturapi_client"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_derive_pac_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_derive_pac_reconciliation.py
@@ -81,6 +81,12 @@ class TestDerivePacReconciliation(IntegrationTestCase):
 		self._assert(None, None, None, SyncStates.ERROR)
 
 
+# Identidades fiscales únicas por corrida (evita colisiones con registros residuales y cumple la
+# regla de IDs generados).
+_FA_ID = "FA-" + frappe.generate_hash()[:10]
+_UUID = "U-" + frappe.generate_hash()[:10]
+
+
 def _seed_si(*, fiscal_status="", ffm=None):
 	si = frappe.get_doc(
 		{
@@ -168,7 +174,7 @@ class TestExpiredUnificado(IntegrationTestCase):
 
 	# FASE 3 de cancelar_factura: una cancelación EXPIRED deja el FFM en TIMBRADO (antes PENDIENTE).
 	def test_fase3_expired_timbrado(self):
-		ffm = self._ffm(None, "TIMBRADO", facturapi_id="FA-1", uuid="U-1")
+		ffm = self._ffm(None, "TIMBRADO", facturapi_id=_FA_ID, uuid=_UUID)
 		si = self._si(fiscal_status="TIMBRADO", ffm=ffm)
 		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
 		frappe.db.commit()
@@ -189,7 +195,7 @@ class TestExpiredUnificado(IntegrationTestCase):
 	# revisar_estatus_cancelacion: EXPIRED resuelve a TIMBRADO (antes quedaba PENDIENTE_CANCELACION).
 	def test_revisar_expired_timbrado(self):
 		si = self._si(fiscal_status="PENDIENTE_CANCELACION")
-		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1", uuid="U-1")
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id=_FA_ID, uuid=_UUID)
 		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", ffm)
 		frappe.db.commit()
 		with (
@@ -202,7 +208,7 @@ class TestExpiredUnificado(IntegrationTestCase):
 		):
 			result = revisar_estatus_cancelacion(ffm)
 		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
-		self.assertEqual(result.get("nuevo_estado", "TIMBRADO"), "TIMBRADO")
+		self.assertEqual(result.get("status"), "TIMBRADO")
 
 	# cero referencias al cliente PAC importadas en el módulo de prueba
 	def test_cero_trafico_pac(self):

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
@@ -117,6 +117,9 @@ class TestFFMReconciliation(IntegrationTestCase):
 	def _sync(self, ffm):
 		return frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_sync_status")
 
+	def _last_sync(self, ffm):
+		return frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_last_pac_sync")
+
 	# ─────────────────────────── Selector ───────────────────────────
 
 	def test_selector_incluye_timbrado_pending(self):
@@ -255,6 +258,53 @@ class TestFFMReconciliation(IntegrationTestCase):
 		self.assertEqual(res["outcome"], "error")
 		self.assertEqual(res.get("error_type"), "correlacion")
 		self.assertIsNone(frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_last_pac_sync"))
+
+	# ─────────── fm_last_pac_sync: solo en GET exitoso y correlacionado ───────────
+
+	_VIEJO = "2020-01-01 00:00:00"
+
+	def _ffm_con_last_sync(self, sync="pending"):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync=sync, last_sync=self._VIEJO)
+		return ffm, self._last_sync(ffm)
+
+	def test_last_sync_timeout_no_modifica(self):
+		ffm, antes = self._ffm_con_last_sync()
+		self._reconciliar(ffm, get_return={"success": False, "status_code": 500})
+		self.assertEqual(self._last_sync(ffm), antes)
+
+	def test_last_sync_429_no_modifica(self):
+		ffm, antes = self._ffm_con_last_sync()
+		self._reconciliar(ffm, get_side_effect=_http_error(429))
+		self.assertEqual(self._last_sync(ffm), antes)
+
+	def test_last_sync_5xx_no_modifica(self):
+		ffm, antes = self._ffm_con_last_sync()
+		self._reconciliar(ffm, get_side_effect=_http_error(503))
+		self.assertEqual(self._last_sync(ffm), antes)
+
+	def test_last_sync_404_no_modifica(self):
+		ffm, antes = self._ffm_con_last_sync()
+		self._reconciliar(ffm, get_side_effect=_http_error(404))
+		self.assertEqual(self._last_sync(ffm), antes)
+
+	def test_last_sync_contradiccion_no_modifica(self):
+		ffm, antes = self._ffm_con_last_sync()
+		bad = {"success": True, "status_code": 200, "raw_response": {"id": "FA-OTRO", "status": "valid"}}
+		self._reconciliar(ffm, get_return=bad)
+		self.assertEqual(self._last_sync(ffm), antes)
+
+	def test_last_sync_get_exitoso_con_cambio_si_modifica(self):
+		# FFM pending + valid -> cambio (pending->synced): fm_last_pac_sync se actualiza.
+		ffm, antes = self._ffm_con_last_sync(sync="pending")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		self.assertNotEqual(self._last_sync(ffm), antes)
+
+	def test_last_sync_get_exitoso_sin_cambio_si_modifica(self):
+		# FFM synced + valid -> no-op: igual se actualiza fm_last_pac_sync (consulta exitosa).
+		ffm, antes = self._ffm_con_last_sync(sync="synced")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		self.assertNotEqual(self._last_sync(ffm), antes)
 
 	# ─────────────────────────── Errores y seguridad ───────────────────────────
 

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
@@ -14,6 +14,12 @@ from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as
 
 MOD = "facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation"
 
+# Identidades fiscales únicas por corrida (evita colisiones con registros residuales y cumple la
+# regla de IDs generados). El seed y el mock de respuesta comparten estas constantes para que la
+# correlación estricta (id/uuid) pase; los tests de contradicción usan literales distintos.
+_FA_ID = "FA-" + frappe.generate_hash()[:10]
+_UUID = "U-" + frappe.generate_hash()[:10]
+
 
 def _seed_si():
 	si = frappe.get_doc(
@@ -35,7 +41,7 @@ def _seed_si():
 	return si.name
 
 
-def _seed_ffm(sales_invoice, status, *, facturapi_id="FA-1", uuid="U-1", sync="pending", last_sync=None):
+def _seed_ffm(sales_invoice, status, *, facturapi_id=_FA_ID, uuid=_UUID, sync="pending", last_sync=None):
 	ffm = frappe.get_doc(
 		{
 			"doctype": "Factura Fiscal Mexico",
@@ -61,7 +67,7 @@ def _seed_ffm(sales_invoice, status, *, facturapi_id="FA-1", uuid="U-1", sync="p
 
 
 def _ok(raw, status_code=200):
-	return {"success": True, "status_code": status_code, "raw_response": {"id": "FA-1", "uuid": "U-1", **raw}}
+	return {"success": True, "status_code": status_code, "raw_response": {"id": _FA_ID, "uuid": _UUID, **raw}}
 
 
 def _http_error(code):
@@ -403,7 +409,7 @@ class TestFFMReconciliation(IntegrationTestCase):
 		bad = {
 			"success": True,
 			"status_code": 200,
-			"raw_response": {"id": "FA-1", "uuid": "U-OTRO", "status": "valid"},
+			"raw_response": {"id": _FA_ID, "uuid": "U-OTRO", "status": "valid"},
 		}
 		res, _, _ = self._reconciliar(ffm, get_return=bad)
 		self.assertEqual(res.get("error_type"), "correlacion")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
@@ -306,6 +306,47 @@ class TestFFMReconciliation(IntegrationTestCase):
 		self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
 		self.assertNotEqual(self._last_sync(ffm), antes)
 
+	# ─────────── Persistencia transaccional (commit explícito en ramas sin writer) ───────────
+	# Estas pruebas simulan el cierre de la request (botón vía frappe.call, sin auto-commit) con
+	# un frappe.db.rollback() posterior: si la rama NO commitea, el rollback revierte la escritura
+	# y la aserción falla. Un set_value en la misma transacción es invisible a este defecto.
+
+	def test_noop_persiste_last_sync_tras_rollback(self):
+		ffm, antes = self._ffm_con_last_sync(sync="synced")
+		res, _, _ = self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		self.assertEqual(res["outcome"], "unchanged")
+		frappe.db.rollback()  # simula fin de request sin auto-commit
+		self.assertNotEqual(self._last_sync(ffm), antes)  # sobrevive al rollback => hubo commit
+
+	def test_noop_dos_consultas_consecutivas_avanzan_timestamp(self):
+		ffm, antes = self._ffm_con_last_sync(sync="synced")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		frappe.db.rollback()
+		t1 = self._last_sync(ffm)
+		self.assertNotEqual(t1, antes)  # primera consulta selló y persistió
+		# Segunda consulta, también no-op: vuelve a sellar y persistir.
+		self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		frappe.db.rollback()
+		t2 = self._last_sync(ffm)
+		self.assertGreaterEqual(t2, t1)
+
+	def test_error_persiste_sync_y_conserva_last_sync_tras_rollback(self):
+		# 404 -> error: el override final de _log_and_set_sync (sync=error + last_sync restaurado)
+		# corre DESPUÉS del commit del writer y debe commitearse para sobrevivir al fin de request.
+		ffm, antes = self._ffm_con_last_sync(sync="pending")
+		res, _, _ = self._reconciliar(ffm, get_side_effect=_http_error(404))
+		self.assertEqual(res["outcome"], "error")
+		frappe.db.rollback()  # simula fin de request sin auto-commit
+		self.assertEqual(self._sync(ffm), "error")  # override persistido
+		self.assertEqual(self._last_sync(ffm), antes)  # se conservó el valor previo
+
+	def test_noop_no_modifica_sales_invoice(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="synced")
+		ds_antes = frappe.db.get_value("Sales Invoice", si, "docstatus")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		self.assertEqual(frappe.db.get_value("Sales Invoice", si, "docstatus"), ds_antes)
+
 	# ─────────────────────────── Errores y seguridad ───────────────────────────
 
 	def test_timeout_pending(self):

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
@@ -1,0 +1,439 @@
+"""Motor de reconciliación FFM ↔ FacturAPI (Paso 3).
+
+Selector, estados (vía helper único), persistencia (cambio/no-op), errores HTTP, locks y permisos.
+El boundary del PAC (get_invoice) se mockea por completo. Cero PAC real.
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+MOD = "facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation"
+
+
+def _seed_si():
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(sales_invoice, status, *, facturapi_id="FA-1", uuid="U-1", sync="pending", last_sync=None):
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"facturapi_id": facturapi_id or None,
+			"fm_uuid": uuid or None,
+			"fm_sync_status": sync,
+			"fm_last_pac_sync": last_sync,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+def _ok(raw, status_code=200):
+	return {"success": True, "status_code": status_code, "raw_response": {"id": "FA-1", "uuid": "U-1", **raw}}
+
+
+def _http_error(code):
+	exc = frappe.ValidationError(f"Error FacturAPI {code}")
+	exc.response = types.SimpleNamespace(status_code=code)
+	return exc
+
+
+class TestFFMReconciliation(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for ffm in self.ffm_names:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		for u in getattr(self, "user_ids", []):
+			frappe.db.delete("User", {"name": u})
+		frappe.db.commit()
+
+	def _si(self):
+		name = _seed_si()
+		self.si_names.append(name)
+		return name
+
+	def _ffm(self, *args, **kwargs):
+		name = _seed_ffm(*args, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	def _client(self, *, get_return=None, get_side_effect=None):
+		client = MagicMock()
+		if get_side_effect is not None:
+			client.get_invoice.side_effect = get_side_effect
+		else:
+			client.get_invoice.return_value = get_return
+		return client
+
+	def _reconciliar(self, ffm_name, *, get_return=None, get_side_effect=None):
+		client = self._client(get_return=get_return, get_side_effect=get_side_effect)
+		with patch(f"{MOD}.get_facturapi_client", return_value=client) as gfc:
+			res = mod._reconcile_ffm(ffm_name)
+		return res, client, gfc
+
+	def _status(self, ffm):
+		return frappe.db.get_value("Factura Fiscal Mexico", ffm, "status")
+
+	def _sync(self, ffm):
+		return frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_sync_status")
+
+	# ─────────────────────────── Selector ───────────────────────────
+
+	def test_selector_incluye_timbrado_pending(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending", facturapi_id="FA-A")
+		self.assertIn(ffm, mod._select_candidates())
+
+	def test_selector_incluye_pendiente_cancelacion_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", sync="synced", facturapi_id="FA-B")
+		self.assertIn(ffm, mod._select_candidates())  # entra aunque esté synced
+
+	def test_selector_excluye_sin_facturapi_id(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending", facturapi_id="")
+		self.assertNotIn(ffm, mod._select_candidates())
+
+	def test_selector_excluye_timbrado_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="synced", facturapi_id="FA-C")
+		self.assertNotIn(ffm, mod._select_candidates())
+
+	def test_selector_prioriza_cancelaciones(self):
+		si = self._si()
+		pend = self._ffm(si, "TIMBRADO", sync="pending", facturapi_id="FA-A")
+		cancel = self._ffm(si, "PENDIENTE_CANCELACION", sync="pending", facturapi_id="FA-B")
+		sel = mod._select_candidates()
+		self.assertLess(sel.index(cancel), sel.index(pend))
+
+	def test_selector_respeta_limit(self):
+		si = self._si()
+		for i in range(3):
+			self._ffm(si, "TIMBRADO", sync="pending", facturapi_id=f"FA-{i}")
+		self.assertEqual(len(mod._select_candidates(limit=2)), 2)
+
+	# ─────────────────────────── Estados ───────────────────────────
+
+	def test_vigente_pending_a_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		res, _, _ = self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		self.assertEqual(res["outcome"], "changed")
+		self.assertEqual(self._status(ffm), "TIMBRADO")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	def test_cancelacion_pendiente(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid", "cancellation_status": "pending"}))
+		self.assertEqual(self._status(ffm), "PENDIENTE_CANCELACION")
+
+	def test_verifying(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", sync="synced")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid", "cancellation_status": "verifying"}))
+		self.assertEqual(self._status(ffm), "PENDIENTE_CANCELACION")
+
+	def test_canceled(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", sync="synced")
+		self._reconciliar(ffm, get_return=_ok({"status": "canceled"}))
+		self.assertEqual(self._status(ffm), "CANCELADO")
+
+	def test_accepted(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", sync="synced")
+		self._reconciliar(ffm, get_return=_ok({"cancellation_status": "accepted"}))
+		self.assertEqual(self._status(ffm), "CANCELADO")
+
+	def test_rejected(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", sync="synced")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid", "cancellation_status": "rejected"}))
+		self.assertEqual(self._status(ffm), "TIMBRADO")
+
+	def test_expired(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", sync="synced")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid", "cancellation_status": "expired"}))
+		self.assertEqual(self._status(ffm), "TIMBRADO")
+
+	def test_remoto_pending_conserva_estado_y_pending(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="synced")
+		res, _, _ = self._reconciliar(ffm, get_return=_ok({"status": "pending"}))
+		self.assertEqual(self._status(ffm), "TIMBRADO")  # sin cambio fiscal
+		self.assertEqual(self._sync(ffm), "pending")
+		self.assertEqual(res["outcome"], "changed")  # synced -> pending sí es cambio
+
+	def test_estado_desconocido_conserva_estado_y_error(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="synced")
+		self._reconciliar(ffm, get_return=_ok({"status": "draft"}))
+		self.assertEqual(self._status(ffm), "TIMBRADO")  # sin cambio fiscal
+		self.assertEqual(self._sync(ffm), "error")
+
+	# ─────────────────────────── Persistencia ───────────────────────────
+
+	def test_cambio_llama_al_writer(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		with patch(f"{MOD}._write_pac_response") as wpr:
+			self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		wpr.assert_called_once()
+
+	def test_noop_no_llama_al_writer_y_actualiza_timestamp(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="synced", last_sync=None)
+		with patch(f"{MOD}._write_pac_response") as wpr:
+			res, _, _ = self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		wpr.assert_not_called()
+		self.assertEqual(res["outcome"], "unchanged")
+		self.assertIsNotNone(frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_last_pac_sync"))
+
+	def test_noop_no_crea_log(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="synced")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		self.assertEqual(frappe.db.count("FacturAPI Response Log", {"factura_fiscal_mexico": ffm}), 0)
+
+	def test_cambio_solo_sync_llama_al_writer(self):
+		# valid -> TIMBRADO (sin cambio fiscal) pero sync pending->synced sí es cambio.
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		with patch(f"{MOD}._write_pac_response") as wpr:
+			self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		wpr.assert_called_once()
+
+	def test_noop_valida_identidad_antes_de_timestamp(self):
+		# Respuesta que sería no-op (valid) pero con facturapi_id contradictorio: NO debe actualizar
+		# timestamp ni quedar unchanged; valida identidad primero -> error.
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="synced", last_sync=None)
+		bad = {"success": True, "status_code": 200, "raw_response": {"id": "FA-OTRO", "status": "valid"}}
+		res, _, _ = self._reconciliar(ffm, get_return=bad)
+		self.assertEqual(res["outcome"], "error")
+		self.assertEqual(res.get("error_type"), "correlacion")
+		self.assertIsNone(frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_last_pac_sync"))
+
+	# ─────────────────────────── Errores y seguridad ───────────────────────────
+
+	def test_timeout_pending(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		res, _, _ = self._reconciliar(ffm, get_return={"success": False, "status_code": 500})
+		self.assertEqual(res["outcome"], "pending")
+		self.assertEqual(self._sync(ffm), "pending")
+		self.assertEqual(self._status(ffm), "TIMBRADO")
+
+	def test_429_pending(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		res, _, _ = self._reconciliar(ffm, get_side_effect=_http_error(429))
+		self.assertEqual(res["outcome"], "pending")
+		self.assertEqual(self._sync(ffm), "pending")
+
+	def test_5xx_pending(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		res, _, _ = self._reconciliar(ffm, get_side_effect=_http_error(503))
+		self.assertEqual(res["outcome"], "pending")
+		self.assertEqual(self._sync(ffm), "pending")
+
+	def test_404_error(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		res, _, _ = self._reconciliar(ffm, get_side_effect=_http_error(404))
+		self.assertEqual(res["outcome"], "error")
+		self.assertEqual(self._sync(ffm), "error")
+		self.assertEqual(self._status(ffm), "TIMBRADO")
+
+	def test_401_403_error(self):
+		si = self._si()
+		for code in (401, 403):
+			ffm = self._ffm(si, "TIMBRADO", sync="pending", facturapi_id=f"FA-{code}")
+			res, _, _ = self._reconciliar(ffm, get_side_effect=_http_error(code))
+			self.assertEqual(res["outcome"], "error")
+			self.assertEqual(self._sync(ffm), "error")
+
+	def test_contradiccion_id_error_correlacion(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		bad = {"success": True, "status_code": 200, "raw_response": {"id": "FA-OTRO", "status": "valid"}}
+		res, _, _ = self._reconciliar(ffm, get_return=bad)
+		self.assertEqual(res["outcome"], "error")
+		self.assertEqual(res.get("error_type"), "correlacion")
+		self.assertEqual(self._sync(ffm), "error")
+		self.assertEqual(self._status(ffm), "TIMBRADO")  # nunca cambia el estado fiscal
+
+	def test_contradiccion_uuid_error_correlacion(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		bad = {
+			"success": True,
+			"status_code": 200,
+			"raw_response": {"id": "FA-1", "uuid": "U-OTRO", "status": "valid"},
+		}
+		res, _, _ = self._reconciliar(ffm, get_return=bad)
+		self.assertEqual(res.get("error_type"), "correlacion")
+
+	def test_cliente_recibe_company(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		_, _, gfc = self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		gfc.assert_called_once_with(company="_Test Company")
+
+	def test_nunca_create_ni_cancel_invoice(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		_, client, _ = self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+		client.create_invoice.assert_not_called()
+		client.cancel_invoice.assert_not_called()
+
+	def test_lote_un_fallo_no_detiene(self):
+		si = self._si()
+		a = self._ffm(si, "TIMBRADO", sync="pending", facturapi_id="FA-A")
+		self._ffm(si, "TIMBRADO", sync="pending", facturapi_id="FA-B")
+
+		def _side(name):
+			if name == a:
+				raise RuntimeError("boom")
+			return {"ffm": name, "outcome": "unchanged"}
+
+		with (
+			patch(f"{MOD}._reconcile_ffm", side_effect=_side),
+			patch(f"{MOD}._acquire_lock", return_value=True),
+			patch(f"{MOD}._release_lock"),
+		):
+			summary = mod.run_auto_reconciliation()
+		self.assertEqual(summary["processed"], 2)
+		self.assertGreaterEqual(summary["errors"], 1)
+
+	def test_lock_global_ocupado_sale_sin_error(self):
+		frappe.cache().delete(mod._lock_key(mod.LOCK_BATCH))
+		token = mod._acquire_lock(mod.LOCK_BATCH, 60)
+		self.assertTrue(token)
+		try:
+			summary = mod.run_auto_reconciliation()
+			self.assertTrue(summary.get("batch_locked"))
+			self.assertEqual(summary["selected"], 0)
+		finally:
+			mod._release_lock(mod.LOCK_BATCH, token)
+
+	# ─────────────────────────── Propiedad del lock ───────────────────────────
+
+	def test_lock_propietario_libera(self):
+		key = "test:own:" + frappe.generate_hash()[:8]
+		token = mod._acquire_lock(key, 60)
+		self.assertTrue(token)
+		mod._release_lock(key, token)
+		# Liberado: se puede re-adquirir.
+		token2 = mod._acquire_lock(key, 60)
+		self.assertTrue(token2)
+		mod._release_lock(key, token2)
+
+	def test_lock_token_distinto_no_libera(self):
+		key = "test:own:" + frappe.generate_hash()[:8]
+		token = mod._acquire_lock(key, 60)
+		mod._release_lock(key, "token-ajeno")  # NO debe borrar
+		self.assertIsNone(mod._acquire_lock(key, 60))  # sigue ocupado por el dueño
+		mod._release_lock(key, token)
+
+	def test_lock_expirado_no_borra_el_nuevo(self):
+		key = "test:own:" + frappe.generate_hash()[:8]
+		token_viejo = mod._acquire_lock(key, 60)
+		# Simular: el lock del viejo expiró y OTRO proceso adquirió uno nuevo (mismo key, otro valor).
+		frappe.cache().set(mod._lock_key(key), "dueno-nuevo", ex=60)
+		# El proceso viejo intenta liberar con su token: NO debe borrar el lock del nuevo.
+		mod._release_lock(key, token_viejo)
+		valor = frappe.cache().get(mod._lock_key(key))
+		valor = valor.decode() if isinstance(valor, bytes) else valor
+		self.assertEqual(valor, "dueno-nuevo")
+		frappe.cache().delete(mod._lock_key(key))
+
+	def test_lock_liberado_en_finally_con_excepcion(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		key = mod.LOCK_FFM_PREFIX + ffm
+		frappe.cache().delete(mod._lock_key(key))
+		with patch(f"{MOD}.get_facturapi_client", side_effect=RuntimeError("boom")):
+			with self.assertRaises(RuntimeError):
+				mod._reconcile_ffm(ffm)
+		# El finally liberó el lock: se puede re-adquirir.
+		token = mod._acquire_lock(key, 60)
+		self.assertTrue(token)
+		mod._release_lock(key, token)
+
+	def test_lock_ffm_ocupado_devuelve_locked(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		key = mod.LOCK_FFM_PREFIX + ffm
+		frappe.cache().delete(mod._lock_key(key))
+		token = mod._acquire_lock(key, 60)
+		self.assertTrue(token)
+		try:
+			res, _, _ = self._reconciliar(ffm, get_return=_ok({"status": "valid"}))
+			self.assertEqual(res["outcome"], "locked")
+		finally:
+			mod._release_lock(key, token)
+
+	def test_permiso_servidor_aplicado(self):
+		self.user_ids = []
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		uid = "recon-noperm-" + frappe.generate_hash()[:8] + "@test.com"
+		user = frappe.get_doc(
+			{"doctype": "User", "email": uid, "first_name": "NoPerm", "roles": [{"role": "Sales User"}]}
+		)
+		user.flags.ignore_permissions = True
+		user.insert(ignore_permissions=True)
+		self.user_ids.append(uid)
+		frappe.db.commit()
+		frappe.set_user(uid)
+		with self.assertRaises(frappe.PermissionError):
+			mod.reconcile_ffm(ffm)
+
+	def test_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "cancel_invoice", "requests"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation_button.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation_button.py
@@ -1,0 +1,85 @@
+"""Prueba estática del botón 'Verificar estado en FacturAPI' (Paso 5).
+
+Verifica el contrato del botón de reconciliación manual en el JS del FFM: texto, grupo, guardas
+de visibilidad, método servidor, payload, recarga, y que NO contenga lógica fiscal (timbrado,
+cancelación, escritura de campos). Es estática: lee el archivo, no ejecuta JS ni abre formularios.
+"""
+
+import os
+import re
+import unittest
+
+APP_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+FFM_JS = os.path.join(
+	APP_ROOT, "facturacion_fiscal", "doctype", "factura_fiscal_mexico", "factura_fiscal_mexico.js"
+)
+
+_LABEL = "Verificar estado en FacturAPI"
+_METHOD = "facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.reconcile_ffm"
+
+
+def _strip_js_line_comments(source: str) -> str:
+	"""Solo líneas de código (descarta comentarios `//`), para evaluar código ejecutable."""
+	return "\n".join(line for line in source.splitlines() if not line.strip().startswith("//"))
+
+
+class TestReconciliationButton(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		with open(FFM_JS, encoding="utf-8") as fh:
+			cls.raw = fh.read()
+		cls.code = _strip_js_line_comments(cls.raw)
+		# Bloque del botón: desde su etiqueta hasta el cierre con el grupo "Comprobantes".
+		start = cls.code.index(_LABEL)
+		end = cls.code.index('Comprobantes")', start) + len('Comprobantes")')
+		cls.block = cls.code[start:end]
+
+	# 1 — existe el texto
+	def test_existe_texto(self):
+		self.assertIn(_LABEL, self.code)
+
+	# 2 — pertenece al grupo Comprobantes
+	def test_grupo_comprobantes(self):
+		self.assertRegex(self.block, r'__\(\s*"Comprobantes"\s*\)\s*$')
+
+	# 3 y 4 — exige documento guardado y facturapi_id (guarda de visibilidad)
+	def test_guarda_guardado_y_facturapi_id(self):
+		self.assertIn("!frm.is_new() && frm.doc.facturapi_id", self.code)
+		# La guarda precede a la creación del botón.
+		self.assertLess(self.code.index("!frm.is_new() && frm.doc.facturapi_id"), self.code.index(_LABEL))
+
+	# 5 — llama exactamente a reconcile_ffm
+	def test_llama_reconcile_ffm(self):
+		self.assertIn(_METHOD, self.block)
+
+	# 6 — envía ffm_name: frm.doc.name
+	def test_payload_ffm_name(self):
+		self.assertRegex(self.block, r"ffm_name:\s*frm\.doc\.name")
+
+	# 7 — recarga el documento tras la consulta
+	def test_recarga_documento(self):
+		self.assertIn("frm.reload_doc()", self.block)
+
+	# congelar interfaz / evitar doble clic
+	def test_freeze_activo(self):
+		self.assertIn("freeze: true", self.block)
+
+	# 8 — sin llamadas a timbrado, cancelación ni cancelación de Sales Invoice
+	def test_sin_timbrado_ni_cancelacion(self):
+		prohibidos = ("timbrar", "create_invoice", "cancel_invoice", "cancelar", "cancel_ffm")
+		for p in prohibidos:
+			self.assertNotIn(p, self.block.lower(), f"El bloque no debe contener '{p}'")
+
+	# 9 — no escribe campos fiscales directamente
+	def test_no_escribe_campos_fiscales(self):
+		for p in ("set_value", "db_set", "fm_sync_status", '"status"', "'status'"):
+			self.assertNotIn(p, self.block, f"El bloque no debe escribir '{p}'")
+		# Tampoco debe interpretar el estado remoto.
+		for p in ("cancellation_status", "status ==", "status==="):
+			self.assertNotIn(p, self.block, f"El bloque no debe interpretar '{p}'")
+
+	# referencia: el método servidor existe en su módulo
+	def test_metodo_servidor_existe(self):
+		svc = os.path.join(APP_ROOT, "facturacion_fiscal", "services", "ffm_reconciliation.py")
+		with open(svc, encoding="utf-8") as fh:
+			self.assertTrue(re.search(r"def\s+reconcile_ffm\s*\(", fh.read()))

--- a/facturacion_mexico/facturacion_fiscal/tests/test_persistence_recovery.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_persistence_recovery.py
@@ -322,7 +322,9 @@ class TestPersistenceRecovery(IntegrationTestCase):
 
 	# 14 — cancelación RECHAZADA: FASE 3 mantiene TIMBRADO → se reconoce como persistido (recuperado)
 	def test_14_cancelacion_rejected_recuperada_timbrado(self):
-		result, ffm, client = self._run_cancelacion("02", {"cancellation_status": "rejected"})
+		result, ffm, client = self._run_cancelacion(
+			"02", {"status": "valid", "cancellation_status": "rejected"}
+		)
 		self.assertTrue(result["success"])
 		self.assertEqual(result.get("persistence_status"), "recovered_by_phase3")
 		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
@@ -330,7 +332,7 @@ class TestPersistenceRecovery(IntegrationTestCase):
 
 	# 15 — cancelación PENDIENTE: conserva el comportamiento existente (PENDIENTE_CANCELACION recuperado)
 	def test_15_cancelacion_pending_recuperada(self):
-		result, ffm, _ = self._run_cancelacion("02", {"cancellation_status": "pending"})
+		result, ffm, _ = self._run_cancelacion("02", {"status": "valid", "cancellation_status": "pending"})
 		self.assertTrue(result["success"])
 		self.assertEqual(result.get("persistence_status"), "recovered_by_phase3")
 		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "PENDIENTE_CANCELACION")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_scheduler_hooks.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_scheduler_hooks.py
@@ -1,0 +1,43 @@
+"""Prueba estática del registro del motor de reconciliación en scheduler_events (Paso 4).
+
+Verifica que run_auto_reconciliation esté en `hourly_long`, una sola vez, y NO en ningún otro
+evento. Es estática (inspecciona hooks.scheduler_events); no ejecuta el scheduler ni el PAC.
+"""
+
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico import hooks
+
+_RECON = "facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.run_auto_reconciliation"
+
+
+def _count_in_event(value, target):
+	"""Cuenta apariciones de `target` en un valor de scheduler_events (lista o dict de listas)."""
+	if isinstance(value, list):
+		return value.count(target)
+	if isinstance(value, dict):
+		return sum(tasks.count(target) for tasks in value.values() if isinstance(tasks, list))
+	return 0
+
+
+class TestSchedulerHooks(IntegrationTestCase):
+	def test_hourly_long_existe_con_motor(self):
+		se = hooks.scheduler_events
+		self.assertIn("hourly_long", se)
+		self.assertIn(_RECON, se["hourly_long"])
+
+	def test_motor_no_en_otros_eventos(self):
+		se = hooks.scheduler_events
+		for evento, value in se.items():
+			if evento == "hourly_long":
+				continue
+			self.assertEqual(
+				_count_in_event(value, _RECON), 0, f"El motor no debe estar en el evento '{evento}'"
+			)
+
+	def test_motor_no_duplicado(self):
+		se = hooks.scheduler_events
+		# Exactamente una vez en hourly_long y una vez en total (todos los eventos).
+		self.assertEqual(se["hourly_long"].count(_RECON), 1)
+		total = sum(_count_in_event(value, _RECON) for value in se.values())
+		self.assertEqual(total, 1)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_writer_reconciliacion.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_writer_reconciliacion.py
@@ -1,0 +1,208 @@
+"""Soporte del writer para operation_type='reconciliacion' (Paso 2 del motor).
+
+Ante una respuesta PAC exitosa, el writer delega EXCLUSIVAMENTE en derive_pac_reconciliation
+(no duplica la matriz) y aplica (estado_fiscal, fm_sync_status). Estado fiscal solo si no es None.
+Errores HTTP/timeout y contradicciones de identidad conservan su semántica (no se reinterpretan).
+
+Todo con respuestas SIMULADAS contra el writer (PACResponseWriter). Cero PAC real.
+"""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.api import FiscalCorrelationError, PACResponseWriter
+
+
+def _seed_si(*, fiscal_status="", ffm=None):
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+			"fm_fiscal_status": fiscal_status or None,
+			"fm_factura_fiscal_mx": ffm,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(sales_invoice, status, *, facturapi_id="FA-1", uuid="U-1", sync="pending"):
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"facturapi_id": facturapi_id or None,
+			"fm_uuid": uuid or None,
+			"fm_sync_status": sync,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+class TestWriterReconciliacion(IntegrationTestCase):
+	def setUp(self):
+		self.si_names = []
+		self.ffm_names = []
+		self.writer = PACResponseWriter()
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for ffm in self.ffm_names:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self.si_names:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def _si(self, **kwargs):
+		name = _seed_si(**kwargs)
+		self.si_names.append(name)
+		return name
+
+	def _ffm(self, *args, **kwargs):
+		name = _seed_ffm(*args, **kwargs)
+		self.ffm_names.append(name)
+		return name
+
+	def _reconciliar(self, si, ffm, raw, *, status_code=200, success=True):
+		"""Ejecuta el writer con operation_type='reconciliacion'. raw = cuerpo del invoice del PAC."""
+		# get_invoice siempre trae id/uuid para que la correlación estricta pase (salvo en los
+		# tests de contradicción, que los sobreescriben).
+		raw_full = {"id": "FA-1", "uuid": "U-1", **raw}
+		self.writer.write_pac_response(
+			si,
+			{"action": "reconciliacion", "facturapi_id": "FA-1"},
+			{"success": success, "status_code": status_code, "raw_response": raw_full},
+			"reconciliacion",
+			factura_fiscal_name=ffm,
+		)
+
+	def _status(self, ffm):
+		return frappe.db.get_value("Factura Fiscal Mexico", ffm, "status")
+
+	def _sync(self, ffm):
+		return frappe.db.get_value("Factura Fiscal Mexico", ffm, "fm_sync_status")
+
+	# --- estados que delegan en el helper (respuesta exitosa) ---
+
+	def test_valid_none_timbrado_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO")
+		self._reconciliar(si, ffm, {"status": "valid"})
+		self.assertEqual(self._status(ffm), "TIMBRADO")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	def test_valid_pending_pendiente_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO")
+		self._reconciliar(si, ffm, {"status": "valid", "cancellation_status": "pending"})
+		self.assertEqual(self._status(ffm), "PENDIENTE_CANCELACION")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	def test_valid_verifying_pendiente_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO")
+		self._reconciliar(si, ffm, {"status": "valid", "cancellation_status": "verifying"})
+		self.assertEqual(self._status(ffm), "PENDIENTE_CANCELACION")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	def test_canceled_cancelado_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION")
+		self._reconciliar(si, ffm, {"status": "canceled"})
+		self.assertEqual(self._status(ffm), "CANCELADO")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	def test_accepted_sin_status_cancelado_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION")
+		self._reconciliar(si, ffm, {"cancellation_status": "accepted"})
+		self.assertEqual(self._status(ffm), "CANCELADO")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	def test_valid_rejected_timbrado_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION")
+		self._reconciliar(si, ffm, {"status": "valid", "cancellation_status": "rejected"})
+		self.assertEqual(self._status(ffm), "TIMBRADO")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	def test_valid_expired_timbrado_synced(self):
+		si = self._si()
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION")
+		self._reconciliar(si, ffm, {"status": "valid", "cancellation_status": "expired"})
+		self.assertEqual(self._status(ffm), "TIMBRADO")
+		self.assertEqual(self._sync(ffm), "synced")
+
+	# --- sin transición fiscal (helper devuelve None) ---
+
+	def test_remoto_pending_conserva_estado_y_pending(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO")
+		self._reconciliar(si, ffm, {"status": "pending"})
+		self.assertEqual(self._status(ffm), "TIMBRADO")  # sin cambio fiscal
+		self.assertEqual(self._sync(ffm), "pending")
+
+	def test_estado_desconocido_conserva_estado_y_error(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO")
+		self._reconciliar(si, ffm, {"status": "draft"})
+		self.assertEqual(self._status(ffm), "TIMBRADO")  # sin cambio fiscal
+		self.assertEqual(self._sync(ffm), "error")
+
+	# --- contradicción de identidad: conserva la semántica de FiscalCorrelationError ---
+
+	def test_contradiccion_facturapi_id_propaga(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", facturapi_id="FA-1", uuid="U-1")
+		with self.assertRaises(FiscalCorrelationError):
+			self.writer.write_pac_response(
+				si,
+				{"action": "reconciliacion"},
+				{"success": True, "status_code": 200, "raw_response": {"id": "FA-OTRO", "status": "valid"}},
+				"reconciliacion",
+				factura_fiscal_name=ffm,
+			)
+
+	def test_contradiccion_uuid_propaga(self):
+		si = self._si()
+		ffm = self._ffm(si, "TIMBRADO", facturapi_id="FA-1", uuid="U-1")
+		with self.assertRaises(FiscalCorrelationError):
+			self.writer.write_pac_response(
+				si,
+				{"action": "reconciliacion"},
+				{
+					"success": True,
+					"status_code": 200,
+					"raw_response": {"id": "FA-1", "uuid": "U-OTRO", "status": "valid"},
+				},
+				"reconciliacion",
+				factura_fiscal_name=ffm,
+			)
+
+	# cero referencias al cliente PAC en el módulo
+	def test_cero_trafico_pac(self):
+		g = globals()
+		for simbolo in ("FacturapiClient", "create_invoice", "cancel_invoice", "requests", "get_invoice"):
+			self.assertNotIn(simbolo, g, f"La prueba no debe importar {simbolo}")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_writer_reconciliacion.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_writer_reconciliacion.py
@@ -12,6 +12,12 @@ from frappe.tests import IntegrationTestCase
 
 from facturacion_mexico.facturacion_fiscal.api import FiscalCorrelationError, PACResponseWriter
 
+# Identidades fiscales únicas por corrida (evita colisiones con registros residuales y cumple la
+# regla de IDs generados). El seed y el builder de respuesta comparten estas constantes para que la
+# correlación estricta pase; los tests de contradicción usan pares literales propios.
+_FA_ID = "FA-" + frappe.generate_hash()[:10]
+_UUID = "U-" + frappe.generate_hash()[:10]
+
 
 def _seed_si(*, fiscal_status="", ffm=None):
 	si = frappe.get_doc(
@@ -35,7 +41,7 @@ def _seed_si(*, fiscal_status="", ffm=None):
 	return si.name
 
 
-def _seed_ffm(sales_invoice, status, *, facturapi_id="FA-1", uuid="U-1", sync="pending"):
+def _seed_ffm(sales_invoice, status, *, facturapi_id=_FA_ID, uuid=_UUID, sync="pending"):
 	ffm = frappe.get_doc(
 		{
 			"doctype": "Factura Fiscal Mexico",
@@ -89,10 +95,10 @@ class TestWriterReconciliacion(IntegrationTestCase):
 		"""Ejecuta el writer con operation_type='reconciliacion'. raw = cuerpo del invoice del PAC."""
 		# get_invoice siempre trae id/uuid para que la correlación estricta pase (salvo en los
 		# tests de contradicción, que los sobreescriben).
-		raw_full = {"id": "FA-1", "uuid": "U-1", **raw}
+		raw_full = {"id": _FA_ID, "uuid": _UUID, **raw}
 		self.writer.write_pac_response(
 			si,
-			{"action": "reconciliacion", "facturapi_id": "FA-1"},
+			{"action": "reconciliacion", "facturapi_id": _FA_ID},
 			{"success": success, "status_code": status_code, "raw_response": raw_full},
 			"reconciliacion",
 			factura_fiscal_name=ffm,

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -38,7 +38,11 @@ def _log_payload_checkpoint(tag, payload: dict):
 	_log_text(f"{tag}.customer.legal_name", name)
 
 
-from facturacion_mexico.config.fiscal_states_config import FiscalStates, OperationTypes
+from facturacion_mexico.config.fiscal_states_config import (
+	FiscalStates,
+	OperationTypes,
+	derive_pac_reconciliation,
+)
 
 from .api import (  # PAC Response Writer - Arquitectura resiliente activada
 	FiscalCorrelationError,
@@ -1552,24 +1556,20 @@ class TimbradoAPI:
 					f"Respuesta PAC para FFM {factura_fiscal.name}: status='{response_status}', cancellation_status='{cancellation_status}'"
 				)
 
-				# Mapeo correcto según documentación FacturAPI
-				if response_status == "canceled" or cancellation_status == "accepted":
-					fiscal_status = FiscalStates.CANCELADO
+				# Mapeo ÚNICO (derive_pac_reconciliation): mantiene accepted->CANCELADO y suma
+				# expired->TIMBRADO. Se consume solo el estado fiscal ([0]); el sync lo maneja el writer.
+				fiscal_status = derive_pac_reconciliation(response_status, cancellation_status)[0]
+				if fiscal_status == FiscalStates.CANCELADO:
 					cancellation_date = now_datetime()
-				elif cancellation_status == "pending":
-					fiscal_status = FiscalStates.PENDIENTE_CANCELACION
-					cancellation_date = None
-				elif cancellation_status == "rejected":
-					# Mantener como timbrado - no cambiar estado fiscal
-					fiscal_status = FiscalStates.TIMBRADO
-					cancellation_date = None
-				else:
-					# Fallback conservador para respuestas inesperadas
+				elif fiscal_status is None:
+					# Respuesta inesperada/no definitiva: fallback conservador (comportamiento previo).
 					fiscal_status = FiscalStates.PENDIENTE_CANCELACION
 					cancellation_date = None
 					frappe.logger().warning(
 						f"Respuesta PAC inesperada para FFM {factura_fiscal.name}: status='{response_status}', cancellation_status='{cancellation_status}'. Usando fallback PENDIENTE_CANCELACION"
 					)
+				else:
+					cancellation_date = None
 
 				# Actualizar FFM con estado correcto
 				update_data = {
@@ -3486,23 +3486,25 @@ def revisar_estatus_cancelacion(ffm_name: str) -> dict:
 	pac_status = data.get("status", "")
 	cancel_status = data.get("cancellation_status", "")
 
-	if pac_status == "canceled" or cancel_status == "accepted":
-		nuevo_estado = FiscalStates.CANCELADO
+	# Mapeo ÚNICO (derive_pac_reconciliation): se consume solo el estado fiscal ([0]).
+	# Mantiene accepted->CANCELADO y suma expired->TIMBRADO (antes caía a PENDIENTE_CANCELACION).
+	nuevo_estado = derive_pac_reconciliation(pac_status, cancel_status)[0]
+	if nuevo_estado == FiscalStates.CANCELADO:
 		update_data = {
 			"status": nuevo_estado,
 			"cancellation_date": now_datetime(),
 		}
 		msg = _("Cancelación confirmada por el receptor. CFDI cancelado.")
 		indicator = "green"
-	elif cancel_status == "rejected":
-		nuevo_estado = FiscalStates.TIMBRADO
+	elif nuevo_estado == FiscalStates.TIMBRADO:
 		update_data = {
 			"status": nuevo_estado,
 			"fm_motivo_cancelacion": None,
 		}
-		msg = _("El receptor rechazó la cancelación. CFDI sigue vigente.")
+		msg = _("La cancelación no procedió (rechazada o expirada). CFDI sigue vigente.")
 		indicator = "orange"
 	else:
+		# None (no definitivo) o cualquier otro: conservar PENDIENTE_CANCELACION.
 		nuevo_estado = FiscalStates.PENDIENTE_CANCELACION
 		update_data = {"status": nuevo_estado}
 		msg = _("Cancelación aún pendiente de aceptación por el receptor.")

--- a/facturacion_mexico/hooks.py
+++ b/facturacion_mexico/hooks.py
@@ -447,6 +447,10 @@ scheduler_events = {
 		"facturacion_mexico.complementos_pago.api.process_pending_complements",
 		"facturacion_mexico.ereceipts.api.expire_ereceipts",
 	],
+	"hourly_long": [
+		# Reconciliación FFM ↔ FacturAPI: solo consulta al PAC; nunca timbra ni cancela.
+		"facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.run_auto_reconciliation",
+	],
 	"cron": {
 		# Validación RFC automática nocturna a las 2:00 AM todos los días
 		"0 2 * * *": [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Primeros Pasos: usuario/getting-started.md
     - Emitir un CFDI: usuario/emitir-cfdi.md
     - Cancelar CFDI: usuario/cancelar-cfdi.md
+    - Verificar estado en FacturAPI: usuario/verificar-estado-facturapi.md
     - Complemento de Pago: usuario/complemento-pago.md
     - CFDI Recibidos: usuario/cfdi-recibidos.md
     - E-Receipts y Autofactura: usuario/ereceipts.md
@@ -109,6 +110,7 @@ nav:
       - adr/0032-ereceipts-facturapi-arquitectura.md
       - adr/0033-factura-global-hardcodes.md
       - adr/0034-integridad-correlacion-ffm.md
+      - adr/0035-motor-reconciliacion-ffm.md
   - Referencia:
     - referencia/index.md
     - DocTypes: referencia/doctypes.md


### PR DESCRIPTION
## Objetivo

Conciliar el estado local de cada **Factura Fiscal Mexico (FFM)** con el estado real en FacturAPI,
resolviendo el residuo histórico de FFM `TIMBRADO + fm_sync_status=pending` (bug de doble FFM) y
manteniendo al día las cancelaciones en curso. El PAC es la fuente de verdad; el motor **solo lee**.

## Cambios principales

- **Motor automático + verificación manual** de FFM contra FacturAPI (`reconcile_ffm` whitelisted con
  permiso fiscal, y `run_auto_reconciliation` por lote). Botón **"Verificar estado en FacturAPI"** en el FFM.
- **Tráfico PAC exclusivamente GET** (`get_invoice`): nunca `create_invoice`/`cancel_invoice`, ni POST/DELETE,
  ni timbrado/sustitución; nunca toca la Sales Invoice.
- **Correlación estricta por identidad fiscal** (`facturapi_id` + `fm_uuid`) antes de decidir cambios;
  ante contradicción → `fm_sync_status=error`, sin tocar el estado fiscal.
- **Helper único de mapeo** `derive_pac_reconciliation` (fuente de verdad compartida con los flujos de cancelación).
- **Locks de cache (Redis)**: global del lote (TTL 2 h) y por-FFM (TTL 5 min), liberados con compare-and-delete atómico (Lua).
- **Persistencia transaccional correcta**: `fm_last_pac_sync` se sella en cada GET exitoso **incluido el no-op**,
  y se **conserva** en errores (timeout/429/5xx/4xx/contradicción); `fm_sync_status` final del error se persiste.
  (Fix de commit en las ramas que no pasan por el writer — detectado en validación real.)
- **Visualización**: limpieza de layout del FFM (campos de archivo/URL ocultos, secciones reorganizadas) y
  **semáforo de sincronización** (badge 🟢 synced / 🟠 pending / 🔴 error).

## Documentación actualizada

- `docs/adr/0035-motor-reconciliacion-ffm.md` (+ `docs/adr/index.md`).
- `docs/usuario/verificar-estado-facturapi.md` (+ `mkdocs.yml` nav).

## Validaciones realizadas

- **225 pruebas verdes** (suite completa de la app), incluidas 4 nuevas de regresión transaccional
  (persistencia del no-op, dos consultas consecutivas, conservación en error, SI intacta).
- **Ruff** (check + format), **Prettier** y **`mkdocs build --strict`** limpios.
- **Validación real A–E en `llantascs-v16.dev`**:
  - A) `pending → synced` con Response Log 200; B) no-op + idempotencia (no duplica log) + sellado de timestamp;
    C) CANCELADO no-op; D) históricos `FFM-HIST-*` (existen en la cuenta, no-op); E) sin `facturapi_id` → sin botón.
  - **Backlog ~69–70 FFM `TIMBRADO+pending` → 0.**
  - **Lote final: 56 seleccionados / 56 procesados / 56 corregidos / 0 errores.**
  - En `llantascs-v16.dev`, todo FFM con `facturapi_id` quedó `synced` tras la reconciliación (11,194 TIMBRADO + 464 CANCELADO).
  - **Ninguna Sales Invoice fue modificada ni cancelada.** Tráfico PAC **exclusivamente GET**.

## Despliegue

- **Requiere `bench migrate`** — registra el `Scheduled Job Type` `hourly_long` y sincroniza el DocType (campos ocultos, badge HTML).
- **Requiere `bench build --app facturacion_mexico`** — compila el asset JS (botón + semáforo).
- El job **`hourly_long` ya está registrado** en `llantascs-v16.dev` (creado por el migrate de validación).
- ⚠️ **El scheduler global permanece DESHABILITADO y NO debe habilitarse como parte de este PR.** Habilitarlo
  inicia GET reales por hora contra FacturAPI; se hará solo cuando se autorice ese tráfico.

## Fuera de alcance

- Barrido del histórico completo, `fm_sync_status='error'` sin `facturapi_id`, reparación de duplicados, archivado de huérfanos.
- Habilitación del scheduler.

## Riesgos / pendientes

- Backups restaurados pueden traer credenciales FacturAPI cifradas con otra `encryption_key` (bloqueo de entorno, no de código).
- Branches sin datos reales para GUI (cubiertos por unit tests): `404→error`, `PENDIENTE_CANCELACION → accepted/rejected/expired`, correlación contradictoria, `pending` remoto.
