### PR TITLE
fix(cancelacion): integridad de proyección, fail-closed y consolidación del flujo manual

### DIFF
--- a/docs/adr/0035-motor-reconciliacion-ffm.md
+++ b/docs/adr/0035-motor-reconciliacion-ffm.md
@@ -1,9 +1,17 @@
 # ADR-0035 — Motor de reconciliación FFM ↔ FacturAPI
 
-- **Estado:** Propuesto
+- **Estado:** Propuesto (extendido por ADR-0036)
 - **Fecha:** 2026-06-21
 - **Rama:** `feat/motor-reconciliacion-ffm`
 - **Relacionado:** [[0034-integridad-correlacion-ffm]] (integridad y correlación del FFM)
+
+> **Nota (ADR-0036):** Esta decisión fue **extendida/corregida por [[0036-integridad-proyeccion-cancelacion]]**
+> en lo relativo a la **proyección completa del estado de cancelación y la consolidación del flujo manual**:
+> clasificación fail-closed (solo `status=canceled` es terminal; `accepted` aislado ya no produce CANCELADO
+> — corrige §2.4), escritura autoritativa `apply_cancellation_state` (motivo/reason/fecha/sync/snapshot SI),
+> reparación idempotente de FFM terminales incompletas (extiende §2.6), `canceled_at` del PAC como fecha de
+> cancelación, y un solo botón manual (§2.8). El resto sigue vigente (GET-only, correlación, selector de
+> candidatos, scheduler `hourly_long`, locks, semántica de `fm_sync_status`/`fm_last_pac_sync`).
 
 ---
 

--- a/docs/adr/0036-integridad-proyeccion-cancelacion.md
+++ b/docs/adr/0036-integridad-proyeccion-cancelacion.md
@@ -34,6 +34,7 @@ SI stale → **la Sales Invoice no se podía cancelar** (el guard validaba el sn
 ## 2. Decisión
 
 ### 2.1 Clasificación de cancelación **fail-closed** (corrige ADR-0035 §2.4)
+
 El HTTP 200 confirma que la *solicitud* se procesó, **no** que el SAT canceló. La cancelación se
 clasifica con un helper acotado `derive_cancellation_reconciliation(remote_status, cancellation_status)`:
 
@@ -52,6 +53,7 @@ El mismo criterio se usa en los tres caminos: cancelación síncrona (FASE 3), `
 y el motor de reconciliación.
 
 ### 2.2 Operación autoritativa única: `apply_cancellation_state`
+
 Una sola función escribe el estado de cancelación, idempotente y monotónica:
 - conserva `fm_motivo_cancelacion` (motivo SAT solicitado);
 - deriva `cancellation_reason` desde ese motivo (sobrescribe residuos como `01`);
@@ -66,6 +68,7 @@ La escritura de estado en cancelación deja de pasar por el writer (que solo cre
 `skip_state_persist`), eliminando la doble escritura / commit parcial.
 
 ### 2.3 Reparación idempotente desde el motor (extiende ADR-0035 §2.6)
+
 El reconciliador ejecuta `apply_cancellation_state` en cancelaciones **aunque `status` y
 `fm_sync_status` no cambien**, para reparar FFM terminales incompletas (reason/fecha/snapshot SI).
 Se crea Response Log de reconciliación cuando hubo cambio real (status, sync **o** reparación de
@@ -73,18 +76,21 @@ campos); si nada cambió, no se crea log. **No** se altera el selector de candid
 (`_select_candidates`): el scheduler sigue procesando solo `pending` / `PENDIENTE_CANCELACION`.
 
 ### 2.4 `cancellation_date` desde `canceled_at` del PAC
+
 La fecha de cancelación usa el `canceled_at` **real** que entrega FacturAPI (UTC ISO-8601 con `Z`),
 normalizado a la zona horaria del sitio (`convert_utc_to_system_timezone`). `now()` solo se usa como
 respaldo si el PAC no entrega `canceled_at`. Una `cancellation_date` ya existente nunca se sobrescribe.
 Solo se fija fecha cuando el estado es CANCELADO.
 
 ### 2.5 Consolidación del flujo manual (corrige ADR-0035 §2.8)
+
 Queda **un solo** botón de consulta: **"Verificar estado en FacturAPI"** (→ `reconcile_ffm`). El botón
 duplicado "Revisar Estatus Cancelación" se eliminó. La función `revisar_estatus_cancelacion` se mantiene
 por compatibilidad como **wrapper** que delega en `reconcile_ffm` (hereda company, correlación estricta,
 lock por FFM y permiso fiscal; no realiza una segunda consulta al PAC).
 
 ### 2.6 Otros endurecimientos
+
 - **Guard de cancelación de SI:** `cancelar_si_post_fiscal` valida el estado **real** de la FFM activa,
   no el snapshot `SI.fm_fiscal_status` (derivado).
 - **Resolución de FFM en el endpoint de cancelación:** se resuelve la FFM activa por

--- a/docs/adr/0036-integridad-proyeccion-cancelacion.md
+++ b/docs/adr/0036-integridad-proyeccion-cancelacion.md
@@ -1,0 +1,126 @@
+# ADR-0036 — Integridad de la proyección de cancelación y consolidación del flujo manual
+
+- **Estado:** Propuesto
+- **Fecha:** 2026-06-24
+- **Rama:** `fix/cancelacion-integridad`
+- **Relacionado:** [[0034-integridad-correlacion-ffm]] (correlación estricta y writer) · [[0035-motor-reconciliacion-ffm]] (motor de reconciliación)
+- **Extiende/corrige:** ADR-0035 (clasificación de cancelación, persistencia y flujo manual). **No** lo reemplaza por completo.
+
+---
+
+## 1. Contexto y problema
+
+Tras ADR-0035, se detectaron en producción (LlantasCS) FFM marcadas localmente como `CANCELADO` que
+**no estaban canceladas ante el SAT** o que quedaron con campos incompletos. Causas confirmadas
+(forense sobre FFMX-2026-00117 y 00137):
+
+1. **`CANCELADO` prematuro.** El writer clasificaba la respuesta de la cancelación por **HTTP 200**
+   (`Solicitud Cancelación → CANCELADO`), ignorando `cancellation_status`. Una respuesta
+   `valid + verifying` (la cancelación apenas se está verificando en el SAT) se marcaba CANCELADO.
+2. **Crash `(1406) Data too long for column 'method'`** durante la finalización: el antipatrón
+   `frappe.log_error(<texto largo>, "título")` contra la firma `log_error(title, message)` desbordaba
+   la columna `method` (140) y abortaba la FASE 3, dejando `cancellation_reason` residual (`01`),
+   `cancellation_date` vacía y el snapshot de la SI sin sincronizar.
+3. **Finalización asíncrona incompleta.** El motor (ADR-0035) escribía solo `status` + `fm_sync_status`
+   al llegar a CANCELADO; no completaba `cancellation_reason`/`cancellation_date`/snapshot SI.
+4. **Duplicación de flujo manual.** Coexistían dos botones que consultaban el PAC: "Verificar estado
+   en FacturAPI" (motor, con company/correlación/lock/permiso) y "Revisar Estatus Cancelación"
+   (camino laxo, sin esas protecciones).
+5. **Fecha de cancelación = `now()`** en vez del `canceled_at` real del PAC.
+
+Efecto convergente: `CANCELADO` + `cancellation_reason="01"` + `cancellation_date` vacía + snapshot
+SI stale → **la Sales Invoice no se podía cancelar** (el guard validaba el snapshot, no el estado real).
+
+## 2. Decisión
+
+### 2.1 Clasificación de cancelación **fail-closed** (corrige ADR-0035 §2.4)
+El HTTP 200 confirma que la *solicitud* se procesó, **no** que el SAT canceló. La cancelación se
+clasifica con un helper acotado `derive_cancellation_reconciliation(remote_status, cancellation_status)`:
+
+| Respuesta PAC | Estado local |
+|---|---|
+| `status = canceled` | **CANCELADO** (único terminal) |
+| `valid` + `pending` / `verifying` / `accepted` (aislado) | **PENDIENTE_CANCELACION** |
+| `valid` + `rejected` / `expired` | TIMBRADO (sigue vigente) |
+| `valid` + ninguno | TIMBRADO |
+| desconocido / incoherente | sin transición (**nunca CANCELADO**) |
+
+> **Corrección a ADR-0035:** `accepted` **aislado** (sin `status=canceled`) ya **no** produce
+> CANCELADO. Solo `status=canceled` es terminal.
+
+El mismo criterio se usa en los tres caminos: cancelación síncrona (FASE 3), `revisar_estatus_cancelacion`
+y el motor de reconciliación.
+
+### 2.2 Operación autoritativa única: `apply_cancellation_state`
+Una sola función escribe el estado de cancelación, idempotente y monotónica:
+- conserva `fm_motivo_cancelacion` (motivo SAT solicitado);
+- deriva `cancellation_reason` desde ese motivo (sobrescribe residuos como `01`);
+- fija `cancellation_date` (ver §2.4);
+- fija `fm_sync_status` (valor derivado, no asumido);
+- sincroniza `SI.fm_fiscal_status` **solo si** la SI apunta a esa FFM (`SI.fm_factura_fiscal_mx == FFM.name`);
+- **monotonicidad:** una FFM `CANCELADO` **no se degrada** a PENDIENTE/TIMBRADO por una respuesta vieja;
+- **reparación:** `CANCELADO → CANCELADO` **sí** ejecuta la parte reparadora para completar campos faltantes;
+- devuelve si escribió algún campo (para decidir trazabilidad).
+
+La escritura de estado en cancelación deja de pasar por el writer (que solo crea el Response Log con
+`skip_state_persist`), eliminando la doble escritura / commit parcial.
+
+### 2.3 Reparación idempotente desde el motor (extiende ADR-0035 §2.6)
+El reconciliador ejecuta `apply_cancellation_state` en cancelaciones **aunque `status` y
+`fm_sync_status` no cambien**, para reparar FFM terminales incompletas (reason/fecha/snapshot SI).
+Se crea Response Log de reconciliación cuando hubo cambio real (status, sync **o** reparación de
+campos); si nada cambió, no se crea log. **No** se altera el selector de candidatos asíncronos
+(`_select_candidates`): el scheduler sigue procesando solo `pending` / `PENDIENTE_CANCELACION`.
+
+### 2.4 `cancellation_date` desde `canceled_at` del PAC
+La fecha de cancelación usa el `canceled_at` **real** que entrega FacturAPI (UTC ISO-8601 con `Z`),
+normalizado a la zona horaria del sitio (`convert_utc_to_system_timezone`). `now()` solo se usa como
+respaldo si el PAC no entrega `canceled_at`. Una `cancellation_date` ya existente nunca se sobrescribe.
+Solo se fija fecha cuando el estado es CANCELADO.
+
+### 2.5 Consolidación del flujo manual (corrige ADR-0035 §2.8)
+Queda **un solo** botón de consulta: **"Verificar estado en FacturAPI"** (→ `reconcile_ffm`). El botón
+duplicado "Revisar Estatus Cancelación" se eliminó. La función `revisar_estatus_cancelacion` se mantiene
+por compatibilidad como **wrapper** que delega en `reconcile_ffm` (hereda company, correlación estricta,
+lock por FFM y permiso fiscal; no realiza una segunda consulta al PAC).
+
+### 2.6 Otros endurecimientos
+- **Guard de cancelación de SI:** `cancelar_si_post_fiscal` valida el estado **real** de la FFM activa,
+  no el snapshot `SI.fm_fiscal_status` (derivado).
+- **Resolución de FFM en el endpoint de cancelación:** se resuelve la FFM activa por
+  `SI.fm_factura_fiscal_mx` (validando el vínculo), no por `get_all(... limit=1)`.
+- **`cancellation_reason` (Select):** primera opción **vacía** + `read_only`. Evita que una FFM nueva
+  nazca con el motivo `01` implícito (default de Select de Frappe).
+- **Logging:** las llamadas `frappe.log_error` del camino de cancelación usan argumentos nombrados
+  (`title=`, `message=`); el fallo del logger ya no reemplaza la excepción original (corrige el 1406).
+
+## 3. Consecuencias
+
+- Una solicitud de cancelación en proceso permanece en `PENDIENTE_CANCELACION` hasta que el SAT confirme.
+- El motor y la verificación manual **completan/reparan** FFM CANCELADO incompletas sin degradarlas.
+- `cancellation_date` refleja el instante fiscal real (`canceled_at`).
+- La SI vuelve a ser cancelable cuando la FFM activa está realmente CANCELADO.
+- **Estado de los ADR:** ADR-0035 sigue vigente en lo relativo al motor (GET-only, correlación,
+  selector de candidatos, scheduler `hourly_long`, locks, semántica de `fm_sync_status`/`fm_last_pac_sync`,
+  sin DocTypes/campos nuevos). ADR-0034 sigue vigente (correlación estricta y writer). Este ADR-0036
+  **corrige** la clasificación de cancelación y la persistencia de cancelación de ADR-0035, y **agrega**
+  la proyección completa, la reparación idempotente, el `canceled_at` y la consolidación del flujo manual.
+
+## 4. Validación
+
+Validado en `llantascs-v16.dev` (backup de producción) con datos reales del PAC:
+- **FFMX-2026-00137:** PAC `status=canceled`, motivo `02`, SAT `2026-06-23T18:01:23.572Z` → local
+  `2026-06-23 12:01:23.572` (UTC-6), `cancellation_reason → 02`, `SI.fm_fiscal_status → CANCELADO`,
+  Response Log de reconciliación, **0** nuevas solicitudes de cancelación, **0** nuevos errores 1406.
+- Suites de regresión de ADR-0034/0035 verdes + suite nueva de integridad de cancelación.
+
+## 5. Alternativas descartadas
+
+- **Mantener los dos botones** alineando el laxo con company/correlación/lock/permiso: descartado;
+  deja dos puertas para la misma operación.
+- **Comando de "reparación" separado** del reconciliador: descartado; la reparación idempotente dentro
+  del motor reutiliza el flujo único sin arquitectura nueva.
+- **Incluir las FFM `CANCELADO` incompletas en el selector asíncrono:** descartado en este alcance; la
+  reparación de terminales se hace por el botón manual, sin tocar `_select_candidates`.
+- **Usar `now()` como fecha de cancelación:** descartado; no es el instante fiscal real cuando el PAC
+  entrega `canceled_at`.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -39,3 +39,4 @@ Registro permanente de decisiones de arquitectura. Un ADR nunca se modifica — 
 | [0033](0033-factura-global-hardcodes.md) | Eliminación de defaults fiscales silenciosos en Factura Global |
 | [0034](0034-integridad-correlacion-ffm.md) | Integridad y correlación de Factura Fiscal Mexico |
 | [0035](0035-motor-reconciliacion-ffm.md) | Motor de reconciliación FFM ↔ FacturAPI |
+| [0036](0036-integridad-proyeccion-cancelacion.md) | Integridad de la proyección de cancelación y consolidación del flujo manual |

--- a/docs/tecnico/arquitectura.md
+++ b/docs/tecnico/arquitectura.md
@@ -106,6 +106,8 @@ Campos relevantes definidos directamente en el JSON del DocType (no como Custom 
 | `fm_sync_status` | Select | Estado sincronización PAC: `synced` / `pending` / `error` |
 | `fm_payment_method_sat` | Select | `PUE` o `PPD` |
 | `fm_pdf_custom_section` | Long Text | Texto enviado a FacturAPI como `pdf_custom_section` al timbrar. Read-only — registra exactamente lo enviado. Solo para CFDI tipo I. |
+| `fm_motivo_cancelacion` | Data | Motivo SAT **solicitado** (01/02/03/04). Se **conserva** durante todo el ciclo de cancelación. |
+| `cancellation_reason` | Select | Descripción **derivada** del motivo, **read-only** (salida del sistema). La primera opción es **vacía** para no asignar implícitamente el motivo `01` al crear la FFM. |
 
 ### Complemento Pago MX — campos propios del DocType
 
@@ -120,6 +122,32 @@ Campos relevantes definidos directamente en el JSON del DocType (no como Custom 
 | `timbrar_factura` | `timbrado_api` | Timbra CFDI desde SI |
 | `cancelar_factura` | `timbrado_api` | Cancela CFDI con motivo SAT |
 | `descargar_archivos_cfdi` | `timbrado_api` | Descarga PDF+XML desde FacturAPI y los adjunta al FFM. Wrapper de `TimbradoAPI._download_fiscal_files()` — no duplica lógica. |
+| `revisar_estatus_cancelacion` | `timbrado_api` | **Compat:** wrapper que delega en `reconcile_ffm`. No tiene lógica propia. |
+
+## Flujo de cancelación y reconciliación
+
+> Decisiones y detalle en [ADR-0036](../adr/0036-integridad-proyeccion-cancelacion.md) (proyección de
+> cancelación) y [ADR-0035](../adr/0035-motor-reconciliacion-ffm.md) (motor de reconciliación).
+
+- **Solicitud de cancelación:** el HTTP 200 confirma que la *solicitud* se procesó, **no** que el SAT canceló.
+- **Clasificación fail-closed** (`derive_cancellation_reconciliation`):
+  - `status = canceled` → **CANCELADO** (único estado terminal);
+  - `valid` + `pending`/`verifying`/`accepted` (aislado) → **PENDIENTE_CANCELACION**;
+  - `valid` + `rejected`/`expired` → TIMBRADO (vigente);
+  - desconocido/incoherente → sin transición (**nunca** CANCELADO).
+- **Confirmación síncrona** (FASE 3 de `cancelar_factura`) y **asíncrona** (motor / botón "Verificar estado
+  en FacturAPI") usan el **mismo** helper autoritativo `apply_cancellation_state`, que escribe en una sola
+  operación: `status`, `fm_motivo_cancelacion` (conservado), `cancellation_reason` (derivado),
+  `cancellation_date`, `fm_sync_status` y el snapshot `SI.fm_fiscal_status` (solo si `SI.fm_factura_fiscal_mx == FFM.name`).
+- **Monotonicidad y reparación:** una FFM `CANCELADO` **no se degrada**; una FFM `CANCELADO` **incompleta**
+  sí se **repara** (idempotente) aunque `status`/`fm_sync_status` no cambien. El reconciliador crea Response
+  Log solo si hubo cambio real; **no** se altera el selector de candidatos (`_select_candidates`) ni el
+  alcance del scheduler.
+- **`cancellation_date`:** usa el `canceled_at` real del PAC (UTC → zona del sitio); `now()` solo como
+  respaldo si el PAC no lo entrega; una fecha existente nunca se sobrescribe.
+- **Flujo manual único:** un solo botón **"Verificar estado en FacturAPI"** (`reconcile_ffm`).
+- **Guard de cancelación de la SI:** `cancelar_si_post_fiscal` valida el estado **real** de la FFM activa,
+  no el snapshot derivado `SI.fm_fiscal_status`.
 
 ## Integraciones externas
 

--- a/docs/usuario/cancelar-cfdi.md
+++ b/docs/usuario/cancelar-cfdi.md
@@ -39,17 +39,20 @@ Este camino cancela el CFDI sin emitir uno nuevo.
 3. En el FFM → sección **Cancelación** → seleccionar el **motivo** (02, 03 o 04)
 4. Confirmar
 
-El sistema envía la solicitud de cancelación a FacturAPI.io.
+El sistema envía la **solicitud** de cancelación a FacturAPI.io. Que FacturAPI reciba la solicitud
+**no** significa que el CFDI ya esté cancelado: solo cuando el SAT lo confirma queda en `CANCELADO`.
 
 ### Qué pasa después
 
-| Respuesta del SAT | Estado resultante | Qué significa |
+| Estado real en el SAT | Estado resultante | Qué significa |
 |---|---|---|
-| `canceled` / `accepted` | `CANCELADO` | Cancelación aceptada de inmediato |
-| `pending` | `PENDIENTE_CANCELACION` | El receptor tiene 72 horas para aceptar o rechazar |
-| `rejected` | `TIMBRADO` (sin cambio) | El receptor rechazó la cancelación |
+| `canceled` | `CANCELADO` | Cancelación **confirmada** por el SAT |
+| `pending` / `verifying` / `accepted` (sin `canceled`) | `PENDIENTE_CANCELACION` | La solicitud se procesó; el SAT/receptor aún no la confirma |
+| `rejected` / `expired` | `TIMBRADO` (sin cambio) | La cancelación no procedió; el CFDI sigue vigente |
 
-Si queda en `PENDIENTE_CANCELACION`: esperar. El SAT acepta automáticamente después de 72 horas si el receptor no responde. Puedes verificar el estado con el botón **"Revisar estatus cancelación"** en el FFM.
+Si queda en `PENDIENTE_CANCELACION`: esperar. El SAT acepta automáticamente después de 72 horas si el
+receptor no responde. Puedes verificar o actualizar el estado con el botón **"Verificar estado en
+FacturAPI"** en el FFM (ver [Verificar estado en FacturAPI](verificar-estado-facturapi.md)).
 
 ---
 

--- a/docs/usuario/verificar-estado-facturapi.md
+++ b/docs/usuario/verificar-estado-facturapi.md
@@ -14,10 +14,23 @@ En ambos casos el sistema **solo consulta** a FacturAPI: nunca timbra, cancela n
 
 El botón **solo aparece** cuando la FFM ya está **guardada** y tiene un comprobante en FacturAPI
 (`facturapi_id`). Al pulsarlo, el sistema consulta el estado real en FacturAPI, actualiza la FFM si
-corresponde y **recarga el documento** para mostrar el estado al día.
+corresponde y **recarga el documento** para mostrar el estado al día. **Es el único botón de
+consulta**: realiza una **consulta de estado**, nunca envía una nueva solicitud de cancelación.
 
 > El botón **no cancela la Sales Invoice**. Si la verificación confirma que el CFDI quedó
 > **CANCELADO**, después puedes cancelar la Sales Invoice con el procedimiento normal.
+
+**Importante:** una cancelación **pendiente** permanece pendiente hasta que el SAT la confirme. Que
+FacturAPI haya recibido la solicitud **no** significa que el CFDI ya esté cancelado: solo cuando el
+estado real es *cancelado* la FFM pasa a **CANCELADO**.
+
+### Reparación de cancelaciones
+
+Si una FFM quedó marcada como **CANCELADO** pero con información incompleta (motivo, descripción,
+fecha de cancelación, o el estado de la venta sin actualizar), pulsar **"Verificar estado en
+FacturAPI"** **completa esos campos** conforme a la respuesta del PAC, **sin cambiar** el estado ya
+cancelado. La **fecha de cancelación** mostrada proviene del `canceled_at` que entrega FacturAPI (la
+hora real de cancelación), no de la hora de la consulta.
 
 ### Resultados posibles
 

--- a/facturacion_mexico/api/fiscal_operations.py
+++ b/facturacion_mexico/api/fiscal_operations.py
@@ -188,8 +188,12 @@ def cancelar_si_post_fiscal(si_name: str):
 	if si.docstatus != 1:
 		frappe.throw(_("Solo se puede cancelar una Sales Invoice enviada."))
 
-	if (si.get("fm_fiscal_status") or "").upper() != "CANCELADO":
-		frappe.throw(_("Solo aplica cuando la Factura Fiscal está cancelada ante el SAT."))
+	# Validar el estado REAL de la FFM activa, no el snapshot SI.fm_fiscal_status (que puede quedar
+	# desactualizado tras una resolución asíncrona). El snapshot es derivado, no autoritativo.
+	active_ffm = si.get("fm_factura_fiscal_mx")
+	active_status = frappe.db.get_value("Factura Fiscal Mexico", active_ffm, "status") if active_ffm else None
+	if (active_status or "").upper() != "CANCELADO":
+		frappe.throw(_("Solo aplica cuando la Factura Fiscal activa está cancelada ante el SAT."))
 
 	if not frappe.has_permission("Sales Invoice", "cancel", si):
 		frappe.throw(_("Sin permisos para cancelar Sales Invoice."))

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -241,6 +241,7 @@ class PACResponseWriter:
 		operation_type: str = "timbrado",
 		*,
 		factura_fiscal_name: str | None = None,
+		skip_state_persist: bool = False,
 	) -> dict[str, Any]:
 		"""
 		Escribir respuesta PAC con máxima resilencia.
@@ -280,6 +281,7 @@ class PACResponseWriter:
 			None,  # fm_last_response_log se asigna después, cuando el log exista
 			operation_type,
 			factura_fiscal_name=factura_fiscal_name,
+			skip_state_persist=skip_state_persist,
 		)
 		result["success"] = True
 		result["method"] = "database"
@@ -637,6 +639,7 @@ class PACResponseWriter:
 		operation_type: str = "Timbrado",
 		*,
 		factura_fiscal_name: str | None = None,
+		skip_state_persist: bool = False,
 	):
 		"""Actualizar Factura Fiscal Mexico con datos de respuesta."""
 		try:
@@ -666,17 +669,25 @@ class PACResponseWriter:
 			# M1 (CodeRabbit): tampoco se refresca fm_last_pac_sync en eventos internos no-PAC;
 			# hacerlo haría que un fallback interno parezca una sincronización fresca con el PAC.
 			_is_fiscal_event = isinstance(operation_type, str) and operation_type.startswith("fiscal_event_")
+			# Cancelación: el estado de negocio (status + fm_sync_status) lo persiste EXCLUSIVAMENTE
+			# apply_cancellation_state, no el writer (evita doble escritura / commit parcial). El
+			# writer sigue creando el Response Log y refresca fm_last_pac_sync (evidencia de consulta).
+			# "Solicitud Cancelación" siempre omite; "Reconciliacion" solo cuando el caller lo indica
+			# (skip_state_persist) tras decidir que reconcilia una cancelación.
+			_skip_fiscal = skip_state_persist or _normalized_op == "Solicitud Cancelación"
+
 			update_fields = {}
 			if not _is_fiscal_event:
 				update_fields["fm_last_pac_sync"] = now_datetime()
-			sync_status = _derive_sync_status_from_response(response_data, operation_type)
-			if sync_status is not None:
-				update_fields["fm_sync_status"] = sync_status
+			if not _skip_fiscal:
+				sync_status = _derive_sync_status_from_response(response_data, operation_type)
+				if sync_status is not None:
+					update_fields["fm_sync_status"] = sync_status
 
-			# Solo actualizar estado fiscal si la operación lo requiere (new_status no es None)
-			if new_status is not None:
-				normalized_status = _norm_status(new_status)
-				update_fields["status"] = normalized_status
+				# Solo actualizar estado fiscal si la operación lo requiere (new_status no es None)
+				if new_status is not None:
+					normalized_status = _norm_status(new_status)
+					update_fields["status"] = normalized_status
 
 			# Actualizar UUID solo si es exitoso
 			if uuid:
@@ -785,10 +796,23 @@ class PACResponseWriter:
 			return "ERROR", status_code or 500, ""
 
 		elif operation_type == "Solicitud Cancelación":
-			# Para cancelación: éxito = CANCELADO, error = mantener estado actual (no cambiar)
-			if ok and status_code in (200, 201):
-				return "CANCELADO", status_code, ""
-			# ERROR EN CANCELACIÓN: NO cambiar estado fiscal (return None = no update)
+			# El HTTP 200 solo confirma que la SOLICITUD se procesó, no que el SAT canceló.
+			# Criterio fiscal acotado y fail-closed: verifying/pending/accepted-aislado ->
+			# PENDIENTE_CANCELACION; canceled -> CANCELADO; rejected/expired -> TIMBRADO;
+			# desconocido/incoherente -> None (nunca CANCELADO). En cancelación el estado lo
+			# persiste apply_cancellation_state, no el writer (skip_state_persist).
+			from facturacion_mexico.facturacion_fiscal.cancellation_state import (
+				derive_cancellation_reconciliation,
+			)
+
+			try:
+				code = int(status_code) if status_code is not None else 0
+			except (TypeError, ValueError):
+				code = 0
+			if ok and code in (200, 201):
+				rs, cs = _extract_reconciliation_states(resp)
+				fiscal_status, _sync = derive_cancellation_reconciliation(rs, cs)
+				return fiscal_status, code, ""
 			return None, status_code or 500, ""
 
 		elif operation_type == "Reconciliacion":
@@ -825,6 +849,7 @@ def write_pac_response(
 	response_data: str,
 	operation_type: str = "timbrado",
 	factura_fiscal_name: str | None = None,
+	skip_state_persist: bool = False,
 ) -> dict[str, Any]:
 	"""
 	API pública para escribir respuesta PAC.
@@ -854,6 +879,7 @@ def write_pac_response(
 			response_dict,
 			operation_type,
 			factura_fiscal_name=factura_fiscal_name,
+			skip_state_persist=skip_state_persist,
 		)
 
 		return result

--- a/facturacion_mexico/facturacion_fiscal/api/__init__.py
+++ b/facturacion_mexico/facturacion_fiscal/api/__init__.py
@@ -849,7 +849,6 @@ def write_pac_response(
 	response_data: str,
 	operation_type: str = "timbrado",
 	factura_fiscal_name: str | None = None,
-	skip_state_persist: bool = False,
 ) -> dict[str, Any]:
 	"""
 	API pública para escribir respuesta PAC.
@@ -865,13 +864,19 @@ def write_pac_response(
 
 	Returns:
 		Dict con resultado operación
+
+	Nota de seguridad: `skip_state_persist` NO se expone en esta frontera pública.
+	Saltarse la persistencia del estado fiscal es una decisión server-side que se deriva
+	internamente de `operation_type` ("Solicitud Cancelación") en el writer; un caller del
+	endpoint no puede controlarla. El flag solo existe en `PACResponseWriter.write_pac_response`
+	para uso interno (p. ej. el motor de reconciliación).
 	"""
 	try:
 		# Parse JSON strings
 		request_dict = json.loads(request_data) if isinstance(request_data, str) else request_data
 		response_dict = json.loads(response_data) if isinstance(response_data, str) else response_data
 
-		# Usar writer resiliente
+		# Usar writer resiliente (sin skip_state_persist: el writer lo deriva de operation_type)
 		writer = PACResponseWriter()
 		result = writer.write_pac_response(
 			sales_invoice_name,
@@ -879,7 +884,6 @@ def write_pac_response(
 			response_dict,
 			operation_type,
 			factura_fiscal_name=factura_fiscal_name,
-			skip_state_persist=skip_state_persist,
 		)
 
 		return result

--- a/facturacion_mexico/facturacion_fiscal/cancellation_state.py
+++ b/facturacion_mexico/facturacion_fiscal/cancellation_state.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, Buzola and contributors
+# For license information, please see license.txt
+"""Operación autoritativa única para aplicar el estado de cancelación de una FFM.
+
+Centraliza la transición de cancelación (PENDIENTE_CANCELACION / CANCELADO / TIMBRADO) para que
+TODOS los caminos (síncrono, revisión manual, motor de reconciliación y cascada de sustitución)
+dejen consistentes: FFM.status, fm_motivo_cancelacion, cancellation_reason, cancellation_date,
+fm_sync_status y SI.fm_fiscal_status.
+
+No crea Response Log, no llama al PAC, no cancela DocTypes, no agrega campos ni DocTypes.
+"""
+
+from datetime import datetime, timezone
+
+import frappe
+from frappe.utils import convert_utc_to_system_timezone, now_datetime
+
+from facturacion_mexico.config.fiscal_states_config import FiscalStates, SyncStates
+
+
+def extract_canceled_at(response):
+	"""Devuelve el timestamp REAL de cancelación del PAC (`canceled_at`) normalizado a la zona horaria
+	del sitio, o None si no hay un timestamp válido.
+
+	FacturAPI entrega el instante en UTC ISO-8601 (con sufijo 'Z'), p. ej. `2026-06-23T15:51:42.045Z`.
+	Se interpreta como UTC (no se descarta la zona) y se convierte al MISMO instante en la zona del
+	sitio, devolviendo un datetime naive apto para el campo Datetime.
+	"""
+	if not isinstance(response, dict):
+		return None
+	raw = response.get("raw_response")
+	raw = raw if isinstance(raw, dict) else response
+	cancellation = raw.get("cancellation")
+	ts = cancellation.get("canceled_at") if isinstance(cancellation, dict) else None
+	ts = ts or raw.get("canceled_at")
+	if not ts or not isinstance(ts, str):
+		return None
+	try:
+		# 'Z' -> offset explícito (+00:00): se interpreta como UTC, no se elimina la zona.
+		parsed = datetime.fromisoformat(ts.strip().replace("Z", "+00:00"))
+	except (ValueError, TypeError):
+		return None
+	# Llevar a UTC naive y convertir al mismo instante en la zona del sitio.
+	if parsed.tzinfo is not None:
+		parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+	local = convert_utc_to_system_timezone(parsed)
+	return local.replace(tzinfo=None) if getattr(local, "tzinfo", None) else local
+
+
+def derive_cancellation_reconciliation(remote_status, cancellation_status):
+	"""Criterio ACOTADO y fail-closed para cancelación (no modifica `derive_pac_reconciliation`).
+
+	A diferencia del helper global, `accepted` AISLADO (sin `status=canceled`) NO es terminal:
+	el HTTP/aceptación del receptor no confirma la cancelación fiscal ante el SAT.
+
+	Returns:
+	    tuple (fiscal_status | None, fm_sync_status):
+	    - canceled                          -> (CANCELADO, synced)          # único terminal
+	    - valid + pending/verifying/accepted-> (PENDIENTE_CANCELACION, synced)
+	    - valid + rejected/expired          -> (TIMBRADO, synced)           # cancelación no procedió
+	    - valid + none/""                   -> (TIMBRADO, synced)
+	    - pending                           -> (None, pending)
+	    - desconocido/incoherente           -> (None, error)  # nunca CANCELADO
+	"""
+	rs = (remote_status or "").strip().lower()
+	cs = (cancellation_status or "").strip().lower()
+
+	if rs == "canceled":
+		return FiscalStates.CANCELADO, SyncStates.SYNCED
+
+	if rs == "valid":
+		if cs in ("pending", "verifying", "accepted"):
+			return FiscalStates.PENDIENTE_CANCELACION, SyncStates.SYNCED
+		if cs in ("rejected", "expired"):
+			return FiscalStates.TIMBRADO, SyncStates.SYNCED
+		if cs in ("", "none"):
+			return FiscalStates.TIMBRADO, SyncStates.SYNCED
+		return None, SyncStates.ERROR
+
+	if rs == "pending":
+		return None, SyncStates.PENDING
+
+	return None, SyncStates.ERROR
+
+
+def _reason_from_motive(motivo: str | None) -> str:
+	"""Derivar el texto del Select `cancellation_reason` desde el código de motivo solicitado.
+
+	Se deriva por prefijo contra las opciones reales del DocType (evita drift con descripciones).
+	Si no hay motivo o no matchea ninguna opción, devuelve "" (fail-soft: no bloquea la transición).
+	"""
+	motivo = (motivo or "").strip()
+	if not motivo:
+		return ""
+	field = frappe.get_meta("Factura Fiscal Mexico").get_field("cancellation_reason")
+	opts = [(o or "").strip() for o in (field.options or "").split("\n") if (o or "").strip()]
+	for o in opts:
+		if o.startswith(f"{motivo} -") or o.startswith(f"{motivo} "):
+			return o
+	return ""
+
+
+def apply_cancellation_state(ffm, fiscal_status, *, sync_status, cancellation_date=None) -> bool:
+	"""Única escritura autoritativa del estado de cancelación. Idempotente y monotónica.
+
+	Returns:
+	    bool: True si escribió ALGÚN campo (FFM o snapshot SI); False si no cambió nada
+	    (idempotencia / monotonicidad). Lo usa el motor para decidir si crear Response Log.
+
+	Args:
+	    ffm: doc o name de Factura Fiscal Mexico.
+	    fiscal_status: PENDIENTE_CANCELACION | CANCELADO | TIMBRADO.
+	    sync_status: fm_sync_status ya derivado (no se asume "synced").
+	    cancellation_date: fecha del PAC (canceled_at) cuando aplique; None en pendiente/timbrado.
+
+	Reglas:
+	    - Relee SIEMPRE la FFM desde BD (el objeto en memoria puede estar desactualizado).
+	    - Monotonicidad: una FFM CANCELADO no se degrada a PENDIENTE/TIMBRADO por una respuesta vieja.
+	      CANCELADO -> CANCELADO SÍ ejecuta la parte reparadora (completa reason/date/sync/SI faltantes).
+	    - fm_motivo_cancelacion se CONSERVA (nunca se pone None aquí).
+	    - cancellation_date idempotente: una fecha existente nunca se sobrescribe.
+	    - SI.fm_fiscal_status solo si SI.fm_factura_fiscal_mx == ffm.name.
+	"""
+	ffm_name = ffm if isinstance(ffm, str) else ffm.name
+	cur = frappe.db.get_value(
+		"Factura Fiscal Mexico",
+		ffm_name,
+		[
+			"status",
+			"fm_motivo_cancelacion",
+			"cancellation_date",
+			"cancellation_reason",
+			"fm_sync_status",
+			"sales_invoice",
+		],
+		as_dict=True,
+	)
+	if not cur:
+		return False
+
+	# Monotonicidad: no degradar un CANCELADO; pero CANCELADO->CANCELADO repara.
+	if cur.status == FiscalStates.CANCELADO and fiscal_status != FiscalStates.CANCELADO:
+		return False
+
+	reason = _reason_from_motive(cur.fm_motivo_cancelacion)
+
+	target = {
+		"status": fiscal_status,
+		"cancellation_reason": reason,
+		"fm_sync_status": sync_status,
+	}
+	if fiscal_status == FiscalStates.CANCELADO:
+		# Fecha existente NUNCA se sobrescribe (idempotencia); luego canceled_at; luego observación.
+		target["cancellation_date"] = cur.cancellation_date or cancellation_date or now_datetime()
+	else:
+		target["cancellation_date"] = None
+
+	wrote = False
+	changed = {k: v for k, v in target.items() if cur.get(k) != v}
+	if changed:
+		frappe.db.set_value("Factura Fiscal Mexico", ffm_name, changed)
+		wrote = True
+
+	# Snapshot de la SI solo si esta FFM es la activa de esa SI.
+	si = cur.sales_invoice
+	if si and frappe.db.get_value("Sales Invoice", si, "fm_factura_fiscal_mx") == ffm_name:
+		if frappe.db.get_value("Sales Invoice", si, "fm_fiscal_status") != fiscal_status:
+			frappe.db.set_value("Sales Invoice", si, "fm_fiscal_status", fiscal_status)
+			wrote = True
+
+	return wrote

--- a/facturacion_mexico/facturacion_fiscal/cancellation_state.py
+++ b/facturacion_mexico/facturacion_fiscal/cancellation_state.py
@@ -83,19 +83,19 @@ def derive_cancellation_reconciliation(remote_status, cancellation_status):
 	return None, SyncStates.ERROR
 
 
-def _reason_from_motive(motivo: str | None) -> str:
+def _reason_from_motive(motive: str | None) -> str:
 	"""Derivar el texto del Select `cancellation_reason` desde el código de motivo solicitado.
 
 	Se deriva por prefijo contra las opciones reales del DocType (evita drift con descripciones).
 	Si no hay motivo o no matchea ninguna opción, devuelve "" (fail-soft: no bloquea la transición).
 	"""
-	motivo = (motivo or "").strip()
-	if not motivo:
+	motive = (motive or "").strip()
+	if not motive:
 		return ""
 	field = frappe.get_meta("Factura Fiscal Mexico").get_field("cancellation_reason")
 	opts = [(o or "").strip() for o in (field.options or "").split("\n") if (o or "").strip()]
 	for o in opts:
-		if o.startswith(f"{motivo} -") or o.startswith(f"{motivo} "):
+		if o.startswith((f"{motive} -", f"{motive} ")):
 			return o
 	return ""
 

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -196,30 +196,8 @@
 			}).addClass("btn-danger");
 		}
 
-		// Revisar estatus cancelación
-		if (actions.can_retry_cancel) {
-			frm.add_custom_button(__("Revisar Estatus Cancelación"), async () => {
-				frappe.show_alert({
-					message: __("Consultando estado en FacturAPI..."),
-					indicator: "blue",
-				});
-				const r = await frappe.call({
-					method: "facturacion_mexico.facturacion_fiscal.timbrado_api.revisar_estatus_cancelacion",
-					args: { ffm_name: frm.doc.name },
-					freeze: true,
-					freeze_message: __("Consultando PAC..."),
-				});
-				const res = r && r.message;
-				if (res) {
-					frappe.msgprint({
-						title: __("Resultado"),
-						message: __(res.message),
-						indicator: res.indicator,
-					});
-					frm.reload_doc();
-				}
-			}).addClass("btn-primary");
-		}
+		// (Botón duplicado de revisión de estatus eliminado: duplicaba la consulta del PAC. El flujo
+		// único es "Verificar estado en FacturAPI" → reconcile_ffm, que también repara CANCELADO.)
 
 		// Descargar PDF+XML
 		if (actions.can_download_xml || actions.can_download_pdf) {

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -334,7 +334,8 @@
    "fieldname": "cancellation_reason",
    "fieldtype": "Select",
    "label": "Motivo de Cancelación",
-   "options": "01 - Comprobantes emitidos con errores con relación\n02 - Comprobantes emitidos con errores sin relación\n03 - No se llevó a cabo la operación\n04 - Operación nominativa relacionada en la factura global"
+   "options": "\n01 - Comprobantes emitidos con errores con relación\n02 - Comprobantes emitidos con errores sin relación\n03 - No se llevó a cabo la operación\n04 - Operación nominativa relacionada en la factura global",
+   "read_only": 1
   },
   {
    "fieldname": "cancellation_date",

--- a/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
@@ -37,7 +37,7 @@ from facturacion_mexico.facturacion_fiscal.cancellation_state import (
 
 def _write_pac_response(
 	sales_invoice_name, request_data, response_data, factura_fiscal_name, *, skip_state_persist=False
-):
+) -> dict:
 	"""Persistir vía el writer (método, acepta dicts) con operation_type='reconciliacion'.
 
 	Se usa el método del writer y NO la función whitelisted pública (que exige str por type-hints).

--- a/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
@@ -17,19 +17,32 @@ import frappe
 from frappe import _
 from frappe.utils import now_datetime
 
-from facturacion_mexico.config.fiscal_states_config import SyncStates, derive_pac_reconciliation
+from facturacion_mexico.config.fiscal_states_config import (
+	FiscalStates,
+	SyncStates,
+	derive_pac_reconciliation,
+)
 from facturacion_mexico.facturacion_fiscal.api import (
 	FiscalCorrelationError,
 	PACResponseWriter,
 	_extract_reconciliation_states,
 )
 from facturacion_mexico.facturacion_fiscal.api_client import get_facturapi_client
+from facturacion_mexico.facturacion_fiscal.cancellation_state import (
+	apply_cancellation_state,
+	derive_cancellation_reconciliation,
+	extract_canceled_at,
+)
 
 
-def _write_pac_response(sales_invoice_name, request_data, response_data, factura_fiscal_name):
+def _write_pac_response(
+	sales_invoice_name, request_data, response_data, factura_fiscal_name, *, skip_state_persist=False
+):
 	"""Persistir vía el writer (método, acepta dicts) con operation_type='reconciliacion'.
 
 	Se usa el método del writer y NO la función whitelisted pública (que exige str por type-hints).
+	`skip_state_persist=True` cuando se reconcilia una CANCELACIÓN: el writer crea el Response Log
+	pero NO persiste el estado fiscal (lo aplica apply_cancellation_state).
 	"""
 	return PACResponseWriter().write_pac_response(
 		sales_invoice_name,
@@ -37,6 +50,7 @@ def _write_pac_response(sales_invoice_name, request_data, response_data, factura
 		response_data,
 		"reconciliacion",
 		factura_fiscal_name=factura_fiscal_name,
+		skip_state_persist=skip_state_persist,
 	)
 
 
@@ -169,19 +183,57 @@ def _reconcile_ffm(ffm_name: str) -> dict:
 			return {"ffm": ffm_name, "outcome": "error", "error_type": "correlacion"}
 
 		remote_status, cancellation_status = _extract_reconciliation_states(response)
-		fiscal_status, sync_status = derive_pac_reconciliation(remote_status, cancellation_status)
+
+		# CORR-1: decidir EXPLÍCITAMENTE si esta reconciliación corresponde a una cancelación.
+		# No se deduce solo del estado derivado: una FFM ya CANCELADO no debe degradarse por una
+		# respuesta `valid` sin estado de cancelación.
+		_rs = (remote_status or "").strip().lower()
+		_cs = (cancellation_status or "").strip().lower()
+		is_cancellation = (
+			ffm.status in (FiscalStates.PENDIENTE_CANCELACION, FiscalStates.CANCELADO)
+			or _rs == "canceled"
+			or _cs in ("pending", "verifying", "accepted", "rejected", "expired")
+		)
+
+		if is_cancellation:
+			fiscal_status, sync_status = derive_cancellation_reconciliation(
+				remote_status, cancellation_status
+			)
+		else:
+			fiscal_status, sync_status = derive_pac_reconciliation(remote_status, cancellation_status)
 
 		status_changed = fiscal_status is not None and fiscal_status != ffm.status
 		sync_changed = sync_status != ffm.fm_sync_status
 
-		if status_changed or sync_changed:
-			# Cambio real: el writer persiste estado/sync y crea Response Log correlacionado.
+		# Cancelación: aplicar SIEMPRE (idempotente) para REPARAR campos incompletos (reason/date/
+		# snapshot SI) de una FFM ya terminal, aunque status/sync no cambien. La correlación estricta
+		# ya se validó arriba (_resolve_validated_ffm). apply devuelve si escribió algún campo.
+		# NO altera la selección de candidatos asíncronos (_select_candidates) — solo cómo se aplica.
+		repaired = False
+		if is_cancellation and fiscal_status is not None:
+			# CANCELADO: usar el `canceled_at` REAL del PAC cuando exista; observación solo si no hay.
+			_cdate = (
+				(extract_canceled_at(response) or now_datetime())
+				if fiscal_status == FiscalStates.CANCELADO
+				else None
+			)
+			repaired = apply_cancellation_state(
+				ffm.name, fiscal_status, sync_status=sync_status, cancellation_date=_cdate
+			)
+
+		if status_changed or sync_changed or repaired:
+			# El writer crea el Response Log correlacionado. En cancelación NO persiste el estado
+			# fiscal (skip_state_persist): la escritura autoritativa es apply_cancellation_state.
 			_write_pac_response(
 				ffm.sales_invoice or "",
 				{"action": "reconciliacion", "facturapi_id": ffm.facturapi_id},
 				response,
 				ffm.name,
+				skip_state_persist=is_cancellation,
 			)
+			if is_cancellation and fiscal_status is None and sync_changed:
+				# pending/no concluyente pero el sync cambió (apply no corre con fiscal_status=None).
+				frappe.db.set_value("Factura Fiscal Mexico", ffm.name, "fm_sync_status", sync_status)
 			return {
 				"ffm": ffm_name,
 				"outcome": "changed",

--- a/facturacion_mexico/facturacion_fiscal/tests/test_audit_warning.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_audit_warning.py
@@ -253,27 +253,23 @@ class TestAuditWarning(IntegrationTestCase):
 			)
 
 	# 4 — consulta exitosa + auditoría incompleta: estado conservado, advertencia, sin repetir PAC
-	def test_04_consulta_audit_incompleta(self):
+	def test_04_revisar_delega_en_motor(self):
+		# Consolidación: revisar_estatus_cancelacion ya no tiene lógica/consulta propia; delega en el
+		# motor (reconcile_ffm) y NO realiza una segunda llamada al PAC (query_pac_status). El manejo
+		# de auditoría incompleta queda en el camino único del motor/writer (probado en sus suites).
 		si = self._si()
 		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1", uuid="U-1")
-
-		mock_query = patch(
-			"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
-			return_value={"success": True, "data": {"cancellation_status": "accepted"}},
-		)
 		with (
-			mock_query as mq,
-			patch("frappe.set_value", side_effect=_set_value_si_noop_factory()),
 			patch(
-				f"{_TIMBRADO_API}.write_pac_response",
-				return_value={"success": True, "fiscal_updated": True, "audit_log_failed": True},
-			),
+				"facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.reconcile_ffm",
+				return_value={"ffm": ffm, "outcome": "changed"},
+			) as rec,
+			patch("facturacion_mexico.facturacion_fiscal.api_client.query_pac_status") as qps,
 		):
 			result = revisar_estatus_cancelacion(ffm)
-
-		self.assertEqual(result.get("status"), "CANCELADO")  # estado conservado
-		self.assertTrue(result.get("audit_warning"))
-		mq.assert_called_once()  # no repite la consulta al PAC
+		rec.assert_called_once_with(ffm)
+		qps.assert_not_called()
+		self.assertEqual(result, {"ffm": ffm, "outcome": "changed"})
 
 	# 10 — cero referencias al cliente del PAC en este módulo
 	def test_10_cero_trafico_pac(self):

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cancelacion_integridad.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cancelacion_integridad.py
@@ -1,0 +1,628 @@
+"""Integridad del flujo de cancelación CFDI (síncrono + asíncrono).
+
+Valida el criterio acotado de cancelación, la operación autoritativa única
+`apply_cancellation_state`, la consistencia de FFM/SI en todas las transiciones, la guarda de la
+cascada y la protección contra el crash 1406. Todo con respuestas SIMULADAS — cero PAC real.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.config.fiscal_states_config import FiscalStates, SyncStates
+from facturacion_mexico.facturacion_fiscal.api import PACResponseWriter
+from facturacion_mexico.facturacion_fiscal.cancellation_state import (
+	apply_cancellation_state,
+	derive_cancellation_reconciliation,
+)
+
+_FA = "FA-" + frappe.generate_hash()[:10]
+_UUID = "U-" + frappe.generate_hash()[:10]
+
+
+def _seed_si(*, fiscal_status="", ffm=None):
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+			"fm_fiscal_status": fiscal_status or None,
+			"fm_factura_fiscal_mx": ffm,
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	frappe.db.commit()
+	return si.name
+
+
+def _seed_ffm(
+	sales_invoice,
+	status,
+	*,
+	motivo=None,
+	reason=None,
+	date=None,
+	facturapi_id=_FA,
+	uuid=_UUID,
+	sync="pending",
+):
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"naming_series": "FFM-TEST-.YYYY.-",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"fm_tipo_comprobante": "I",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"facturapi_id": facturapi_id or None,
+			"fm_uuid": uuid or None,
+			"fm_sync_status": sync,
+			"fm_motivo_cancelacion": motivo,
+			"cancellation_reason": reason,
+			"cancellation_date": date,
+			"docstatus": 1,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	frappe.db.commit()
+	return ffm.name
+
+
+class TestCancelacionIntegridad(IntegrationTestCase):
+	def setUp(self):
+		self._si = []
+		self._ffm = []
+		self.addCleanup(frappe.set_user, "Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for ffm in self._ffm:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self._si:
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()
+
+	def si(self, **kw):
+		n = _seed_si(**kw)
+		self._si.append(n)
+		return n
+
+	def ffm(self, *a, **kw):
+		n = _seed_ffm(*a, **kw)
+		self._ffm.append(n)
+		return n
+
+	def _status(self, ffm):
+		return frappe.db.get_value("Factura Fiscal Mexico", ffm, "status")
+
+	def _field(self, ffm, f):
+		return frappe.db.get_value("Factura Fiscal Mexico", ffm, f)
+
+	def _si_status(self, si):
+		return frappe.db.get_value("Sales Invoice", si, "fm_fiscal_status")
+
+	def _derive_writer(self, raw, success=True, code=200):
+		resp = {"success": success, "status_code": code, "raw_response": raw}
+		return PACResponseWriter()._derive_status_from_response(resp, "Solicitud Cancelación")[0]
+
+	# ---------- Clasificación (criterio acotado + writer) ----------
+
+	def test_01_verifying_pendiente_ffm_y_si(self):
+		ffm = self.ffm(None, FiscalStates.TIMBRADO, motivo="02")
+		si = self.si(fiscal_status=FiscalStates.TIMBRADO, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		st, sync = derive_cancellation_reconciliation("valid", "verifying")
+		apply_cancellation_state(ffm, st, sync_status=sync)
+		self.assertEqual(self._status(ffm), FiscalStates.PENDIENTE_CANCELACION)
+		self.assertEqual(self._si_status(si), FiscalStates.PENDIENTE_CANCELACION)
+		self.assertEqual(
+			self._derive_writer({"status": "valid", "cancellation_status": "verifying"}),
+			FiscalStates.PENDIENTE_CANCELACION,
+		)
+
+	def test_03_canceled_es_cancelado(self):
+		self.assertEqual(
+			self._derive_writer({"status": "canceled", "cancellation_status": "accepted"}),
+			FiscalStates.CANCELADO,
+		)
+
+	def test_09_desconocido_nunca_cancelado(self):
+		for raw in (
+			{},
+			{"status": "valid"},
+			{"status": "weird", "cancellation_status": "??"},
+			{"status": "valid", "cancellation_status": None},
+		):
+			self.assertNotEqual(self._derive_writer(raw), FiscalStates.CANCELADO)
+		self.assertIsNone(self._derive_writer({}, success=False, code=500))
+
+	def test_18_accepted_aislado_no_cancela(self):
+		# valid + accepted SIN status=canceled NO es terminal.
+		st, _ = derive_cancellation_reconciliation("valid", "accepted")
+		self.assertEqual(st, FiscalStates.PENDIENTE_CANCELACION)
+		self.assertEqual(
+			self._derive_writer({"status": "valid", "cancellation_status": "accepted"}),
+			FiscalStates.PENDIENTE_CANCELACION,
+		)
+
+	# ---------- apply_cancellation_state ----------
+
+	def test_02_motivo_persiste_en_verifying(self):
+		ffm = self.ffm(None, FiscalStates.TIMBRADO, motivo="02")
+		apply_cancellation_state(ffm, FiscalStates.PENDIENTE_CANCELACION, sync_status=SyncStates.SYNCED)
+		self.assertEqual(self._field(ffm, "fm_motivo_cancelacion"), "02")
+
+	def test_03b_reason_es_02_no_residual_01(self):
+		ffm = self.ffm(
+			None,
+			FiscalStates.TIMBRADO,
+			motivo="02",
+			reason="01 - Comprobantes emitidos con errores con relación",
+		)
+		apply_cancellation_state(ffm, FiscalStates.PENDIENTE_CANCELACION, sync_status=SyncStates.SYNCED)
+		self.assertEqual((self._field(ffm, "cancellation_reason") or "")[:2], "02")
+
+	def test_04_date_vacia_en_pendiente(self):
+		ffm = self.ffm(None, FiscalStates.TIMBRADO, motivo="02")
+		apply_cancellation_state(ffm, FiscalStates.PENDIENTE_CANCELACION, sync_status=SyncStates.SYNCED)
+		self.assertIsNone(self._field(ffm, "cancellation_date"))
+
+	def test_05_terminal_completa_ffm_y_si(self):
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02")
+		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		apply_cancellation_state(ffm, FiscalStates.CANCELADO, sync_status=SyncStates.SYNCED)
+		self.assertEqual(self._status(ffm), FiscalStates.CANCELADO)
+		self.assertEqual((self._field(ffm, "cancellation_reason") or "")[:2], "02")
+		self.assertIsNotNone(self._field(ffm, "cancellation_date"))
+		self.assertEqual(self._si_status(si), FiscalStates.CANCELADO)
+
+	def test_08_no_toca_si_de_otra_ffm(self):
+		ffm_act = self.ffm(None, FiscalStates.TIMBRADO, motivo="02")
+		ffm_otra = self.ffm(
+			None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", facturapi_id="FA-X", uuid="U-X"
+		)
+		si = self.si(fiscal_status=FiscalStates.TIMBRADO, ffm=ffm_act)  # SI apunta a ffm_act
+		frappe.db.set_value("Factura Fiscal Mexico", ffm_otra, "sales_invoice", si)
+		# Aplicar CANCELADO a ffm_otra: como la SI NO apunta a ella, el snapshot SI no cambia.
+		apply_cancellation_state(ffm_otra, FiscalStates.CANCELADO, sync_status=SyncStates.SYNCED)
+		self.assertEqual(self._status(ffm_otra), FiscalStates.CANCELADO)
+		self.assertEqual(self._si_status(si), FiscalStates.TIMBRADO)  # intacto
+
+	def test_15_idempotente(self):
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02")
+		apply_cancellation_state(ffm, FiscalStates.CANCELADO, sync_status=SyncStates.SYNCED)
+		snap = frappe.db.get_value(
+			"Factura Fiscal Mexico",
+			ffm,
+			["status", "cancellation_reason", "cancellation_date", "fm_sync_status"],
+			as_dict=True,
+		)
+		apply_cancellation_state(ffm, FiscalStates.CANCELADO, sync_status=SyncStates.SYNCED)
+		snap2 = frappe.db.get_value(
+			"Factura Fiscal Mexico",
+			ffm,
+			["status", "cancellation_reason", "cancellation_date", "fm_sync_status"],
+			as_dict=True,
+		)
+		self.assertEqual(snap, snap2)
+
+	def test_16_rejected_expired_a_timbrado(self):
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02")
+		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		st, sync = derive_cancellation_reconciliation("valid", "rejected")
+		self.assertEqual(st, FiscalStates.TIMBRADO)
+		apply_cancellation_state(ffm, st, sync_status=sync)
+		self.assertEqual(self._status(ffm), FiscalStates.TIMBRADO)
+		self.assertIsNone(self._field(ffm, "cancellation_date"))
+		self.assertEqual(self._si_status(si), FiscalStates.TIMBRADO)
+
+	def test_17_cancelado_no_regresa(self):
+		ffm = self.ffm(None, FiscalStates.CANCELADO, motivo="02", date=frappe.utils.now_datetime())
+		apply_cancellation_state(ffm, FiscalStates.PENDIENTE_CANCELACION, sync_status=SyncStates.SYNCED)
+		self.assertEqual(self._status(ffm), FiscalStates.CANCELADO)  # no degrada
+
+	def test_20_sync_status_derivado(self):
+		ffm = self.ffm(None, FiscalStates.TIMBRADO, motivo="02", sync="pending")
+		apply_cancellation_state(ffm, FiscalStates.PENDIENTE_CANCELACION, sync_status=SyncStates.SYNCED)
+		val = self._field(ffm, "fm_sync_status")
+		self.assertEqual(val, SyncStates.SYNCED)
+		opts = frappe.get_meta("Factura Fiscal Mexico").get_field("fm_sync_status").options or ""
+		self.assertIn(val, [o.strip() for o in opts.split("\n") if o.strip()])
+
+	def test_23_objeto_stale_usa_motivo_actual(self):
+		ffm_name = self.ffm(None, FiscalStates.TIMBRADO, motivo="03")
+		ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm_name)  # objeto en memoria con motivo=03
+		frappe.db.set_value("Factura Fiscal Mexico", ffm_name, "fm_motivo_cancelacion", "02")  # cambia en BD
+		apply_cancellation_state(ffm_doc, FiscalStates.PENDIENTE_CANCELACION, sync_status=SyncStates.SYNCED)
+		self.assertEqual((self._field(ffm_name, "cancellation_reason") or "")[:2], "02")  # usa el actual
+
+	def test_24_fecha_no_se_sobrescribe(self):
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02")
+		apply_cancellation_state(ffm, FiscalStates.CANCELADO, sync_status=SyncStates.SYNCED)
+		fecha1 = self._field(ffm, "cancellation_date")
+		# Segunda ejecución sin fecha y una "observación posterior" no reemplazan la fecha existente.
+		apply_cancellation_state(ffm, FiscalStates.CANCELADO, sync_status=SyncStates.SYNCED)
+		apply_cancellation_state(
+			ffm,
+			FiscalStates.CANCELADO,
+			sync_status=SyncStates.SYNCED,
+			cancellation_date=frappe.utils.add_to_date(fecha1, days=1),
+		)
+		self.assertEqual(self._field(ffm, "cancellation_date"), fecha1)
+
+	def test_25_repara_cancelado_incompleto(self):
+		# CANCELADO con motivo correcto pero reason/fecha/SI incompletos -> se completan sin tocar fecha.
+		ffm = self.ffm(None, FiscalStates.CANCELADO, motivo="02", reason="", date=None)
+		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		apply_cancellation_state(ffm, FiscalStates.CANCELADO, sync_status=SyncStates.SYNCED)
+		self.assertEqual((self._field(ffm, "cancellation_reason") or "")[:2], "02")
+		self.assertIsNotNone(self._field(ffm, "cancellation_date"))
+		self.assertEqual(self._si_status(si), FiscalStates.CANCELADO)
+
+	def test_13_cancelar_si_con_ffm_real_cancelado(self):
+		from facturacion_mexico.api.fiscal_operations import cancelar_si_post_fiscal
+
+		ffm = self.ffm(None, FiscalStates.CANCELADO, motivo="02")
+		# Snapshot de la SI DESACTUALIZADO (PENDIENTE) aunque la FFM real está CANCELADO.
+		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		with patch("frappe.has_permission", return_value=True), patch("frappe.get_doc") as gd:
+			# get_doc("Sales Invoice") -> obj con docstatus 1; el cancel() real se mockea.
+			real_get_doc = frappe.get_doc
+
+			def _gd(*a, **k):
+				if a and a[0] == "Sales Invoice":
+					m = MagicMock()
+					m.docstatus = 1
+					m.get.side_effect = lambda f: {
+						"fm_fiscal_status": "PENDIENTE_CANCELACION",
+						"fm_factura_fiscal_mx": ffm,
+					}.get(f)
+					m.name = si
+					return m
+				return real_get_doc(*a, **k)
+
+			gd.side_effect = _gd
+			# No debe lanzar "Solo aplica cuando..." porque la FFM real está CANCELADO.
+			try:
+				cancelar_si_post_fiscal(si)
+			except frappe.ValidationError as e:
+				self.assertNotIn("cancelada ante el SAT", str(e))
+
+	# ---------- Motor asíncrono ----------
+
+	def _fake_client(self, raw):
+		c = MagicMock()
+		c.get_invoice.return_value = {"success": True, "status_code": 200, "raw_response": raw}
+		return c
+
+	def test_06_motor_pendiente_a_cancelado_completo(self):
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		raw = {"status": "canceled", "cancellation_status": "accepted", "id": _FA, "uuid": _UUID}
+		with patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)):
+			mod._reconcile_ffm(ffm)
+		self.assertEqual(self._status(ffm), FiscalStates.CANCELADO)
+		self.assertEqual((self._field(ffm, "cancellation_reason") or "")[:2], "02")
+		self.assertIsNotNone(self._field(ffm, "cancellation_date"))
+		self.assertEqual(self._field(ffm, "fm_sync_status"), SyncStates.SYNCED)
+		self.assertEqual(self._si_status(si), FiscalStates.CANCELADO)
+
+	def test_22_reconciliacion_no_cancelacion_intacta(self):
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+		# FFM TIMBRADO con sync pending; respuesta valid sin cancelación -> NO es cancelación.
+		ffm = self.ffm(None, FiscalStates.TIMBRADO, sync="pending")
+		raw = {"status": "valid", "cancellation_status": "none", "id": _FA, "uuid": _UUID}
+		with (
+			patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)),
+			patch.object(mod, "apply_cancellation_state") as apply_mock,
+		):
+			mod._reconcile_ffm(ffm)
+			apply_mock.assert_not_called()  # no usa el helper de cancelación
+		self.assertEqual(self._status(ffm), FiscalStates.TIMBRADO)
+
+	# ---------- Consolidación: un solo flujo (motor) + revisar como wrapper ----------
+
+	def test_07_revisar_delega_en_motor(self):
+		# revisar_estatus_cancelacion NO tiene lógica propia: delega en reconcile_ffm y NO hace
+		# una segunda consulta al PAC (no llama query_pac_status).
+		from facturacion_mexico.facturacion_fiscal import timbrado_api as tmod
+
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02")
+		with (
+			patch(
+				"facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.reconcile_ffm",
+				return_value={"ffm": ffm, "outcome": "changed"},
+			) as rec,
+			patch("facturacion_mexico.facturacion_fiscal.api_client.query_pac_status") as qps,
+		):
+			out = tmod.revisar_estatus_cancelacion(ffm)
+		rec.assert_called_once_with(ffm)  # delega en el motor
+		qps.assert_not_called()  # sin segunda llamada al PAC
+		self.assertEqual(out, {"ffm": ffm, "outcome": "changed"})
+
+	def test_07b_motor_repara_cancelado_incompleto(self):
+		# Flujo A (motor) repara una FFM CANCELADO+synced con reason/fecha/SI incompletos,
+		# aunque status y sync no cambien. Y crea Response Log porque reparó.
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+		ffm = self.ffm(
+			None,
+			FiscalStates.CANCELADO,
+			motivo="02",
+			reason="01 - Comprobantes emitidos con errores con relación",
+			date=None,
+			sync="synced",
+		)
+		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)  # snapshot viejo
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		n0 = frappe.db.count("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+		raw = {"status": "canceled", "cancellation_status": "accepted", "id": _FA, "uuid": _UUID}
+		with patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)):
+			out = mod._reconcile_ffm(ffm)
+		self.assertEqual(self._status(ffm), FiscalStates.CANCELADO)  # no degrada
+		self.assertEqual((self._field(ffm, "cancellation_reason") or "")[:2], "02")  # reparado
+		self.assertIsNotNone(self._field(ffm, "cancellation_date"))  # reparado
+		self.assertEqual(self._si_status(si), FiscalStates.CANCELADO)  # snapshot reparado
+		self.assertEqual(out.get("outcome"), "changed")
+		self.assertEqual(  # reparar SÍ deja Response Log
+			frappe.db.count("FacturAPI Response Log", {"factura_fiscal_mexico": ffm}), n0 + 1
+		)
+
+	def test_07c_motor_consistente_no_reescribe_ni_loguea(self):
+		# FFM CANCELADO ya completa y consistente: el motor no reescribe ni crea Response Log.
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+		ffm = self.ffm(
+			None,
+			FiscalStates.CANCELADO,
+			motivo="02",
+			reason="02 - Comprobantes emitidos con errores sin relación",
+			date=frappe.utils.now_datetime(),
+			sync="synced",
+		)
+		si = self.si(fiscal_status=FiscalStates.CANCELADO, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		before = frappe.db.get_value(
+			"Factura Fiscal Mexico",
+			ffm,
+			["cancellation_reason", "cancellation_date", "fm_sync_status", "status"],
+			as_dict=True,
+		)
+		n0 = frappe.db.count("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+		raw = {"status": "canceled", "cancellation_status": "accepted", "id": _FA, "uuid": _UUID}
+		with patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)):
+			out = mod._reconcile_ffm(ffm)
+		after = frappe.db.get_value(
+			"Factura Fiscal Mexico",
+			ffm,
+			["cancellation_reason", "cancellation_date", "fm_sync_status", "status"],
+			as_dict=True,
+		)
+		self.assertEqual(out.get("outcome"), "unchanged")
+		self.assertEqual(before, after)  # no reescribe
+		self.assertEqual(  # sin log automático
+			frappe.db.count("FacturAPI Response Log", {"factura_fiscal_mexico": ffm}), n0
+		)
+
+	def test_07e_correlacion_invalida_no_aplica(self):
+		# Respuesta con identidad que NO corresponde a la FFM: no se aplica, no se modifica FFM/SI.
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		raw = {
+			"status": "canceled",
+			"cancellation_status": "accepted",
+			"id": "FA-OTRO",
+			"uuid": "U-OTRO",
+		}  # identidad contradictoria
+		with patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)):
+			out = mod._reconcile_ffm(ffm)
+		self.assertEqual(out.get("outcome"), "error")
+		self.assertEqual(self._status(ffm), FiscalStates.PENDIENTE_CANCELACION)  # sin cambio
+		self.assertEqual(self._si_status(si), FiscalStates.PENDIENTE_CANCELACION)
+
+	def test_07f_solo_un_boton_consulta_en_gui(self):
+		import os
+
+		js = os.path.join(
+			frappe.get_app_path("facturacion_mexico"),
+			"facturacion_fiscal",
+			"doctype",
+			"factura_fiscal_mexico",
+			"factura_fiscal_mexico.js",
+		)
+		with open(js, encoding="utf-8") as f:
+			content = f.read()
+		self.assertNotIn("Revisar Estatus Cancelación", content)  # botón duplicado eliminado
+		self.assertIn("Verificar estado en FacturAPI", content)  # único botón de consulta
+
+	# ---------- canceled_at del PAC (timestamp real + zona horaria) ----------
+
+	def test_canceledat_extrae_y_normaliza_tz(self):
+		# UTC con 'Z' -> MISMO instante en la zona del sitio (no se descarta la zona).
+		import datetime as dt
+
+		from facturacion_mexico.facturacion_fiscal.cancellation_state import extract_canceled_at
+
+		resp = {"raw_response": {"cancellation": {"canceled_at": "2026-06-23T15:51:42.045Z"}}}
+		got = extract_canceled_at(resp)
+		self.assertIsNotNone(got)
+		expected = frappe.utils.convert_utc_to_system_timezone(dt.datetime(2026, 6, 23, 15, 51, 42))
+		expected = expected.replace(tzinfo=None) if getattr(expected, "tzinfo", None) else expected
+		self.assertEqual(got.replace(microsecond=0), expected.replace(microsecond=0))  # mismo instante
+
+	def test_canceledat_ausente_devuelve_none(self):
+		from facturacion_mexico.facturacion_fiscal.cancellation_state import extract_canceled_at
+
+		self.assertIsNone(extract_canceled_at({"raw_response": {"status": "canceled"}}))
+		self.assertIsNone(extract_canceled_at({"raw_response": {"cancellation": {"status": "none"}}}))
+
+	def test_motor_usa_canceledat_del_pac(self):
+		# canceled + canceled_at -> la fecha persistida es el timestamp REAL del PAC (no now()).
+		from facturacion_mexico.facturacion_fiscal.cancellation_state import extract_canceled_at
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		raw = {
+			"status": "canceled",
+			"cancellation_status": "none",
+			"id": _FA,
+			"uuid": _UUID,
+			"cancellation": {"canceled_at": "2026-06-23T15:51:42.045Z"},
+		}
+		with patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)):
+			mod._reconcile_ffm(ffm)
+		got = self._field(ffm, "cancellation_date")
+		expected = extract_canceled_at({"raw_response": raw})
+		self.assertEqual(got.replace(microsecond=0), expected.replace(microsecond=0))
+
+	def test_motor_sin_canceledat_usa_observacion(self):
+		# canceled SIN canceled_at -> hora de observación (no None).
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+		raw = {"status": "canceled", "cancellation_status": "none", "id": _FA, "uuid": _UUID}
+		with patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)):
+			mod._reconcile_ffm(ffm)
+		self.assertIsNotNone(self._field(ffm, "cancellation_date"))
+
+	def test_motor_pasa_canceledat_al_helper(self):
+		from facturacion_mexico.facturacion_fiscal.cancellation_state import extract_canceled_at
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+		raw = {
+			"status": "canceled",
+			"cancellation_status": "none",
+			"id": _FA,
+			"uuid": _UUID,
+			"cancellation": {"canceled_at": "2026-06-23T15:51:42.045Z"},
+		}
+		exp = extract_canceled_at({"raw_response": raw})
+		with (
+			patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)),
+			patch.object(mod, "apply_cancellation_state", return_value=True) as ap,
+		):
+			mod._reconcile_ffm(ffm)
+		_, kwargs = ap.call_args
+		self.assertEqual(kwargs.get("cancellation_date").replace(microsecond=0), exp.replace(microsecond=0))
+
+	def test_motor_no_terminal_sin_fecha(self):
+		# verifying / pending / rejected / desconocido -> NO se fija cancellation_date.
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
+
+		for cs in ("verifying", "pending", "rejected", "zzz-desconocido"):
+			ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+			raw = {"status": "valid", "cancellation_status": cs, "id": _FA, "uuid": _UUID}
+			with patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)):
+				mod._reconcile_ffm(ffm)
+			self.assertIsNone(self._field(ffm, "cancellation_date"), f"cs={cs}")
+
+	# ---------- Cascada ----------
+
+	def test_10_21_cascada_no_terminal_no_cancela(self):
+		from facturacion_mexico.facturacion_fiscal import timbrado_api as tmod
+
+		src_uuid = "U-SRC-" + frappe.generate_hash()[:8]
+		new_uuid = "U-NEW-" + frappe.generate_hash()[:8]
+		orig_ffm = self.ffm(None, FiscalStates.TIMBRADO, motivo="02", facturapi_id="FA-ORIG", uuid=src_uuid)
+		orig_si = self.si(fiscal_status=FiscalStates.TIMBRADO, ffm=orig_ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", orig_ffm, "sales_invoice", orig_si)
+		new_ffm = self.ffm(None, FiscalStates.TIMBRADO, facturapi_id="FA-NEW", uuid=new_uuid)
+		new_si = self.si(fiscal_status=FiscalStates.TIMBRADO, ffm=new_ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", new_ffm, "sales_invoice", new_si)
+		frappe.db.set_value("Sales Invoice", new_si, "ffm_substitution_source_uuid", src_uuid)
+		frappe.db.commit()
+
+		# PAC deja la cancelación NO terminal (no marca CANCELADO la FFM previa).
+		with patch.object(
+			tmod.TimbradoAPI, "cancelar_factura", return_value={"status_ffm": "PENDIENTE_CANCELACION"}
+		):
+			res = tmod._cascade_cancel_previous_after_substitute(new_ffm)
+		self.assertEqual(res.get("cascade"), "halted_not_terminal")
+		self.assertNotEqual(self._status(orig_ffm), FiscalStates.CANCELADO)
+		self.assertEqual(frappe.db.get_value("Sales Invoice", orig_si, "docstatus"), 1)  # SI NO cancelada
+
+	# ---------- FFM nueva / endpoint / 1406 / logger ----------
+
+	def test_12_ffm_nueva_reason_vacio(self):
+		from frappe.model.create_new import get_new_doc
+
+		nuevo = get_new_doc("Factura Fiscal Mexico")
+		self.assertIn((nuevo.get("cancellation_reason") or ""), ("", None))
+
+	def test_14_endpoint_usa_ffm_enlazada(self):
+		from facturacion_mexico.facturacion_fiscal import timbrado_api as tmod
+
+		ffm_link = self.ffm(None, FiscalStates.TIMBRADO, facturapi_id="FA-L", uuid="U-L")
+		ffm_otra = self.ffm(None, FiscalStates.TIMBRADO, facturapi_id="FA-O", uuid="U-O")
+		si = self.si(fiscal_status=FiscalStates.TIMBRADO, ffm=ffm_link)
+		# Ambas FFM apuntan a la misma SI; la activa es ffm_link (SI.fm_factura_fiscal_mx).
+		frappe.db.set_value("Factura Fiscal Mexico", ffm_link, "sales_invoice", si)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm_otra, "sales_invoice", si)
+		frappe.db.commit()
+		with patch.object(tmod, "TimbradoAPI") as TApi:
+			TApi.return_value.cancelar_factura.return_value = {"ok": True}
+			tmod.cancelar_factura(sales_invoice=si, motivo="02")
+		self.assertEqual(self._field(ffm_link, "fm_motivo_cancelacion"), "02")  # se escribió en la enlazada
+		self.assertIsNone(self._field(ffm_otra, "fm_motivo_cancelacion"))  # NO en la otra (no limit=1)
+
+	def test_11_log_error_nombrado_sin_1406(self):
+		# El fix usa args nombrados: un mensaje largo va a 'error' (Long Text), no a 'method' (140).
+		try:
+			frappe.log_error(title="PAC Cancelación Error", message="X" * 500)
+		except Exception as e:
+			self.fail(f"log_error con args nombrados no debe fallar (1406): {e}")
+
+	def test_26_logger_no_enmascara_original(self):
+		# Flujo SÍNCRONO de cancelación: si el logger falla, NO reemplaza el error original.
+		from facturacion_mexico.facturacion_fiscal import timbrado_api as tmod
+
+		ffm = self.ffm(None, FiscalStates.TIMBRADO, motivo="02", facturapi_id="FA-1", uuid="U-1")
+		si = self.si(fiscal_status=FiscalStates.TIMBRADO, ffm=ffm)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
+		frappe.db.commit()
+		client = MagicMock()
+		client.cancel_invoice.return_value = {
+			"success": True,
+			"status_code": 200,
+			"raw_response": {"status": "canceled", "id": "FA-1", "uuid": "U-1"},
+		}
+		with patch.object(tmod, "get_facturapi_client", return_value=client):
+			api = tmod.TimbradoAPI(company="_Test Company")
+			with (
+				patch.object(tmod, "apply_cancellation_state", side_effect=ValueError("ORIGINAL")),
+				patch.object(tmod, "write_pac_response", return_value={"success": True}),
+				patch.object(tmod.TimbradoAPI, "_download_cancellation_receipt_files", return_value=None),
+				patch("frappe.log_error", side_effect=Exception("LOGGER-1406")),
+			):
+				result = api.cancelar_factura(si, "02")
+		# El fallo del logger se tragó; el resultado refleja el error ORIGINAL, no el del logger.
+		self.assertIn("ORIGINAL", str(result.get("error", "")))
+		self.assertNotIn("LOGGER-1406", str(result))
+		self.assertEqual(self._status(ffm), FiscalStates.TIMBRADO)  # apply falló -> FFM sin cambio

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cancelacion_integridad.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cancelacion_integridad.py
@@ -50,10 +50,14 @@ def _seed_ffm(
 	motivo=None,
 	reason=None,
 	date=None,
-	facturapi_id=_FA,
-	uuid=_UUID,
+	facturapi_id=None,
+	uuid=None,
 	sync="pending",
 ):
+	# IDs fiscales únicos por fixture cuando el caller no los suministra (aislamiento de pruebas,
+	# RG-003). Los tests de correlación que necesitan emparejar seed↔respuesta pasan ids explícitos.
+	facturapi_id = facturapi_id or "FA-" + frappe.generate_hash()[:10]
+	uuid = uuid or "U-" + frappe.generate_hash()[:10]
 	ffm = frappe.get_doc(
 		{
 			"doctype": "Factura Fiscal Mexico",
@@ -275,35 +279,66 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 		self.assertIsNotNone(self._field(ffm, "cancellation_date"))
 		self.assertEqual(self._si_status(si), FiscalStates.CANCELADO)
 
-	def test_13_cancelar_si_con_ffm_real_cancelado(self):
+	def test_13_guard_usa_estado_real_de_ffm_no_snapshot(self):
+		"""El guard de cancelar_si_post_fiscal valida el estado REAL de la FFM activa, NO el snapshot
+		SI.fm_fiscal_status (que puede quedar stale). Documentos reales; sin mock de frappe.get_doc ni
+		de funciones internas (RG-003). Se detiene de forma determinista en la validación 'todas
+		canceladas', antes del cancel() real de la SI, y falla ante errores no esperados."""
 		from facturacion_mexico.api.fiscal_operations import cancelar_si_post_fiscal
 
-		ffm = self.ffm(None, FiscalStates.CANCELADO, motivo="02")
-		# Snapshot de la SI DESACTUALIZADO (PENDIENTE) aunque la FFM real está CANCELADO.
+		# FFM activa REALMENTE cancelada ante el SAT, pero snapshot SI desactualizado (PENDIENTE).
+		ffm_cancelado = self.ffm(None, FiscalStates.CANCELADO, motivo="02")
+		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm_cancelado)
+		frappe.db.set_value("Factura Fiscal Mexico", ffm_cancelado, "sales_invoice", si)
+		# 2ª FFM ligada a la misma SI AÚN activa: el flujo pasa el guard SAT (la FFM activa SÍ está
+		# CANCELADO) y se detiene en la validación determinista "todas canceladas", sin llegar al
+		# cancel() real de la SI.
+		ffm_activa = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02")
+		frappe.db.set_value("Factura Fiscal Mexico", ffm_activa, "sales_invoice", si)
+		frappe.db.commit()
+
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			cancelar_si_post_fiscal(si)
+		msg = str(ctx.exception)
+		# El guard SAT PASÓ: leyó el estado real de la FFM activa, no el snapshot stale de la SI.
+		self.assertNotIn("cancelada ante el SAT", msg)
+		# Se detuvo, de forma determinista, en la validación de FFMs aún activas (no en el cancel()).
+		self.assertIn(ffm_activa, msg)
+
+	def test_13b_guard_rechaza_cuando_ffm_activa_no_esta_cancelada(self):
+		"""Caso negativo del guard: si la FFM activa NO está CANCELADO, se rechaza con el error SAT."""
+		from facturacion_mexico.api.fiscal_operations import cancelar_si_post_fiscal
+
+		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02")
 		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
 		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
-		with patch("frappe.has_permission", return_value=True), patch("frappe.get_doc") as gd:
-			# get_doc("Sales Invoice") -> obj con docstatus 1; el cancel() real se mockea.
-			real_get_doc = frappe.get_doc
+		frappe.db.commit()
 
-			def _gd(*a, **k):
-				if a and a[0] == "Sales Invoice":
-					m = MagicMock()
-					m.docstatus = 1
-					m.get.side_effect = lambda f: {
-						"fm_fiscal_status": "PENDIENTE_CANCELACION",
-						"fm_factura_fiscal_mx": ffm,
-					}.get(f)
-					m.name = si
-					return m
-				return real_get_doc(*a, **k)
+		with self.assertRaisesRegex(frappe.ValidationError, "cancelada ante el SAT"):
+			cancelar_si_post_fiscal(si)
 
-			gd.side_effect = _gd
-			# No debe lanzar "Solo aplica cuando..." porque la FFM real está CANCELADO.
-			try:
-				cancelar_si_post_fiscal(si)
-			except frappe.ValidationError as e:
-				self.assertNotIn("cancelada ante el SAT", str(e))
+	def test_13c_endpoint_publico_no_controla_skip_state_persist(self):
+		"""Seguridad (#13): la frontera pública @frappe.whitelist() NO expone skip_state_persist; un
+		caller no puede saltarse la persistencia del estado fiscal por el wire. El skip se deriva
+		server-side de operation_type ('Solicitud Cancelación') dentro del writer."""
+		import inspect
+
+		from facturacion_mexico.facturacion_fiscal.api import write_pac_response
+
+		# 1. La firma pública no incluye el parámetro.
+		self.assertNotIn("skip_state_persist", inspect.signature(write_pac_response).parameters)
+
+		# 2. Enviar el flag desde el caller falla por argumento inesperado (TypeError en el binding,
+		#    antes de tocar BD): no es controlable desde el request.
+		with self.assertRaises(TypeError):
+			write_pac_response(
+				"SI-INEXISTENTE",
+				"{}",
+				"{}",
+				"timbrado",
+				factura_fiscal_name="FFM-INEXISTENTE",
+				skip_state_persist=True,
+			)
 
 	# ---------- Motor asíncrono ----------
 
@@ -315,7 +350,14 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 	def test_06_motor_pendiente_a_cancelado_completo(self):
 		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
 
-		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+		ffm = self.ffm(
+			None,
+			FiscalStates.PENDIENTE_CANCELACION,
+			motivo="02",
+			sync="pending",
+			facturapi_id=_FA,
+			uuid=_UUID,
+		)
 		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
 		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
 		raw = {"status": "canceled", "cancellation_status": "accepted", "id": _FA, "uuid": _UUID}
@@ -331,7 +373,7 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
 
 		# FFM TIMBRADO con sync pending; respuesta valid sin cancelación -> NO es cancelación.
-		ffm = self.ffm(None, FiscalStates.TIMBRADO, sync="pending")
+		ffm = self.ffm(None, FiscalStates.TIMBRADO, sync="pending", facturapi_id=_FA, uuid=_UUID)
 		raw = {"status": "valid", "cancellation_status": "none", "id": _FA, "uuid": _UUID}
 		with (
 			patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)),
@@ -373,6 +415,8 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 			reason="01 - Comprobantes emitidos con errores con relación",
 			date=None,
 			sync="synced",
+			facturapi_id=_FA,
+			uuid=_UUID,
 		)
 		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)  # snapshot viejo
 		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
@@ -400,6 +444,8 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 			reason="02 - Comprobantes emitidos con errores sin relación",
 			date=frappe.utils.now_datetime(),
 			sync="synced",
+			facturapi_id=_FA,
+			uuid=_UUID,
 		)
 		si = self.si(fiscal_status=FiscalStates.CANCELADO, ffm=ffm)
 		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
@@ -485,7 +531,14 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 		from facturacion_mexico.facturacion_fiscal.cancellation_state import extract_canceled_at
 		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
 
-		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+		ffm = self.ffm(
+			None,
+			FiscalStates.PENDIENTE_CANCELACION,
+			motivo="02",
+			sync="pending",
+			facturapi_id=_FA,
+			uuid=_UUID,
+		)
 		si = self.si(fiscal_status=FiscalStates.PENDIENTE_CANCELACION, ffm=ffm)
 		frappe.db.set_value("Factura Fiscal Mexico", ffm, "sales_invoice", si)
 		raw = {
@@ -505,7 +558,14 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 		# canceled SIN canceled_at -> hora de observación (no None).
 		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
 
-		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+		ffm = self.ffm(
+			None,
+			FiscalStates.PENDIENTE_CANCELACION,
+			motivo="02",
+			sync="pending",
+			facturapi_id=_FA,
+			uuid=_UUID,
+		)
 		raw = {"status": "canceled", "cancellation_status": "none", "id": _FA, "uuid": _UUID}
 		with patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)):
 			mod._reconcile_ffm(ffm)
@@ -515,7 +575,14 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 		from facturacion_mexico.facturacion_fiscal.cancellation_state import extract_canceled_at
 		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
 
-		ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+		ffm = self.ffm(
+			None,
+			FiscalStates.PENDIENTE_CANCELACION,
+			motivo="02",
+			sync="pending",
+			facturapi_id=_FA,
+			uuid=_UUID,
+		)
 		raw = {
 			"status": "canceled",
 			"cancellation_status": "none",
@@ -537,7 +604,14 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as mod
 
 		for cs in ("verifying", "pending", "rejected", "zzz-desconocido"):
-			ffm = self.ffm(None, FiscalStates.PENDIENTE_CANCELACION, motivo="02", sync="pending")
+			ffm = self.ffm(
+				None,
+				FiscalStates.PENDIENTE_CANCELACION,
+				motivo="02",
+				sync="pending",
+				facturapi_id=_FA,
+				uuid=_UUID,
+			)
 			raw = {"status": "valid", "cancellation_status": cs, "id": _FA, "uuid": _UUID}
 			with patch.object(mod, "get_facturapi_client", return_value=self._fake_client(raw)):
 				mod._reconcile_ffm(ffm)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_correlacion_propagacion.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_correlacion_propagacion.py
@@ -217,25 +217,22 @@ class TestCorrelacionPropagacion(IntegrationTestCase):
 	# ── 6: consulta — reporta la inconsistencia y no toca OTRO FFM ───────────
 
 	def test_06_consulta_correlacion_reporta_y_no_toca_otro_ffm(self):
+		# Consolidación: revisar delega en reconcile_ffm (camino único con correlación estricta del
+		# motor) y NO hace 2ª consulta al PAC. La garantía de no tocar otro FFM la da el motor/writer
+		# (probada en las suites del motor y en los demás tests de correlación de este módulo).
 		si = self._si()
 		target = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-T", uuid="U-T")
-		control = self._ffm(si, "TIMBRADO", facturapi_id="FA-C", uuid="U-C")
-		control_status_before = frappe.db.get_value("Factura Fiscal Mexico", control, "status")
-
 		with (
 			patch(
-				"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
-				return_value={"success": True, "data": {"cancellation_status": "accepted"}},
-			),
-			patch(f"{_TIMBRADO_API}.write_pac_response", side_effect=FiscalCorrelationError("x")),
+				"facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.reconcile_ffm",
+				return_value={"ffm": target, "outcome": "changed"},
+			) as rec,
+			patch("facturacion_mexico.facturacion_fiscal.api_client.query_pac_status") as qps,
 		):
-			with self.assertRaises(FiscalCorrelationError):
-				revisar_estatus_cancelacion(target)
-
-		# El OTRO FFM (control) no fue tocado.
-		self.assertEqual(
-			frappe.db.get_value("Factura Fiscal Mexico", control, "status"), control_status_before
-		)
+			out = revisar_estatus_cancelacion(target)
+		rec.assert_called_once_with(target)
+		qps.assert_not_called()
+		self.assertEqual(out, {"ffm": target, "outcome": "changed"})
 
 	# ── M2 (CodeRabbit): write_pac_timeout también propaga la correlación ────
 

--- a/facturacion_mexico/facturacion_fiscal/tests/test_derive_pac_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_derive_pac_reconciliation.py
@@ -192,23 +192,21 @@ class TestExpiredUnificado(IntegrationTestCase):
 				api.cancelar_factura(si, "02")
 		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
 
-	# revisar_estatus_cancelacion: EXPIRED resuelve a TIMBRADO (antes quedaba PENDIENTE_CANCELACION).
-	def test_revisar_expired_timbrado(self):
-		si = self._si(fiscal_status="PENDIENTE_CANCELACION")
-		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id=_FA_ID, uuid=_UUID)
-		frappe.db.set_value("Sales Invoice", si, "fm_factura_fiscal_mx", ffm)
-		frappe.db.commit()
+	# Consolidación: revisar delega en reconcile_ffm; la clasificación expired→TIMBRADO la cubre el
+	# clasificador acotado (y el motor). revisar no realiza una 2ª consulta al PAC.
+	def test_revisar_delega_en_motor(self):
+		ffm = self._ffm(self._si(), "PENDIENTE_CANCELACION", facturapi_id=_FA_ID, uuid=_UUID)
 		with (
 			patch(
-				"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
-				return_value={"success": True, "data": {"status": "valid", "cancellation_status": "expired"}},
-			),
-			patch("frappe.set_value", side_effect=_set_value_factory()),
-			patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": True}),
+				"facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.reconcile_ffm",
+				return_value={"ffm": ffm, "outcome": "changed"},
+			) as rec,
+			patch("facturacion_mexico.facturacion_fiscal.api_client.query_pac_status") as qps,
 		):
-			result = revisar_estatus_cancelacion(ffm)
-		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO")
-		self.assertEqual(result.get("status"), "TIMBRADO")
+			out = revisar_estatus_cancelacion(ffm)
+		rec.assert_called_once_with(ffm)
+		qps.assert_not_called()
+		self.assertEqual(out, {"ffm": ffm, "outcome": "changed"})
 
 	# cero referencias al cliente PAC importadas en el módulo de prueba
 	def test_cero_trafico_pac(self):

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
@@ -190,10 +190,11 @@ class TestFFMReconciliation(IntegrationTestCase):
 		self.assertEqual(self._status(ffm), "CANCELADO")
 
 	def test_accepted(self):
+		# Fail-closed (req #10): accepted SIN status=canceled NO confirma cancelación fiscal.
 		si = self._si()
-		ffm = self._ffm(si, "PENDIENTE_CANCELACION", sync="synced")
-		self._reconciliar(ffm, get_return=_ok({"cancellation_status": "accepted"}))
-		self.assertEqual(self._status(ffm), "CANCELADO")
+		ffm = self._ffm(si, "TIMBRADO", sync="pending")
+		self._reconciliar(ffm, get_return=_ok({"status": "valid", "cancellation_status": "accepted"}))
+		self.assertEqual(self._status(ffm), "PENDIENTE_CANCELACION")
 
 	def test_rejected(self):
 		si = self._si()

--- a/facturacion_mexico/facturacion_fiscal/tests/test_pac_response_correlacion.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_pac_response_correlacion.py
@@ -116,6 +116,13 @@ class TestPACResponseCorrelacion(IntegrationTestCase):
 
 	# 2
 	def test_cancelacion_se_aplica_al_ffm_explicito(self):
+		"""El writer correlaciona la respuesta de cancelación al FFM explícito, pero NO
+		proyecta el estado de cancelación (skip_state_persist). La proyección autoritativa
+		la hace `apply_cancellation_state`, y solo sobre el FFM explícito."""
+		from facturacion_mexico.facturacion_fiscal.cancellation_state import (
+			apply_cancellation_state,
+		)
+
 		ffm_a = self._ffm(status="TIMBRADO", uuid="UUID-A", facturapi_id="fa-A")
 		ffm_b = self._ffm(status="TIMBRADO", uuid="UUID-B", facturapi_id="fa-B")
 
@@ -123,6 +130,19 @@ class TestPACResponseCorrelacion(IntegrationTestCase):
 			self.si, {"req": 1}, _cancelacion_response(), "cancelacion", factura_fiscal_name=ffm_a
 		)
 		self.assertTrue(result["success"])
+
+		# Response Log correlacionado al FFM explícito (ffm_a)
+		log_ffm = frappe.db.get_value(
+			"FacturAPI Response Log", result["response_log_name"], "factura_fiscal_mexico"
+		)
+		self.assertEqual(log_ffm, ffm_a)
+
+		# El writer no persiste estado de cancelación: ambos siguen TIMBRADO
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_a, "status"), "TIMBRADO")
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_b, "status"), "TIMBRADO")
+
+		# La capa autoritativa proyecta CANCELADO solo sobre el FFM explícito
+		apply_cancellation_state(ffm_a, "CANCELADO", sync_status="canceled")
 		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_a, "status"), "CANCELADO")
 		# ffm_b intacto
 		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm_b, "status"), "TIMBRADO")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_persistence_recovery.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_persistence_recovery.py
@@ -268,38 +268,44 @@ class TestPersistenceRecovery(IntegrationTestCase):
 		client.cancel_invoice.return_value = {"success": True, "raw_response": {"status": "canceled"}}
 		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
 			api = TimbradoAPI(company="_Test Company")
+			# Boundary nuevo: la escritura autoritativa del estado es apply_cancellation_state.
+			# Si falla + el writer también falló -> ni una ni otra confirmó la persistencia.
 			with (
-				patch("frappe.set_value", side_effect=_set_value_factory(ffm_raises=True)),
+				patch(
+					f"{_TIMBRADO_API}.apply_cancellation_state",
+					side_effect=RuntimeError("persistencia FFM caída"),
+				),
 				patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
 			):
 				result = api.cancelar_factura(si, "02")
 		self.assertFalse(result["success"])
 		self.assertEqual(result.get("persistence_status"), "unresolved")
+		self.assertEqual(
+			frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "TIMBRADO"
+		)  # no falso CANCELADO
 		client.cancel_invoice.assert_called_once()  # sin segunda cancelación
 		if recovery_dt:
 			self.assertEqual(frappe.db.count("Fiscal Recovery Task", {"reference_name": ffm}), 0)
 
 	# 6 — consulta: writer falla, el estado ya persistido queda verificado
-	def test_06_consulta_recuperada(self):
+	def test_06_revisar_delega_en_motor(self):
+		# Consolidación: revisar_estatus_cancelacion ya no consulta el PAC ni persiste por sí misma;
+		# delega en reconcile_ffm (único camino, con company/correlación/lock/permiso/writer) y NO
+		# hace una segunda consulta (query_pac_status). La resiliencia ante fallo del writer queda en
+		# el camino único (probada en las suites del motor/writer).
 		si = self._si()
 		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1", uuid="U-1")
-		mock_query = patch(
-			"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
-			return_value={"success": True, "data": {"cancellation_status": "accepted"}},
-		)
 		with (
-			mock_query as mq,
-			patch("frappe.set_value", side_effect=_set_value_factory()),
-			patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
+			patch(
+				"facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.reconcile_ffm",
+				return_value={"ffm": ffm, "outcome": "changed"},
+			) as rec,
+			patch("facturacion_mexico.facturacion_fiscal.api_client.query_pac_status") as qps,
 		):
 			result = revisar_estatus_cancelacion(ffm)
-		self.assertTrue(result.get("success", True))  # éxito con advertencia
-		self.assertEqual(result.get("status"), "CANCELADO")  # estado previamente persistido y verificado
-		self.assertNotEqual(result.get("persistence_status"), "recovered_by_phase3")
-		self.assertEqual(result.get("persistence_status"), "state_verified_after_writer_failure")
-		self.assertEqual(result.get("persistence_recovery_source"), "pre_writer_state_update")
-		self.assertTrue(result.get("persistence_warning"))
-		mq.assert_called_once()  # consulta al PAC una sola vez
+		rec.assert_called_once_with(ffm)
+		qps.assert_not_called()
+		self.assertEqual(result, {"ffm": ffm, "outcome": "changed"})
 
 	# --- M3 (CodeRabbit): verificación de persistencia usa el estado derivado (`fiscal_status`) ---
 
@@ -313,10 +319,19 @@ class TestPersistenceRecovery(IntegrationTestCase):
 		client.cancel_invoice.return_value = {"success": True, "raw_response": raw_response}
 		with patch(f"{_TIMBRADO_API}.get_facturapi_client", return_value=client):
 			api = TimbradoAPI(company="_Test Company")
-			with (
-				patch("frappe.set_value", side_effect=_set_value_factory(ffm_raises=ffm_raises)),
-				patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
-			):
+			with ExitStack() as es:
+				es.enter_context(patch("frappe.set_value", side_effect=_set_value_factory(ffm_raises=False)))
+				es.enter_context(
+					patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False})
+				)
+				if ffm_raises:
+					# Boundary nuevo: la escritura autoritativa es apply_cancellation_state.
+					es.enter_context(
+						patch(
+							f"{_TIMBRADO_API}.apply_cancellation_state",
+							side_effect=RuntimeError("persistencia FFM caída"),
+						)
+					)
 				result = api.cancelar_factura(si, motivo)
 		return result, ffm, client
 

--- a/facturacion_mexico/facturacion_fiscal/tests/test_sync_status_semantics.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_sync_status_semantics.py
@@ -18,7 +18,9 @@ from unittest.mock import MagicMock, patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from facturacion_mexico.config.fiscal_states_config import FiscalStates, SyncStates
 from facturacion_mexico.facturacion_fiscal.api import PACResponseWriter
+from facturacion_mexico.facturacion_fiscal.cancellation_state import apply_cancellation_state
 from facturacion_mexico.facturacion_fiscal.timbrado_api import TimbradoAPI, revisar_estatus_cancelacion
 
 _TIMBRADO_API = "facturacion_mexico.facturacion_fiscal.timbrado_api"
@@ -152,26 +154,34 @@ class TestSyncStatusSemantics(IntegrationTestCase):
 		self.assertEqual(self._sync(ffm), "synced")
 
 	# 4 — cancelación inmediata (raw sin 'success', con id) → synced
+	# Nuevo contrato (CORR-1): en cancelación el writer crea el Response Log pero NO persiste
+	# status/fm_sync_status; eso lo hace apply_cancellation_state. Se verifican ambos por separado.
 	def test_04_cancelacion_inmediata_synced(self):
 		si = self._si()
-		ffm = self._ffm(si, "CANCELADO", facturapi_id="FA-1")
+		ffm = self._ffm(si, "CANCELADO", facturapi_id="FA-1", sync="pending")
 		self._write(si, ffm, {"status": "canceled", "id": "FA-1"}, "cancelacion")
-		self.assertEqual(self._sync(ffm), "synced")
+		self.assertEqual(self._sync(ffm), "pending")  # (1) writer no toca sync
+		apply_cancellation_state(ffm, FiscalStates.CANCELADO, sync_status=SyncStates.SYNCED)
+		self.assertEqual(self._sync(ffm), "synced")  # (2) apply sí
 
-	# 5 — cancelación pendiente de aceptación → synced (la respuesta ya se reflejó)
+	# 5 — cancelación pendiente de aceptación
 	def test_05_cancelacion_pendiente_synced(self):
 		si = self._si()
-		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1")
+		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1", sync="pending")
 		self._write(si, ffm, {"cancellation_status": "pending", "id": "FA-1"}, "cancelacion")
 		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), "PENDIENTE_CANCELACION")
-		self.assertEqual(self._sync(ffm), "synced")
+		self.assertEqual(self._sync(ffm), "pending")  # (1) writer no toca status/sync
+		apply_cancellation_state(ffm, FiscalStates.PENDIENTE_CANCELACION, sync_status=SyncStates.SYNCED)
+		self.assertEqual(self._sync(ffm), "synced")  # (2) apply sí
 
-	# 6 — cancelación rechazada y registrada → synced
+	# 6 — cancelación rechazada y registrada
 	def test_06_cancelacion_rechazada_synced(self):
 		si = self._si()
-		ffm = self._ffm(si, "TIMBRADO", facturapi_id="FA-1")
+		ffm = self._ffm(si, "TIMBRADO", facturapi_id="FA-1", sync="pending")
 		self._write(si, ffm, {"cancellation_status": "rejected", "id": "FA-1"}, "cancelacion")
-		self.assertEqual(self._sync(ffm), "synced")
+		self.assertEqual(self._sync(ffm), "pending")  # (1) writer no toca sync
+		apply_cancellation_state(ffm, FiscalStates.TIMBRADO, sync_status=SyncStates.SYNCED)
+		self.assertEqual(self._sync(ffm), "synced")  # (2) apply sí
 
 	# 7 — consulta con respuesta concluyente → synced
 	def test_07_consulta_concluyente_synced(self):
@@ -292,19 +302,19 @@ class TestSyncStatusSemantics(IntegrationTestCase):
 
 	# 9 — consulta con writer fallido pero estado verificado → synced
 	def test_09_consulta_recuperada_synced(self):
-		si = self._si()
-		ffm = self._ffm(si, "PENDIENTE_CANCELACION", facturapi_id="FA-1", uuid="U-1", sync="pending")
-		mock_query = patch(
-			"facturacion_mexico.facturacion_fiscal.api_client.query_pac_status",
-			return_value={"success": True, "data": {"cancellation_status": "accepted"}},
-		)
+		# Consolidación: revisar delega en reconcile_ffm (camino único) y NO hace 2ª consulta al PAC.
+		ffm = self._ffm(self._si(), "PENDIENTE_CANCELACION", facturapi_id="FA-1", uuid="U-1", sync="pending")
 		with (
-			mock_query,
-			patch("frappe.set_value", side_effect=_set_value_factory()),
-			patch(f"{_TIMBRADO_API}.write_pac_response", return_value={"success": False}),
+			patch(
+				"facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.reconcile_ffm",
+				return_value={"ffm": ffm, "outcome": "changed"},
+			) as rec,
+			patch("facturacion_mexico.facturacion_fiscal.api_client.query_pac_status") as qps,
 		):
-			revisar_estatus_cancelacion(ffm)
-		self.assertEqual(self._sync(ffm), "synced")
+			out = revisar_estatus_cancelacion(ffm)
+		rec.assert_called_once_with(ffm)
+		qps.assert_not_called()
+		self.assertEqual(out, {"ffm": ffm, "outcome": "changed"})
 
 	# 14 — HTTP 5xx / status_code=0 NO se clasifican como concluyentes solo por el código
 	def test_14_http_5xx_no_synced(self):

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -41,7 +41,12 @@ def _log_payload_checkpoint(tag, payload: dict):
 from facturacion_mexico.config.fiscal_states_config import (
 	FiscalStates,
 	OperationTypes,
-	derive_pac_reconciliation,
+	SyncStates,
+)
+from facturacion_mexico.facturacion_fiscal.cancellation_state import (
+	apply_cancellation_state,
+	derive_cancellation_reconciliation,
+	extract_canceled_at,
 )
 
 from .api import (  # PAC Response Writer - Arquitectura resiliente activada
@@ -1543,52 +1548,47 @@ class TimbradoAPI:
 
 			# FASE 3: ACTUALIZACIÓN FRAPPE
 			try:
-				# Construir valor EXACTO esperado por campo Select del DocType
-				motivo_completo = _build_cancellation_reason_for_select(motivo)
-
-				# CORRECCIÓN BUG: Mapear estado fiscal según respuesta real del PAC
+				# Interpretar la respuesta del PAC con el criterio ACOTADO de cancelación
+				# (verifying/pending/accepted-aislado -> PENDIENTE; canceled -> CANCELADO;
+				# rejected/expired -> TIMBRADO; desconocido -> None, nunca CANCELADO).
 				raw_response = pac_response.get("raw_response", {})
 				response_status = raw_response.get("status", "")
 				cancellation_status = raw_response.get("cancellation_status", "")
 
-				# Log respuesta para auditoría
 				frappe.logger().info(
 					f"Respuesta PAC para FFM {factura_fiscal.name}: status='{response_status}', cancellation_status='{cancellation_status}'"
 				)
 
-				# Mapeo ÚNICO (derive_pac_reconciliation): mantiene accepted->CANCELADO y suma
-				# expired->TIMBRADO. Se consume solo el estado fiscal ([0]); el sync lo maneja el writer.
-				fiscal_status = derive_pac_reconciliation(response_status, cancellation_status)[0]
-				if fiscal_status == FiscalStates.CANCELADO:
-					cancellation_date = now_datetime()
-				elif fiscal_status is None:
-					# Respuesta inesperada/no definitiva: fallback conservador (comportamiento previo).
+				fiscal_status, sync_status = derive_cancellation_reconciliation(
+					response_status, cancellation_status
+				)
+				if fiscal_status is None:
+					# Respuesta no concluyente: fallback conservador. No degrada un CANCELADO previo
+					# (la monotonicidad la protege apply_cancellation_state).
 					fiscal_status = FiscalStates.PENDIENTE_CANCELACION
-					cancellation_date = None
+					sync_status = SyncStates.PENDING
 					frappe.logger().warning(
-						f"Respuesta PAC inesperada para FFM {factura_fiscal.name}: status='{response_status}', cancellation_status='{cancellation_status}'. Usando fallback PENDIENTE_CANCELACION"
+						f"Respuesta PAC no concluyente para FFM {factura_fiscal.name}: "
+						f"status='{response_status}', cancellation_status='{cancellation_status}'. "
+						f"Fallback PENDIENTE_CANCELACION"
 					)
-				else:
-					cancellation_date = None
 
-				# Actualizar FFM con estado correcto
-				update_data = {
-					"status": fiscal_status,
-					"cancellation_reason": motivo_completo,
-				}
-				if cancellation_date:
-					update_data["cancellation_date"] = cancellation_date
+				# CANCELADO: usar el `canceled_at` REAL del PAC cuando exista; observación solo si no hay.
+				cancellation_date = (
+					(extract_canceled_at(pac_response) or now_datetime())
+					if fiscal_status == FiscalStates.CANCELADO
+					else None
+				)
 
-				# fm_motivo_cancelacion es el campo canónico del código SAT
-				if fiscal_status == FiscalStates.CANCELADO:
-					update_data["fm_motivo_cancelacion"] = motivo  # código corto: "01", "02", etc.
-				else:
-					update_data["fm_motivo_cancelacion"] = None  # solicitud rechazada o pendiente
-
-				frappe.set_value("Factura Fiscal Mexico", factura_fiscal.name, update_data)
-
-				# Actualizar Sales Invoice con mismo estado fiscal
-				frappe.set_value("Sales Invoice", sales_invoice_name, {"fm_fiscal_status": fiscal_status})
+				# ÚNICA escritura autoritativa del estado de cancelación (status, motivo conservado,
+				# cancellation_reason derivado, cancellation_date, fm_sync_status y snapshot SI).
+				# El writer (FASE previa) creó el Response Log y NO persistió el estado fiscal.
+				apply_cancellation_state(
+					factura_fiscal.name,
+					fiscal_status,
+					sync_status=sync_status,
+					cancellation_date=cancellation_date,
+				)
 
 				frappe.db.commit()  # nosemgrep: frappe-manual-commit - Required to ensure cancellation transaction is committed
 
@@ -1668,9 +1668,13 @@ class TimbradoAPI:
 					return _persistence_unresolved_result()
 
 				# PAC canceló exitosamente pero Frappe falló - CREAR RECOVERY TASK
-				frappe.log_error(
-					f"Error post-cancelación actualizando Frappe: {frappe_error}", "Post-Cancelación Error"
-				)
+				try:
+					frappe.log_error(
+						title="Post-Cancelación Error",
+						message=f"Error post-cancelación actualizando Frappe: {frappe_error}",
+					)
+				except Exception:
+					pass  # el fallo del logger nunca debe reemplazar ni ocultar el error original
 
 				# CRÍTICO: Crear Recovery Task para que jobs automáticos corrijan el estado
 				try:
@@ -1703,9 +1707,13 @@ class TimbradoAPI:
 					)
 
 				except Exception as recovery_error:
-					frappe.log_error(
-						f"Error creando Recovery Task: {recovery_error}", "Recovery Task Creation Error"
-					)
+					try:
+						frappe.log_error(
+							title="Recovery Task Creation Error",
+							message=f"Error creando Recovery Task: {recovery_error}",
+						)
+					except Exception:
+						pass
 
 				return {
 					"success": False,
@@ -1722,16 +1730,22 @@ class TimbradoAPI:
 			# Error ANTES del PAC o error del PAC ya manejado
 			if not pac_response:
 				# Error antes de llamar al PAC - NO guardar en Response Log
-				frappe.log_error(
-					f"Error pre-cancelación (antes de contactar PAC): {e}\nSales Invoice: {sales_invoice_name}",
-					"Pre-Cancelación Error",
-				)
+				try:
+					frappe.log_error(
+						title="Pre-Cancelación Error",
+						message=f"Error pre-cancelación (antes de contactar PAC): {e}\nSales Invoice: {sales_invoice_name}",
+					)
+				except Exception:
+					pass
 			else:
 				# Error del PAC ya fue guardado en Response Log
-				frappe.log_error(
-					f"Error cancelación PAC: {e}\nSales Invoice: {sales_invoice_name}",
-					"PAC Cancelación Error",
-				)
+				try:
+					frappe.log_error(
+						title="PAC Cancelación Error",
+						message=f"Error cancelación PAC: {e}\nSales Invoice: {sales_invoice_name}",
+					)
+				except Exception:
+					pass
 
 			# Generar mensaje amigable SOLO para UI
 			error_details = self._process_pac_error(e)
@@ -2884,15 +2898,20 @@ def cancelar_factura(
 		description = SAT_MOTIVES.get_description(motivo_code)
 		frappe.throw(f"El motivo '{motivo_code}' ({description}) requiere UUID de sustitución obligatorio")
 
-	# [Milestone 3] Guard backend: motivo 01 solo desde flujo sustitución
-	# Obtener FFM doc para el guard y persistencia
+	# [Milestone 3] Guard backend + persistencia: resolver la FFM ACTIVA EXPLÍCITA desde la SI.
+	# Prohibido get_all(... limit=1) (puede caer en una FFM distinta a la cancelada). Se valida
+	# que los vínculos SI<->FFM coincidan; si no, se detiene con error controlado.
 	ffm_doc = None
-	ffm_name = None
-	if sales_invoice:
-		ffm_list = frappe.get_all("Factura Fiscal Mexico", filters={"sales_invoice": sales_invoice}, limit=1)
-		if ffm_list:
-			ffm_name = ffm_list[0].name
-			ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
+	ffm_name = frappe.db.get_value("Sales Invoice", sales_invoice, "fm_factura_fiscal_mx")
+	if ffm_name:
+		ffm_si = frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "sales_invoice")
+		if ffm_si != sales_invoice:
+			frappe.throw(
+				_("Inconsistencia de vínculos: la FFM {0} no corresponde al Sales Invoice {1}.").format(
+					ffm_name, sales_invoice
+				)
+			)
+		ffm_doc = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
 
 	if ffm_doc:
 		_guard_motive_01_only_from_substitution(ffm_doc, motivo_code, substitution_uuid)
@@ -3220,20 +3239,28 @@ def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
 				api = TimbradoAPI()
 				# CRITICAL FIX: Usar orig_si_name en lugar de orig_ffm_name
 				cancel_result = api.cancelar_factura(orig_si_name, "01", new_uuid)
-				frappe.logger().info(f"Cancelación fiscal PAC exitosa: {cancel_result}")
+				frappe.logger().info(f"Cancelación fiscal PAC: {cancel_result}")
 			except Exception as e:
 				frappe.logger().error(f"Error cancelando CFDI previo en PAC: {e}")
 				# No fallar toda la operación por error en cancelación PAC
 				cancel_result = None
 
-			# 2) REORDER: Marcar FFM original con estado fiscal CANCELADO (sin cancelar DocType aún)
-			try:
-				orig_ffm.reload()
-				orig_ffm.set("status", "CANCELADO")
-				orig_ffm.save()
-				frappe.logger().info(f"FFM {orig_ffm_name} marcada como CANCELADO fiscalmente")
-			except Exception as e:
-				frappe.logger().error(f"Error marcando FFM como CANCELADO: {e}")
+			# 2) GUARDA FAIL-CLOSED: relectura autoritativa del estado real (misma transacción, sin
+			# commit extra). La operación interna ya aplicó el estado vía apply_cancellation_state.
+			# Solo se continúa la cancelación DOCUMENTAL si el CFDI previo quedó realmente CANCELADO.
+			# Si el PAC falló / quedó pending/verifying / no terminal, NO se cancela SI ni FFM.
+			orig_status = frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "status")
+			if orig_status != FiscalStates.CANCELADO:
+				frappe.logger().warning(
+					f"Cascada detenida: CFDI previo no terminal "
+					f"(FFM {orig_ffm_name} status={orig_status}). No se cancela SI/FFM."
+				)
+				return {
+					"cascade": "halted_not_terminal",
+					"ffm": orig_ffm_name,
+					"status": orig_status,
+				}
+			frappe.logger().info(f"FFM {orig_ffm_name} CANCELADO confirmado; continúa cancelación documental")
 
 			# 2.5) HARDENING PREVENTIVO - ANTES de cancelar (CONFIRMADO POR EXPERTO)
 			try:
@@ -3469,102 +3496,16 @@ def get_sat_cancellation_motives():
 
 @frappe.whitelist()
 def revisar_estatus_cancelacion(ffm_name: str) -> dict:
-	"""Consulta FacturAPI para resolver estado PENDIENTE_CANCELACION."""
-	ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
+	"""Compat: delega en el flujo ÚNICO de reconciliación (motor `reconcile_ffm`).
 
-	if ffm.status != FiscalStates.PENDIENTE_CANCELACION:
-		frappe.throw(_("El documento no está en estado PENDIENTE_CANCELACION"))
+	No conserva lógica propia (consulta PAC, resolución de company, clasificación, aplicación de
+	estado, Response Log, permisos, lock, correlación): TODO se hereda de `reconcile_ffm` →
+	`_reconcile_ffm`. El botón GUI propio se eliminó; la función se mantiene por compatibilidad con
+	llamadas existentes.
+	"""
+	from facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation import reconcile_ffm
 
-	from facturacion_mexico.facturacion_fiscal.api_client import query_pac_status
-
-	result = query_pac_status(ffm_name)
-
-	if not result.get("success"):
-		frappe.throw(_("Error al consultar PAC: {0}").format(result.get("error")))
-
-	data = result.get("data", {})
-	pac_status = data.get("status", "")
-	cancel_status = data.get("cancellation_status", "")
-
-	# Mapeo ÚNICO (derive_pac_reconciliation): se consume solo el estado fiscal ([0]).
-	# Mantiene accepted->CANCELADO y suma expired->TIMBRADO (antes caía a PENDIENTE_CANCELACION).
-	nuevo_estado = derive_pac_reconciliation(pac_status, cancel_status)[0]
-	if nuevo_estado == FiscalStates.CANCELADO:
-		update_data = {
-			"status": nuevo_estado,
-			"cancellation_date": now_datetime(),
-		}
-		msg = _("Cancelación confirmada por el receptor. CFDI cancelado.")
-		indicator = "green"
-	elif nuevo_estado == FiscalStates.TIMBRADO:
-		update_data = {
-			"status": nuevo_estado,
-			"fm_motivo_cancelacion": None,
-		}
-		msg = _("La cancelación no procedió (rechazada o expirada). CFDI sigue vigente.")
-		indicator = "orange"
-	else:
-		# None (no definitivo) o cualquier otro: conservar PENDIENTE_CANCELACION.
-		nuevo_estado = FiscalStates.PENDIENTE_CANCELACION
-		update_data = {"status": nuevo_estado}
-		msg = _("Cancelación aún pendiente de aceptación por el receptor.")
-		indicator = "blue"
-
-	frappe.db.set_value("Factura Fiscal Mexico", ffm_name, update_data)
-	if ffm.sales_invoice:
-		frappe.db.set_value("Sales Invoice", ffm.sales_invoice, {"fm_fiscal_status": nuevo_estado})
-
-	# Registrar consulta en FacturAPI Response Log para trazabilidad
-	writer_result = None
-	try:
-		writer_result = write_pac_response(
-			sales_invoice_name=ffm.sales_invoice or "",
-			request_data=json.dumps(
-				{"action": "consulta_estatus", "ffm": ffm_name, "facturapi_id": ffm.facturapi_id}
-			),
-			response_data=json.dumps(
-				{
-					"success": True,
-					"status_code": 200,
-					"raw_response": data,
-					"resultado_transicion": nuevo_estado,
-				},
-				default=str,
-			),
-			operation_type="consulta",
-			factura_fiscal_name=ffm_name,
-		)
-	except FiscalCorrelationError:
-		# Corrección 6A: la inconsistencia de correlación en la consulta NO se traga; se reporta.
-		# El cambio de estado escrito sobre ESTE FFM se revierte al propagar (no se hace commit).
-		_raise_correlation_incident()
-	except Exception as log_err:
-		frappe.logger().warning(f"No se pudo registrar log de consulta estatus {ffm_name}: {log_err}")
-
-	frappe.db.commit()  # nosemgrep: frappe-manual-commit - Required to persist status transition immediately after PAC response
-
-	base_result = {
-		"status": nuevo_estado,
-		"message": msg,
-		"indicator": indicator,
-		"cancellation_status": cancel_status,
-	}
-	# Corrección 6B2: si la persistencia principal del writer falló (PAC OK), verificar que el
-	# estado ya determinado por el flujo quedó persistido. No se repite la consulta al PAC.
-	if _writer_persistence_failed(writer_result):
-		recovered = _verify_estado_persisted(ffm_name, nuevo_estado)
-		_alert_persistence_incident("consulta", ffm_name, ffm.sales_invoice, recovered)
-		_set_sync_status_best_effort(ffm_name, "synced" if recovered else "error")  # 7A1
-		return (
-			_persistence_recovered_result(
-				base_result,
-				status="state_verified_after_writer_failure",
-				source="pre_writer_state_update",
-			)
-			if recovered
-			else _persistence_unresolved_result(base_result)
-		)
-	return _apply_audit_warning(writer_result, base_result)
+	return reconcile_ffm(ffm_name)
 
 
 _ALLOWED_PDF_TEMPLATE_KEYS = frozenset({"company", "total", "due_date"})

--- a/facturacion_mexico/tests/legacy_allowlist.py
+++ b/facturacion_mexico/tests/legacy_allowlist.py
@@ -3,5 +3,9 @@
 # Campos históricos *intencionalmente* sin prefijo fm_
 # No añadir aquí campos nuevos; solo legados ya existentes.
 LEGACY_CF_ALLOWLIST = {
-    "ffm_substitution_source_uuid",
+	"ffm_substitution_source_uuid",
+	# Campo externo inyectado por upstream (Frappe CRM) sobre Customer.
+	# No es propiedad de facturacion_mexico; aparece según la versión de
+	# frappe/erpnext instalada en CI. Se excluye de la regla de prefijo fm_.
+	"crm_deal",
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
       - adr/0033-factura-global-hardcodes.md
       - adr/0034-integridad-correlacion-ffm.md
       - adr/0035-motor-reconciliacion-ffm.md
+      - adr/0036-integridad-proyeccion-cancelacion.md
   - Referencia:
     - referencia/index.md
     - DocTypes: referencia/doctypes.md


### PR DESCRIPTION
## Objetivo

Corregir el bug por el que una Factura Fiscal Mexico podía quedar `CANCELADO` de forma prematura o incompleta, dejando la Sales Invoice sin poder cancelarse.

## Cambios principales

- **Clasificación fail-closed:**
  - HTTP 200 no confirma una cancelación;
  - solo el estado remoto `canceled` es terminal;
  - `valid` con `verifying`, `pending` o `accepted` permanece en `PENDIENTE_CANCELACION`;
  - respuestas desconocidas no producen transición a `CANCELADO`.
- **Operación autoritativa única, idempotente y monotónica**, que proyecta consistentemente: estado, motivo solicitado, descripción derivada, fecha de cancelación, sincronización y snapshot fiscal de la Sales Invoice.
- El mismo flujo autoritativo es utilizado por: la confirmación síncrona, la verificación manual y el motor de reconciliación.
- El reconciliador puede **reparar una FFM terminal incompleta** aunque `status` y `fm_sync_status` no cambien, dejando trazabilidad únicamente cuando existe un cambio local real.
- **No se modifica `_select_candidates` ni el alcance del scheduler.**
- `cancellation_date` utiliza prioritariamente el `canceled_at` proporcionado por el PAC: UTC normalizado a la zona horaria del sitio; hora de observación solo como respaldo; una fecha existente no se sobrescribe.
- **Se consolida la consulta manual en un solo botón:** "Verificar estado en FacturAPI". La función anterior de revisión queda como wrapper del flujo autoritativo, sin duplicar consulta al PAC, permisos, compañía, lock, correlación, clasificación ni persistencia.
- **Endurecimientos adicionales:**
  - el guard de cancelación de Sales Invoice valida el estado real de la FFM activa;
  - el endpoint resuelve la FFM mediante su vínculo explícito;
  - `cancellation_reason` queda derivado, de solo lectura y sin asignación implícita del motivo 01;
  - el logging deja de enmascarar la excepción original con errores 1406.

## Documentación actualizada

- `docs/adr/0036-integridad-proyeccion-cancelacion.md` (nuevo ADR de integridad y proyección de cancelación)
- `docs/adr/0035-motor-reconciliacion-ffm.md` (nota de extensión)
- `docs/adr/index.md`
- `docs/tecnico/arquitectura.md`
- `docs/usuario/cancelar-cfdi.md`, `docs/usuario/verificar-estado-facturapi.md`
- `mkdocs.yml`

## Validaciones realizadas

- `ruff check`: correcto. `mkdocs build --strict`: correcto.
- Suites de cancelación y reconciliación: verdes.
- `bench migrate`: correcto en sitios de validación.
- Validación GUI en un entorno restaurado de validación, que confirmó: consulta mediante GET; estado remoto `canceled`; conversión correcta de `canceled_at`; reparación de FFM y snapshot de Sales Invoice; ninguna nueva solicitud de cancelación; ningún nuevo error de logging (1406).
- `bandit` y `semgrep` no estuvieron disponibles en el entorno local (los ejecuta CI).

## Fuera de alcance

- Remediación de registros existentes.
- Modificación de `_select_candidates`.
- Ampliación del alcance del scheduler.

## Riesgos / pendientes

Despliegue: requiere migración del sitio (cambio del DocType), compilación de assets (JavaScript) y limpieza de caché conforme al procedimiento normal de actualización del app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a unified cancellation status verification flow that also performs idempotent repair for incomplete cancellations.
  * Consolidated the manual cancellation/check UI into a single button, with improved handling of pending vs. fully canceled outcomes.
* **Bug Fixes**
  * Prevents marking records as fully canceled without definitive provider confirmation (fail-closed).
  * Ensures consistent cancellation date/reason projection and prevents downgrading terminal states; hardened cancellation logging behavior.
* **Documentation**
  * Updated ADRs and user/technical guides for the revised cancellation and verification behavior.
* **Tests**
  * Added integration coverage for cancellation integrity and updated related reconciliation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->