### PR TITLE
fix(email): unify fiscal recipient resolution

### DIFF
--- a/docs/referencia/doctypes.md
+++ b/docs/referencia/doctypes.md
@@ -881,9 +881,12 @@ Fuente: `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/fac
 | `fm_last_response_log` | Último Log de Respuesta | Link |  | FacturAPI Response Log |
 
 
-### Facturacion Mexico Settings _Single_
+### Facturacion Mexico Settings _(removido — migrado a Facturacion Mexico Company Settings)_
 
-Fuente: `facturacion_mexico/facturacion_fiscal/doctype/facturacion_mexico_settings/facturacion_mexico_settings.json`
+> El DocType Single global `Facturacion Mexico Settings` fue **removido**. Su configuración
+> (credenciales FacturAPI, `customer_email_fallback`, defaults de email, etc.) ahora vive en
+> **`Facturacion Mexico Company Settings`**, por compañía. La tabla de campos siguiente es
+> **histórica** y se conserva solo como referencia de los campos migrados.
 
 
 | Campo | Label | Tipo | Requerido | Opciones |

--- a/docs/tecnico/email-system.md
+++ b/docs/tecnico/email-system.md
@@ -157,7 +157,7 @@ function applyFFMUi(frm) {
 }
 ```
 
-### Facturacion Mexico Settings DocType
+### Facturacion Mexico Company Settings DocType (por compañía)
 ```json
 {
     "fieldname": "send_email_default",
@@ -252,6 +252,11 @@ print(f"Email flag for customer: {flag}")
 customer = frappe.get_doc("Customer", "CUSTOMER_NAME")
 print(f"Customer email setting: {customer.fm_envio_email_cliente}")
 
-settings = frappe.get_single("Facturacion Mexico Settings")
-print(f"Global default: {settings.send_email_default}")
+settings = frappe.db.get_value(
+    "Facturacion Mexico Company Settings",
+    {"company": customer.represents_company or frappe.defaults.get_user_default("company")},
+    ["send_email_default", "customer_email_fallback"],
+    as_dict=True,
+)
+print(f"Company default: {settings.send_email_default if settings else None}")
 ```

--- a/docs/usuario/emitir-cfdi.md
+++ b/docs/usuario/emitir-cfdi.md
@@ -166,7 +166,7 @@ Si el cliente tiene configurado envío automático de CFDI (`fm_enviar_email_tim
 el sistema envía el XML y PDF por correo al hacer el timbrado.
 
 La configuración de correo se hereda de `Customer.fm_auto_send_cfdi` con fallback a
-`Facturacion Mexico Settings`.
+`Facturacion Mexico Company Settings` (configuración por compañía).
 
 ---
 

--- a/docs/usuario/troubleshooting.md
+++ b/docs/usuario/troubleshooting.md
@@ -8,7 +8,7 @@ Solución a los problemas más comunes.
 
 **Verificar en orden:**
 
-1. **Credenciales FacturAPI** — abrir `Facturacion Mexico Settings` y verificar que `API Key` esté configurada y que el modo sandbox/producción sea el correcto.
+1. **Credenciales FacturAPI** — abrir `Facturacion Mexico Company Settings` (de la compañía) y verificar que `API Key` esté configurada y que el modo sandbox/producción sea el correcto.
 
 2. **RFC de la empresa** — en `Setup > Company`, verificar que `Tax ID` tenga el RFC correcto.
 

--- a/facturacion_mexico/complementos_pago/api.py
+++ b/facturacion_mexico/complementos_pago/api.py
@@ -550,19 +550,16 @@ def action_send_email_complemento(complemento_name: str, to: str | None = None) 
 	if not comp.facturapi_id:
 		frappe.throw(_("El complemento no tiene ID de FacturAPI."))
 
-	to_email = to
-	if not to_email:
-		to_email = (
-			frappe.db.get_value("Payment Entry", comp.payment_entry, "contact_email")
-			if comp.payment_entry
-			else None
-		)
-	if not to_email:
-		customer = (
-			frappe.db.get_value("Payment Entry", comp.payment_entry, "party") if comp.payment_entry else None
-		)
-		if customer:
-			to_email = frappe.db.get_value("Customer", customer, "email_id")
+	# Resolución canónica: mismo criterio que Factura Fiscal Mexico (dirección principal del
+	# Customer -> customer_email_fallback de Company Settings por comp.company). Usa el documento
+	# como fuente de Customer/Company; no se consultan fuentes del Payment Entry ni del Customer.
+	from facturacion_mexico.facturacion_fiscal.email_recipient import resolve_fiscal_recipient_email
+
+	to_email = resolve_fiscal_recipient_email(
+		customer=comp.customer,
+		company=comp.company,
+		to=to,
+	)
 
 	if not to_email:
 		comp.add_comment("Comment", "No se envió complemento: no hay destinatario.")

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -1077,7 +1077,8 @@ class FacturaFiscalMexico(Document):
 		if not self.customer:
 			# Mostrar mensajes informativos si no hay customer
 			self.fm_cp_cliente = "⚠️ SELECCIONA UN CLIENTE"
-			self.fm_email_facturacion = "⚠️ SELECCIONA UN CLIENTE"
+			# fm_email_facturacion solo almacena correo real o vacío (nunca avisos): se usa como destinatario.
+			self.fm_email_facturacion = ""
 			self.fm_rfc_cliente = "⚠️ SELECCIONA UN CLIENTE"
 			self.fm_tax_system = "⚠️ SELECCIONA UN CLIENTE"
 			self.fm_direccion_principal_link = ""
@@ -1120,14 +1121,15 @@ class FacturaFiscalMexico(Document):
 			if primary_address:
 				# Poblar datos desde dirección principal
 				self.fm_cp_cliente = primary_address.pincode or "⚠️ FALTA CP EN DIRECCIÓN"
-				self.fm_email_facturacion = primary_address.email_id or "⚠️ FALTA EMAIL EN DIRECCIÓN"
+				# Solo correo real o vacío: el aviso de falta de correo NO se almacena aquí.
+				self.fm_email_facturacion = primary_address.email_id or ""
 				self.fm_direccion_principal_link = primary_address.name
 				self.fm_direccion_principal_display = self._get_primary_address_display()
 				# Datos poblados desde dirección principal
 			else:
 				# No hay dirección principal - marcar campos como faltantes
 				self.fm_cp_cliente = "⚠️ FALTA DIRECCIÓN PRINCIPAL"
-				self.fm_email_facturacion = "⚠️ FALTA DIRECCIÓN PRINCIPAL"
+				self.fm_email_facturacion = ""
 				self.fm_direccion_principal_link = ""
 				self.fm_direccion_principal_display = "⚠️ FALTA DIRECCIÓN PRINCIPAL DEL CLIENTE"
 				# No hay dirección principal - campos marcados como faltantes
@@ -1139,7 +1141,7 @@ class FacturaFiscalMexico(Document):
 			frappe.log_error(f"Error poblando datos de facturación: {e!s}", "Billing Data Population Error")
 			# En caso de error, mostrar mensajes de error
 			self.fm_cp_cliente = "❌ ERROR AL OBTENER CP"
-			self.fm_email_facturacion = "❌ ERROR AL OBTENER EMAIL"
+			self.fm_email_facturacion = ""
 			self.fm_rfc_cliente = "❌ ERROR AL OBTENER RFC"
 			self.fm_tax_system = "❌ ERROR AL OBTENER TAX SYSTEM"
 			self.fm_direccion_principal_link = ""
@@ -1630,15 +1632,23 @@ def _resolve_auto_email_flag(customer_name: str, company=None) -> int:
 
 
 def _resolve_recipient_email(ffm_doc) -> str | None:
-	"""Devuelve el email final según regla estricta:
-	1) FFM.fm_email_facturacion
-	2) Settings.customer_email_fallback
-	3) None si no hay
+	"""Resuelve el destinatario del CFDI con el criterio fiscal canónico (multi-company).
+
+	Delegado al helper común para garantizar el MISMO criterio que el Complemento de Pago:
+	1) `fm_email_facturacion` ya almacenado si es un correo real, o dirección principal del Customer
+	2) `customer_email_fallback` de Company Settings para la company del documento
+	3) None
+
+	El fallback usa SIEMPRE la company del documento (no la company default global).
+	No se aceptan placeholders ni avisos almacenados en `fm_email_facturacion`.
 	"""
-	_, fallback = _get_settings_email_defaults()
-	ffm_email = (getattr(ffm_doc, "fm_email_facturacion", "") or "").strip()
-	result = ffm_email or fallback or None
-	return result
+	from facturacion_mexico.facturacion_fiscal.email_recipient import resolve_fiscal_recipient_email
+
+	return resolve_fiscal_recipient_email(
+		customer=getattr(ffm_doc, "customer", None),
+		company=getattr(ffm_doc, "company", None),
+		stored_email=getattr(ffm_doc, "fm_email_facturacion", None),
+	)
 
 
 def _send_cfdi_email(self, to_override: str | None = None) -> dict:

--- a/facturacion_mexico/facturacion_fiscal/email_recipient.py
+++ b/facturacion_mexico/facturacion_fiscal/email_recipient.py
@@ -1,0 +1,131 @@
+"""Resolución canónica del correo destinatario fiscal (CFDI ingreso y Complemento de Pago).
+
+Fuente única de verdad para decidir a qué correo se envía un comprobante fiscal por email.
+Tanto Factura Fiscal Mexico (envío manual y automático post-timbrado) como Complemento de
+Pago deben usar `resolve_fiscal_recipient_email` para garantizar el MISMO criterio.
+
+Prioridad real aplicada (estricta, sin fallbacks inventados):
+    1. `to` explícito SI es un correo válido (override programático; la UI hoy siempre envía None).
+       Un `to` inválido NUNCA se usa como destinatario: se ignora y la resolución continúa con
+       los pasos siguientes (jamás se intenta enviar a un valor inválido).
+    2. `stored_email` (FFM.fm_email_facturacion) SI es un correo válido. Para la FFM este valor
+       ya ES el correo de la dirección principal capturado al poblar el documento; por eso, cuando
+       es válido, NO se vuelve a consultar la dirección (evita una consulta redundante o
+       contradictoria). El Complemento no pasa `stored_email`, así que cae directo al paso 2b.
+    2b. Correo válido de la dirección principal del Customer (`Address.email_id`).
+    3. `customer_email_fallback` de Facturacion Mexico Company Settings para la company recibida.
+    4. None.
+
+No se aceptan placeholders, advertencias ni textos que no sean un correo válido.
+No se usan: Payment Entry.contact_email, Customer.email_id, Contact.email_id, primeros
+contactos relacionados, ni la compañía default global.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+
+def _is_valid_email(value: str | None) -> bool:
+	"""True solo si `value` parece un correo real (descarta vacíos, placeholders y avisos)."""
+	if not value or not isinstance(value, str):
+		return False
+	email = value.strip()
+	if not email or " " in email:
+		return False
+	# Un correo válido tiene exactamente un '@' con texto a ambos lados y un punto en el dominio.
+	if email.count("@") != 1:
+		return False
+	local, _, domain = email.partition("@")
+	if not local or "." not in domain:
+		return False
+	# Descarta explícitamente placeholders/avisos (emojis o caracteres no ASCII de aviso).
+	return email.isascii()
+
+
+def get_customer_primary_address_email(customer: str | None) -> str | None:
+	"""Correo de la dirección principal del Customer (misma fuente que FFM).
+
+	Resolución de la dirección principal:
+	    1) Address con `is_primary_address=1` ligada al Customer por Dynamic Link.
+	    2) `Customer.customer_primary_address`.
+	    3) Primera Address ligada por Dynamic Link.
+	Devuelve `Address.email_id` si es un correo válido, de lo contrario None.
+	"""
+	if not customer:
+		return None
+
+	addr_name = None
+	primary_addresses = frappe.get_all("Address", filters={"is_primary_address": 1}, pluck="name")
+	for name in primary_addresses:
+		if frappe.db.exists(
+			"Dynamic Link",
+			{
+				"link_doctype": "Customer",
+				"link_name": customer,
+				"parent": name,
+				"parenttype": "Address",
+			},
+		):
+			addr_name = name
+			break
+
+	if not addr_name:
+		addr_name = frappe.db.get_value("Customer", customer, "customer_primary_address")
+
+	if not addr_name:
+		linked = frappe.get_all(
+			"Dynamic Link",
+			filters={"link_doctype": "Customer", "link_name": customer, "parenttype": "Address"},
+			pluck="parent",
+		)
+		if linked:
+			addr_name = linked[0]
+
+	if not addr_name:
+		return None
+
+	email = frappe.db.get_value("Address", addr_name, "email_id")
+	return email.strip() if _is_valid_email(email) else None
+
+
+def get_company_fallback_email(company: str | None) -> str | None:
+	"""`customer_email_fallback` de Facturacion Mexico Company Settings para `company`.
+
+	Multi-company estricto: NO usa la company default global. Si no se recibe `company`,
+	no hay fallback (devuelve None).
+	"""
+	if not company:
+		return None
+	fallback = frappe.db.get_value(
+		"Facturacion Mexico Company Settings",
+		{"company": company},
+		"customer_email_fallback",
+	)
+	return fallback.strip() if _is_valid_email(fallback) else None
+
+
+def resolve_fiscal_recipient_email(
+	*,
+	customer: str | None = None,
+	company: str | None = None,
+	to: str | None = None,
+	stored_email: str | None = None,
+) -> str | None:
+	"""Resuelve el destinatario fiscal según la prioridad canónica. Ver docstring del módulo."""
+	# 1. override explícito
+	if _is_valid_email(to):
+		return to.strip()
+	# 2. correo ya almacenado en el documento (FFM.fm_email_facturacion) si es real
+	if _is_valid_email(stored_email):
+		return stored_email.strip()
+	# 2b. correo real de la dirección principal del Customer
+	address_email = get_customer_primary_address_email(customer)
+	if address_email:
+		return address_email
+	# 3. fallback por company
+	fallback = get_company_fallback_email(company)
+	if fallback:
+		return fallback
+	# 4. sin destinatario
+	return None

--- a/facturacion_mexico/facturacion_fiscal/email_recipient.py
+++ b/facturacion_mexico/facturacion_fiscal/email_recipient.py
@@ -31,59 +31,58 @@ def _is_valid_email(value: str | None) -> bool:
 	if not value or not isinstance(value, str):
 		return False
 	email = value.strip()
-	if not email or " " in email:
+	# Descarta vacíos, espacios y placeholders/avisos (emojis u otros no-ASCII).
+	if not email or " " in email or not email.isascii():
 		return False
-	# Un correo válido tiene exactamente un '@' con texto a ambos lados y un punto en el dominio.
+	# Exactamente un '@' con texto a ambos lados.
 	if email.count("@") != 1:
 		return False
 	local, _, domain = email.partition("@")
-	if not local or "." not in domain:
+	if not local or not domain:
 		return False
-	# Descarta explícitamente placeholders/avisos (emojis o caracteres no ASCII de aviso).
-	return email.isascii()
+	# Dominio: sin punto inicial/final, con al menos dos etiquetas y ninguna vacía
+	# (rechaza cliente@.mx, cliente@example..com, cliente@mx, cliente@example.com.).
+	if domain.startswith(".") or domain.endswith("."):
+		return False
+	labels = domain.split(".")
+	if len(labels) < 2 or any(not label for label in labels):
+		return False
+	return True
 
 
 def get_customer_primary_address_email(customer: str | None) -> str | None:
 	"""Correo de la dirección principal del Customer (misma fuente que FFM).
 
-	Resolución de la dirección principal:
-	    1) Address con `is_primary_address=1` ligada al Customer por Dynamic Link.
-	    2) `Customer.customer_primary_address`.
-	    3) Primera Address ligada por Dynamic Link.
+	Resolución acotada a las Address ligadas a ESTE Customer (sin escaneo global del sitio):
+	    1) Address ligada con `is_primary_address=1`.
+	    2) `Customer.customer_primary_address`, si está ligada al Customer.
+	    3) Primera Address ligada.
 	Devuelve `Address.email_id` si es un correo válido, de lo contrario None.
 	"""
 	if not customer:
 		return None
 
-	addr_name = None
-	primary_addresses = frappe.get_all("Address", filters={"is_primary_address": 1}, pluck="name")
-	for name in primary_addresses:
-		if frappe.db.exists(
-			"Dynamic Link",
-			{
-				"link_doctype": "Customer",
-				"link_name": customer,
-				"parent": name,
-				"parenttype": "Address",
-			},
-		):
-			addr_name = name
-			break
-
-	if not addr_name:
-		addr_name = frappe.db.get_value("Customer", customer, "customer_primary_address")
-
-	if not addr_name:
-		linked = frappe.get_all(
-			"Dynamic Link",
-			filters={"link_doctype": "Customer", "link_name": customer, "parenttype": "Address"},
-			pluck="parent",
-		)
-		if linked:
-			addr_name = linked[0]
-
-	if not addr_name:
+	# Direcciones ligadas a ESTE Customer (consulta acotada por Dynamic Link; sin escaneo global).
+	linked = frappe.get_all(
+		"Dynamic Link",
+		filters={"link_doctype": "Customer", "link_name": customer, "parenttype": "Address"},
+		pluck="parent",
+	)
+	if not linked:
 		return None
+
+	# 1) Entre las ligadas, preferir la marcada is_primary_address=1 (una sola consulta).
+	addr_name = frappe.db.get_value("Address", {"name": ["in", linked], "is_primary_address": 1}, "name")
+
+	# 2) Customer.customer_primary_address, solo si está ligada a este Customer.
+	if not addr_name:
+		cpa = frappe.db.get_value("Customer", customer, "customer_primary_address")
+		if cpa and cpa in linked:
+			addr_name = cpa
+
+	# 3) Primera Address ligada.
+	if not addr_name:
+		addr_name = linked[0]
 
 	email = frappe.db.get_value("Address", addr_name, "email_id")
 	return email.strip() if _is_valid_email(email) else None

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -2285,14 +2285,16 @@ class TimbradoAPI:
 
 		if not company:
 			frappe.throw(
-				"<div style='font-family: -apple-system, BlinkMacSystemFont, sans-serif;'>"
-				"<p style='margin: 0 0 15px 0;'>No se pudo determinar la empresa para buscar configuración fiscal.</p>"
-				"<p style='margin: 15px 0 8px 0; font-weight: 600;'>Solución:</p>"
-				"<ol style='margin: 0; padding-left: 20px;'>"
-				"<li>Configurar empresa en <strong>Facturacion Mexico Company Settings</strong></li>"
-				"</ol>"
-				"</div>",
-				title="Empresa No Configurada",
+				_(
+					"<div style='font-family: -apple-system, BlinkMacSystemFont, sans-serif;'>"
+					"<p style='margin: 0 0 15px 0;'>No se pudo determinar la empresa para buscar configuración fiscal.</p>"
+					"<p style='margin: 15px 0 8px 0; font-weight: 600;'>Solución:</p>"
+					"<ol style='margin: 0; padding-left: 20px;'>"
+					"<li>Configurar empresa en <strong>Facturacion Mexico Company Settings</strong></li>"
+					"</ol>"
+					"</div>"
+				),
+				title=_("Empresa No Configurada"),
 			)
 
 		# Buscar en configuración fiscal por company

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -710,8 +710,8 @@ class TimbradoAPI:
 			),
 		}
 
-		# TODO: Email fallback configurable desde Facturacion Mexico Settings
-		# Si no hay email del cliente ni configurado en settings, email queda None (sin envío correos)
+		# Email fallback configurable por compañía en Facturacion Mexico Company Settings
+		# (customer_email_fallback). Si no hay correo del cliente ni fallback, queda None (sin envío).
 
 		# MIGRACIÓN ARQUITECTURAL: Tax system OBLIGATORIO desde Factura Fiscal
 		tax_system_code = self._get_tax_system_for_timbrado(factura_fiscal, customer)
@@ -1872,7 +1872,7 @@ class TimbradoAPI:
 		if "unauthorized" in error_str or "api" in error_str or "token" in error_str:
 			return {
 				"user_message": "ERROR DE AUTENTICACIÓN: Problema con las credenciales del PAC. Verifique la configuración de API keys.",
-				"corrective_action": "Verificar Facturacion Mexico Settings → API Keys",
+				"corrective_action": "Verificar Facturacion Mexico Company Settings → API Keys",
 				"status_code": status_code,
 			}
 
@@ -2289,7 +2289,7 @@ class TimbradoAPI:
 				"<p style='margin: 0 0 15px 0;'>No se pudo determinar la empresa para buscar configuración fiscal.</p>"
 				"<p style='margin: 15px 0 8px 0; font-weight: 600;'>Solución:</p>"
 				"<ol style='margin: 0; padding-left: 20px;'>"
-				"<li>Configurar empresa en <strong>Facturacion Mexico Settings</strong></li>"
+				"<li>Configurar empresa en <strong>Facturacion Mexico Company Settings</strong></li>"
 				"</ol>"
 				"</div>",
 				title="Empresa No Configurada",

--- a/facturacion_mexico/tests/test_email_recipient_resolution.py
+++ b/facturacion_mexico/tests/test_email_recipient_resolution.py
@@ -29,7 +29,33 @@ def _make_customer(suffix: str) -> str:
 	return c.name
 
 
+def _ensure_default_address_template():
+	"""CI no trae Address Template por defecto; insertar una Address dispara su render
+	(`on_update` -> `get_address_display`), que falla sin un template default."""
+	if frappe.db.exists("Address Template", {"is_default": 1}):
+		return
+	country = frappe.get_all("Country", limit=1, pluck="name")
+	frappe.get_doc(
+		{
+			"doctype": "Address Template",
+			"country": country[0] if country else "Mexico",
+			"is_default": 1,
+			"template": "{{ address_line1 or '' }}",
+		}
+	).insert(ignore_permissions=True)
+
+
+def _first_company() -> str | None:
+	"""Company existente de forma robusta (evita `get_value` con filtro vacío `{}`)."""
+	default = frappe.defaults.get_global_default("company")
+	if default:
+		return default
+	names = frappe.get_all("Company", limit=1, pluck="name")
+	return names[0] if names else None
+
+
 def _make_address(customer: str, suffix: str, email: str | None, primary: bool = True) -> str:
+	_ensure_default_address_template()
 	addr = frappe.get_doc(
 		{
 			"doctype": "Address",
@@ -54,14 +80,16 @@ def _set_company_fallback(company: str, email: str | None):
 	name = frappe.db.get_value("Facturacion Mexico Company Settings", {"company": company}, "name")
 	if name:
 		frappe.db.set_value("Facturacion Mexico Company Settings", name, "customer_email_fallback", email)
-	else:
-		frappe.get_doc(
-			{
-				"doctype": "Facturacion Mexico Company Settings",
-				"company": company,
-				"customer_email_fallback": email,
-			}
-		).insert(ignore_permissions=True, ignore_mandatory=True)
+		return
+	doc = frappe.get_doc(
+		{
+			"doctype": "Facturacion Mexico Company Settings",
+			"company": company,
+			"customer_email_fallback": email,
+		}
+	)
+	doc.flags.ignore_validate = True
+	doc.insert(ignore_permissions=True, ignore_mandatory=True)
 
 
 class TestIsValidEmail(IntegrationTestCase):
@@ -87,9 +115,7 @@ class TestIsValidEmail(IntegrationTestCase):
 class TestResolveHelperRealRecords(IntegrationTestCase):
 	def setUp(self):
 		self.sfx = frappe.generate_hash()[:6]
-		self.company = frappe.defaults.get_global_default("company") or frappe.db.get_value(
-			"Company", {}, "name"
-		)
+		self.company = _first_company()
 
 	def test_address_email_used(self):
 		cust = _make_customer(self.sfx)
@@ -108,6 +134,8 @@ class TestResolveHelperRealRecords(IntegrationTestCase):
 		self.assertNotEqual(out, "customer-directo@example.com")
 
 	def test_fallback_when_address_has_no_email(self):
+		if not self.company:
+			self.skipTest("entorno de pruebas sin Company")
 		cust = _make_customer(self.sfx)
 		_make_address(cust, self.sfx, None)  # dirección sin correo
 		_set_company_fallback(self.company, "fallback@empresa.com")
@@ -160,9 +188,9 @@ class TestCompanyFallbackScoping(IntegrationTestCase):
 	"""Multi-company: el fallback se lee por la company del documento, nunca por la global."""
 
 	def setUp(self):
-		self.company = frappe.defaults.get_global_default("company") or frappe.db.get_value(
-			"Company", {}, "name"
-		)
+		self.company = _first_company()
+		if not self.company:
+			self.skipTest("entorno de pruebas sin Company")
 
 	def test_fallback_scoped_to_company(self):
 		_set_company_fallback(self.company, "scoped@empresa.com")

--- a/facturacion_mexico/tests/test_email_recipient_resolution.py
+++ b/facturacion_mexico/tests/test_email_recipient_resolution.py
@@ -93,8 +93,14 @@ def _set_company_fallback(company: str, email: str | None):
 
 
 class TestIsValidEmail(IntegrationTestCase):
-	def test_accepts_real_email(self):
-		self.assertTrue(_is_valid_email("cliente@example.com"))
+	def test_accepts_real_emails(self):
+		for good in [
+			"cliente@example.com",
+			"cliente@sub.example.com",
+			"cliente.test@example.com.mx",
+			"a@b.co",
+		]:
+			self.assertTrue(_is_valid_email(good), f"debió aceptar: {good!r}")
 
 	def test_rejects_placeholder_and_invalid(self):
 		for bad in [
@@ -108,6 +114,14 @@ class TestIsValidEmail(IntegrationTestCase):
 			"dos@@arrobas.com",
 			"sin dominio@",
 			"con espacio @x.com",
+			# Dominios malformados (endurecimiento CodeRabbit #2)
+			"cliente@.mx",
+			"cliente@example..com",
+			"cliente@mx",
+			"cliente@example.com.",
+			"cliente@.example.com",
+			"@example.com",
+			"cliente@",
 		]:
 			self.assertFalse(_is_valid_email(bad), f"debió rechazar: {bad!r}")
 
@@ -242,17 +256,52 @@ class TestFFMResolverDelegation(IntegrationTestCase):
 		)
 
 	def test_manual_and_auto_use_same_resolver(self):
-		"""El envío manual (_send_cfdi_email) y el automático (_send_fiscal_email) usan
-		el MISMO resolver _resolve_recipient_email."""
+		"""Conductual: el envío manual (`_send_cfdi_email`) y el automático (`_send_fiscal_email`)
+		llaman al MISMO resolver `_resolve_recipient_email` con el documento (company correcta),
+		sin comunicación externa real (FacturAPI mockeado)."""
+		import unittest.mock as m
+		from types import SimpleNamespace
+
 		from facturacion_mexico.facturacion_fiscal import timbrado_api as t_mod
 		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico import (
 			factura_fiscal_mexico as ffm_mod,
 		)
 
-		manual_src = inspect.getsource(ffm_mod._send_cfdi_email)
-		auto_src = inspect.getsource(t_mod.TimbradoAPI._send_fiscal_email)
-		self.assertIn("_resolve_recipient_email", manual_src)
-		self.assertIn("_resolve_recipient_email", auto_src)
+		captured = []
+
+		def fake_resolver(doc):
+			captured.append(doc)
+			return "dest@example.com"
+
+		ffm = frappe.get_doc({"doctype": "Factura Fiscal Mexico"})  # doc en memoria, sin insertar
+		ffm.customer = "CUST-Z"
+		ffm.company = "COMPANY-Z"
+		ffm.fm_uuid = "UUID-123"
+		ffm.facturapi_id = "fapi-123"
+		ffm.add_comment = lambda *a, **k: None  # doc sin guardar: no insertar Comment
+
+		# Ambos flujos resuelven vía _resolve_recipient_email (el automático lo importa localmente
+		# desde el mismo módulo, así que basta parchear ahí).
+		with m.patch.object(ffm_mod, "_resolve_recipient_email", side_effect=fake_resolver):
+			# MANUAL: FacturAPIClient se importa dentro de _send_cfdi_email desde api_client.
+			with m.patch("facturacion_mexico.facturacion_fiscal.api_client.FacturAPIClient") as MockClient:
+				result = ffm_mod._send_cfdi_email(ffm)
+				self.assertTrue(result.get("sent"))
+				self.assertEqual(result.get("to"), "dest@example.com")
+				MockClient.return_value.send_invoice_email.assert_called_once_with(
+					"fapi-123", "dest@example.com"
+				)
+
+			# AUTOMÁTICO post-timbrado: self.client es el boundary externo (mockeado).
+			fake_timbrado = SimpleNamespace(client=m.MagicMock())
+			t_mod.TimbradoAPI._send_fiscal_email(fake_timbrado, ffm, "fapi-123")
+			fake_timbrado.client.send_invoice_email.assert_called_once_with("fapi-123", "dest@example.com")
+
+		# Verificación clave: ambos flujos llamaron al MISMO resolver con el documento (company correcta).
+		self.assertEqual(len(captured), 2)
+		for doc in captured:
+			self.assertIs(doc, ffm)
+			self.assertEqual(getattr(doc, "company", None), "COMPANY-Z")
 
 
 class TestComplementoUsesCanonicalResolver(IntegrationTestCase):

--- a/facturacion_mexico/tests/test_email_recipient_resolution.py
+++ b/facturacion_mexico/tests/test_email_recipient_resolution.py
@@ -1,0 +1,285 @@
+"""Resolución canónica del correo destinatario fiscal (FFM y Complemento de Pago).
+
+Cubre el defecto reportado: el Complemento de Pago no usaba la misma fuente que la Factura
+Fiscal (dirección principal del Customer), y la FFM tenía dos defectos latentes:
+- guardaba un placeholder de aviso en `fm_email_facturacion` que mataba el fallback;
+- consultaba el fallback con la company default global, no la del documento (multi-company).
+
+Estas pruebas usan registros REALES (Customer / Address / Company Settings) — sin sobre-mockear,
+que fue justo lo que impidió detectar el bug antes. El único boundary que se simula es FacturAPI.
+"""
+
+import inspect
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.facturacion_fiscal.email_recipient import (
+	_is_valid_email,
+	get_company_fallback_email,
+	get_customer_primary_address_email,
+	resolve_fiscal_recipient_email,
+)
+
+
+def _make_customer(suffix: str) -> str:
+	c = frappe.get_doc(
+		{"doctype": "Customer", "customer_name": f"TEST-EMAIL-{suffix}", "customer_type": "Company"}
+	).insert(ignore_permissions=True)
+	return c.name
+
+
+def _make_address(customer: str, suffix: str, email: str | None, primary: bool = True) -> str:
+	addr = frappe.get_doc(
+		{
+			"doctype": "Address",
+			"address_title": f"TEST-ADDR-{suffix}",
+			"address_type": "Billing",
+			"address_line1": "Calle Falsa 123",
+			"city": "CDMX",
+			"country": "Mexico",
+			"pincode": "06000",
+			"email_id": email,
+			"is_primary_address": 1 if primary else 0,
+			"links": [{"link_doctype": "Customer", "link_name": customer}],
+		}
+	).insert(ignore_permissions=True)
+	if primary:
+		frappe.db.set_value("Customer", customer, "customer_primary_address", addr.name)
+	return addr.name
+
+
+def _set_company_fallback(company: str, email: str | None):
+	"""get_or_create Company Settings y fija customer_email_fallback (rollback por la suite)."""
+	name = frappe.db.get_value("Facturacion Mexico Company Settings", {"company": company}, "name")
+	if name:
+		frappe.db.set_value("Facturacion Mexico Company Settings", name, "customer_email_fallback", email)
+	else:
+		frappe.get_doc(
+			{
+				"doctype": "Facturacion Mexico Company Settings",
+				"company": company,
+				"customer_email_fallback": email,
+			}
+		).insert(ignore_permissions=True, ignore_mandatory=True)
+
+
+class TestIsValidEmail(IntegrationTestCase):
+	def test_accepts_real_email(self):
+		self.assertTrue(_is_valid_email("cliente@example.com"))
+
+	def test_rejects_placeholder_and_invalid(self):
+		for bad in [
+			"",
+			None,
+			"   ",
+			"⚠️ FALTA EMAIL EN DIRECCIÓN",
+			"⚠️ SELECCIONA UN CLIENTE",
+			"❌ ERROR AL OBTENER EMAIL",
+			"no-arroba",
+			"dos@@arrobas.com",
+			"sin dominio@",
+			"con espacio @x.com",
+		]:
+			self.assertFalse(_is_valid_email(bad), f"debió rechazar: {bad!r}")
+
+
+class TestResolveHelperRealRecords(IntegrationTestCase):
+	def setUp(self):
+		self.sfx = frappe.generate_hash()[:6]
+		self.company = frappe.defaults.get_global_default("company") or frappe.db.get_value(
+			"Company", {}, "name"
+		)
+
+	def test_address_email_used(self):
+		cust = _make_customer(self.sfx)
+		_make_address(cust, self.sfx, "addr@example.com")
+		self.assertEqual(
+			resolve_fiscal_recipient_email(customer=cust, company=self.company), "addr@example.com"
+		)
+
+	def test_ignores_customer_email_id_uses_address(self):
+		"""El helper NO usa Customer.email_id; prioriza la dirección principal."""
+		cust = _make_customer(self.sfx)
+		frappe.db.set_value("Customer", cust, "email_id", "customer-directo@example.com")
+		_make_address(cust, self.sfx, "addr@example.com")
+		out = resolve_fiscal_recipient_email(customer=cust, company=self.company)
+		self.assertEqual(out, "addr@example.com")
+		self.assertNotEqual(out, "customer-directo@example.com")
+
+	def test_fallback_when_address_has_no_email(self):
+		cust = _make_customer(self.sfx)
+		_make_address(cust, self.sfx, None)  # dirección sin correo
+		_set_company_fallback(self.company, "fallback@empresa.com")
+		self.assertEqual(
+			resolve_fiscal_recipient_email(customer=cust, company=self.company), "fallback@empresa.com"
+		)
+
+	def test_none_when_no_address_no_fallback(self):
+		cust = _make_customer(self.sfx)
+		_make_address(cust, self.sfx, None)
+		_set_company_fallback(self.company, None)
+		self.assertIsNone(resolve_fiscal_recipient_email(customer=cust, company=self.company))
+
+	def test_to_override_wins(self):
+		cust = _make_customer(self.sfx)
+		_make_address(cust, self.sfx, "addr@example.com")
+		self.assertEqual(
+			resolve_fiscal_recipient_email(customer=cust, company=self.company, to="override@example.com"),
+			"override@example.com",
+		)
+
+	def test_to_override_invalid_falls_through(self):
+		cust = _make_customer(self.sfx)
+		_make_address(cust, self.sfx, "addr@example.com")
+		self.assertEqual(
+			resolve_fiscal_recipient_email(customer=cust, company=self.company, to="⚠️ no-email"),
+			"addr@example.com",
+		)
+
+	def test_stored_email_real_used(self):
+		cust = _make_customer(self.sfx)
+		_make_address(cust, self.sfx, "addr@example.com")
+		self.assertEqual(
+			resolve_fiscal_recipient_email(
+				customer=cust, company=self.company, stored_email="ffm-real@example.com"
+			),
+			"ffm-real@example.com",
+		)
+
+	def test_stored_placeholder_ignored(self):
+		cust = _make_customer(self.sfx)
+		_make_address(cust, self.sfx, "addr@example.com")
+		out = resolve_fiscal_recipient_email(
+			customer=cust, company=self.company, stored_email="⚠️ FALTA EMAIL EN DIRECCIÓN"
+		)
+		self.assertEqual(out, "addr@example.com")
+
+
+class TestCompanyFallbackScoping(IntegrationTestCase):
+	"""Multi-company: el fallback se lee por la company del documento, nunca por la global."""
+
+	def setUp(self):
+		self.company = frappe.defaults.get_global_default("company") or frappe.db.get_value(
+			"Company", {}, "name"
+		)
+
+	def test_fallback_scoped_to_company(self):
+		_set_company_fallback(self.company, "scoped@empresa.com")
+		self.assertEqual(get_company_fallback_email(self.company), "scoped@empresa.com")
+
+	def test_other_company_does_not_get_this_fallback(self):
+		_set_company_fallback(self.company, "scoped@empresa.com")
+		# Una company distinta (inexistente) no debe heredar el fallback de otra.
+		self.assertIsNone(get_company_fallback_email("Compania Inexistente ZZZ"))
+
+	def test_no_company_returns_none_not_global_default(self):
+		# Sin company, NO se usa frappe.defaults global: simplemente no hay fallback.
+		self.assertIsNone(get_company_fallback_email(None))
+
+
+class TestFFMResolverDelegation(IntegrationTestCase):
+	def test_ffm_resolver_passes_document_company(self):
+		"""_resolve_recipient_email delega al helper con la company del documento (multi-company)."""
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico import (
+			factura_fiscal_mexico as ffm_mod,
+		)
+
+		captured = {}
+
+		def fake_resolver(**kwargs):
+			captured.update(kwargs)
+			return "x@y.com"
+
+		ffm = frappe.get_doc({"doctype": "Factura Fiscal Mexico"})  # doc en memoria, sin insertar
+		ffm.customer = "CUST-A"
+		ffm.company = "COMPANY-A"
+		ffm.fm_email_facturacion = "stored@y.com"
+
+		with self.patch_resolver(ffm_mod, fake_resolver):
+			ffm_mod._resolve_recipient_email(ffm)
+
+		self.assertEqual(captured.get("company"), "COMPANY-A")
+		self.assertEqual(captured.get("customer"), "CUST-A")
+		self.assertEqual(captured.get("stored_email"), "stored@y.com")
+
+	def patch_resolver(self, _mod, fn):
+		import unittest.mock as m
+
+		# _resolve_recipient_email importa el helper localmente desde el módulo fuente,
+		# así que se parchea ahí (no en el módulo de la FFM).
+		return m.patch(
+			"facturacion_mexico.facturacion_fiscal.email_recipient.resolve_fiscal_recipient_email",
+			side_effect=fn,
+		)
+
+	def test_manual_and_auto_use_same_resolver(self):
+		"""El envío manual (_send_cfdi_email) y el automático (_send_fiscal_email) usan
+		el MISMO resolver _resolve_recipient_email."""
+		from facturacion_mexico.facturacion_fiscal import timbrado_api as t_mod
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico import (
+			factura_fiscal_mexico as ffm_mod,
+		)
+
+		manual_src = inspect.getsource(ffm_mod._send_cfdi_email)
+		auto_src = inspect.getsource(t_mod.TimbradoAPI._send_fiscal_email)
+		self.assertIn("_resolve_recipient_email", manual_src)
+		self.assertIn("_resolve_recipient_email", auto_src)
+
+
+class TestComplementoUsesCanonicalResolver(IntegrationTestCase):
+	def test_action_uses_helper_with_doc_customer_and_company(self):
+		"""action_send_email_complemento usa comp.customer/comp.company vía el helper,
+		ignorando Payment Entry.contact_email y Customer.email_id."""
+		src = inspect.getsource(
+			frappe.get_attr("facturacion_mexico.complementos_pago.api.action_send_email_complemento")
+		)
+		# Usa el resolver canónico con el documento como fuente.
+		self.assertIn("resolve_fiscal_recipient_email", src)
+		self.assertIn("comp.customer", src)
+		self.assertIn("comp.company", src)
+		# Ya NO consulta las fuentes prohibidas.
+		self.assertNotIn("contact_email", src)
+		self.assertNotIn('"email_id"', src)
+
+
+class TestPopulateBillingDataNoPlaceholder(IntegrationTestCase):
+	def test_no_placeholder_stored_in_email_field(self):
+		"""Con dirección principal sin correo, fm_email_facturacion queda VACÍO (no un aviso)."""
+		sfx = frappe.generate_hash()[:6]
+		cust = _make_customer(sfx)
+		_make_address(cust, sfx, None)  # sin email
+		ffm = frappe.get_doc({"doctype": "Factura Fiscal Mexico"})
+		ffm.customer = cust
+		ffm.populate_billing_data()
+		self.assertEqual(ffm.fm_email_facturacion, "")
+		self.assertNotIn("⚠", ffm.fm_email_facturacion or "")
+
+
+class TestNoOperationalGlobalSettingsReference(IntegrationTestCase):
+	def test_no_code_reads_legacy_global_settings(self):
+		"""Ningún .py operativo debe leer el DocType global removido 'Facturacion Mexico Settings'."""
+		import os
+
+		import facturacion_mexico
+
+		root = os.path.dirname(facturacion_mexico.__file__)
+		offenders = []
+		read_calls = ("get_single(", "get_cached_single(", "get_doc(", "get_value(")
+		for dirpath, _dirs, files in os.walk(root):
+			if "/tests" in dirpath or "__pycache__" in dirpath:
+				continue
+			for fn in files:
+				if not fn.endswith(".py"):
+					continue
+				path = os.path.join(dirpath, fn)
+				with open(path, encoding="utf-8") as fh:
+					content = fh.read()
+				if "Facturacion Mexico Settings" not in content:
+					continue
+				for line in content.splitlines():
+					if "Company Settings" in line:
+						continue
+					if "Facturacion Mexico Settings" in line and any(rc in line for rc in read_calls):
+						offenders.append(f"{path}: {line.strip()}")
+		self.assertEqual(offenders, [], f"Lecturas operativas del setting global: {offenders}")

--- a/facturacion_mexico/tests/test_pr68_email_system.py
+++ b/facturacion_mexico/tests/test_pr68_email_system.py
@@ -77,18 +77,20 @@ class TestPR68EmailSystem(FrappeTestCase):
 			_resolve_recipient_email,
 		)
 
-		# Mock FFM con email configurado
+		# Documento con correo real -> el helper lo recibe como stored_email
+		self.mock_ffm.customer = "CUST"
+		self.mock_ffm.company = "COMP"
 		self.mock_ffm.fm_email_facturacion = "ffm@test.com"
 
 		with patch(
-			"facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico._get_settings_email_defaults"
-		) as mock_settings:
-			mock_settings.return_value = (True, "fallback@test.com")
+			"facturacion_mexico.facturacion_fiscal.email_recipient.resolve_fiscal_recipient_email"
+		) as mock_helper:
+			mock_helper.return_value = "ffm@test.com"
 
 			result = _resolve_recipient_email(self.mock_ffm)
 
-			# Debe usar email de FFM, no fallback
 			self.assertEqual(result, "ffm@test.com")
+			mock_helper.assert_called_once_with(customer="CUST", company="COMP", stored_email="ffm@test.com")
 
 	def test_resolve_recipient_email_settings_fallback(self):
 		"""Test fallback a settings cuando FFM no tiene email"""
@@ -96,17 +98,18 @@ class TestPR68EmailSystem(FrappeTestCase):
 			_resolve_recipient_email,
 		)
 
-		# Mock FFM sin email
+		# Sin correo en el documento -> el destinatario proviene del helper (fallback por company)
+		self.mock_ffm.customer = "CUST"
+		self.mock_ffm.company = "COMP"
 		self.mock_ffm.fm_email_facturacion = ""
 
 		with patch(
-			"facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico._get_settings_email_defaults"
-		) as mock_settings:
-			mock_settings.return_value = (True, "fallback@test.com")
+			"facturacion_mexico.facturacion_fiscal.email_recipient.resolve_fiscal_recipient_email"
+		) as mock_helper:
+			mock_helper.return_value = "fallback@test.com"
 
 			result = _resolve_recipient_email(self.mock_ffm)
 
-			# Debe usar fallback de settings
 			self.assertEqual(result, "fallback@test.com")
 
 	def test_resolve_recipient_email_no_fallback(self):
@@ -115,17 +118,18 @@ class TestPR68EmailSystem(FrappeTestCase):
 			_resolve_recipient_email,
 		)
 
-		# Mock FFM sin email
+		# El helper no resuelve destinatario -> None
+		self.mock_ffm.customer = "CUST"
+		self.mock_ffm.company = "COMP"
 		self.mock_ffm.fm_email_facturacion = None
 
 		with patch(
-			"facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico._get_settings_email_defaults"
-		) as mock_settings:
-			mock_settings.return_value = (False, None)
+			"facturacion_mexico.facturacion_fiscal.email_recipient.resolve_fiscal_recipient_email"
+		) as mock_helper:
+			mock_helper.return_value = None
 
 			result = _resolve_recipient_email(self.mock_ffm)
 
-			# Debe retornar None
 			self.assertIsNone(result)
 
 	def test_resolve_auto_email_flag_customer_enviar(self):


### PR DESCRIPTION
## Objetivo

Corregir el defecto reportado por clientes: el envío por correo del **Complemento de Pago**
respondía "cliente sin correo" aunque el correo existía y el envío de la **factura fiscal**
del mismo cliente funcionaba. Causa: ambos flujos resolvían el destinatario de forma distinta.

## Cambios principales

- **Helper único** `facturacion_fiscal/email_recipient.py::resolve_fiscal_recipient_email`,
  con prioridad canónica:
  `to` válido → `Address.email_id` de la dirección principal del Customer (o `fm_email_facturacion`
  ya almacenado si es real) → `customer_email_fallback` de **Facturacion Mexico Company Settings
  por la company del documento** → `None`.
- **Complemento** (`action_send_email_complemento`) usa el helper con `comp.customer`/`comp.company`;
  deja de usar `Payment Entry.contact_email` y `Customer.email_id`.
- **FFM**: `_resolve_recipient_email` delega al helper (manual y automático post-timbrado);
  `populate_billing_data` deja `fm_email_facturacion` vacío cuando no hay correo (el placeholder
  de aviso ya no se almacena como destinatario, que antes anulaba el fallback).
- **Multi-company**: el fallback usa la company del documento, no la company default global.
- No se usa `Contact` como fuente.
- Limpieza: referencias de texto/documentación al DocType global legado `Facturacion Mexico
  Settings` → `Facturacion Mexico Company Settings`.

## Documentación actualizada

- `docs/usuario/emitir-cfdi.md`, `docs/usuario/troubleshooting.md`,
  `docs/referencia/doctypes.md`, `docs/tecnico/email-system.md`.

## Validaciones realizadas

- `tests/test_email_recipient_resolution.py` (nuevo): **18/18 OK** — dirección principal,
  fallback por compañía, multi-company aislado (incl. `company=None` no usa global), placeholder
  rechazado, `to` override (válido/ inválido), delegación FFM manual/automática y del Complemento,
  e ignorancia de `Payment Entry.contact_email`/`Customer.email_id`.
- `ruff check` + `ruff format --check`: OK. `mkdocs build --strict`: exit 0.
- `test_pr68_email_system.py` actualizado al nuevo contrato del resolver.

## Fuera de alcance

- No se modifica timbrado, modelo fiscal, datos ni multi-company más allá de la resolución del
  destinatario. Sin patches, sin cambios de BD, sin migraciones.
- Limpieza del registro huérfano del DocType global legado (se atiende por migración estándar).

## Riesgos / pendientes

- El sitio `test-facturacion.localhost` tiene un fallo **preexistente** de fixtures
  (`_Test Item is not a stock Item`) que bloquea `test_pr68` y las suites de Complemento/FFM
  (no es regresión de este cambio); impide validación end-to-end de esas suites.
- `customer_email_fallback` debe configurarse por compañía en producción para que el fallback opere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added canonical fiscal-recipient email resolution for CFDI and payment emails, using a clear priority order and a company-level fallback.

* **Bug Fixes**
  * Improved reliability by ignoring invalid/placeholder email inputs and using valid stored/customer/address/company emails only.
  * When billing data is missing, stored billing email now remains empty instead of placeholder text.

* **Documentation**
  * Updated guides to reflect that global “Facturacion Mexico Settings” was removed and replaced by company-scoped “Facturacion Mexico Company Settings” (including email and API key references).

* **Tests**
  * Added/updated integration and unit tests covering email validation, precedence, fallback scoping, and both sending flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->