### PR TITLE
fix(permisos): roles de facturación pueden asignar/crear claves SAT Producto Servicio

### DIFF
--- a/facturacion_mexico/catalogos_sat/doctype/sat_producto_servicio/sat_producto_servicio.json
+++ b/facturacion_mexico/catalogos_sat/doctype/sat_producto_servicio/sat_producto_servicio.json
@@ -85,6 +85,29 @@
     {
       "read": 1,
       "role": "Accounts Manager"
+    },
+    {
+      "read": 1,
+      "role": "Facturacion Mexico User"
+    },
+    {
+      "create": 1,
+      "read": 1,
+      "report": 1,
+      "role": "Facturacion Mexico Manager",
+      "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "Facturacion Mexico System Manager",
+      "share": 1,
+      "write": 1
     }
   ],
   "search_fields": "descripcion,palabras_similares",


### PR DESCRIPTION
## Objetivo

Permitir que los roles de facturación operen el catálogo `SAT Producto Servicio`. Antes, el doctype
solo concedía permisos a `System Manager` y `Accounts Manager`, por lo que un usuario con rol
`Facturacion Mexico User` no podía **asignar** la clave producto/servicio SAT (`Item.fm_producto_servicio_sat`)
a un Item: fallaba con `PermissionError: Not permitted` (Frappe exige `read` sobre el doctype enlazado
para asignar un Link).

## Cambios principales

Se agregan DocPerm a `SAT Producto Servicio` (en el JSON del doctype):

| Rol | read | write | create | delete | report |
|---|---|---|---|---|---|
| Facturacion Mexico User | ✅ | — | — | — | — |
| Facturacion Mexico Manager | ✅ | ✅ | ✅ | — | ✅ |
| Facturacion Mexico System Manager | ✅ | ✅ | ✅ | ✅ | ✅ |

(System Manager global y Accounts Manager se conservan sin cambios.)

- **User** → `read`: puede asignar la clave a Items, sin tocar el catálogo.
- **Manager** → puede crear categorías nuevas.
- **System Manager (del app)** → control completo.

## Alcance del cambio

- 1 archivo: `facturacion_mexico/catalogos_sat/doctype/sat_producto_servicio/sat_producto_servicio.json`.
- Solo permisos (DocPerm) del doctype propio del app. No toca campos, esquema, flujos, código ni otros doctypes.

## Documentación actualizada

No aplica — cambio de permisos (DocPerm) sin nuevo campo/flujo/esquema/comportamiento; ningún doc
describe los permisos del catálogo a nivel de rol.

## Validaciones realizadas

Sitio: `facturacion-v16.dev` (sandbox, migrado con #198/#199).

- **`bench migrate`**: corrió **limpio**, sin errores ni warnings. Verificado en BD que `tabDocPerm`
  de `SAT Producto Servicio` quedó con los 3 roles nuevos (read/write/create/delete según la matriz).
- **Prueba funcional con `Facturacion Mexico User`**: un usuario con ese rol (+ Sales User / Accounts
  User / Item Manager / Sales Master Manager para acceso operativo a Item) **creó un Item y asignó la
  clave producto/servicio SAT sin error** "Not permitted". Confirmado el caso que fallaba.

## Despliegue

- Requiere **`bench migrate`** al instalar — sincroniza los DocPerm desde el JSON del doctype.
  **No** requiere export-fixtures (los permisos viven en el doctype propio del app).

## Fuera de alcance

- Permisos de otros doctypes, Custom DocPerm (overrides de UI), usuarios y User Permissions: no se tocan.

## Riesgos / rollback

- **Riesgo bajo:** solo amplía permisos sobre un catálogo SAT; no quita permisos existentes.
- **Matiz:** en un sitio con customización de permisos sobre `SAT Producto Servicio` vía UI (`Custom DocPerm`),
  ese override local manda y se conserva; los permisos nuevos podrían no aplicarse ahí hasta reconciliar.
- **Rollback:** revertir el commit `d48641b` + `bench migrate` restaura los permisos previos
  (solo System Manager + Accounts Manager).

## Contenido

- Contiene **exactamente 1 commit**: `d48641b`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-based access control for the SAT Product/Service catalog with granular permission levels. User roles have read-only access, Manager roles can manage and generate reports, and System Manager roles have full administrative permissions including sharing and export capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->