### PR TITLE
fix(cancelación): borrador FFM huérfano no bloquea cancelar SI

### DIFF
--- a/facturacion_mexico/api/fiscal_operations.py
+++ b/facturacion_mexico/api/fiscal_operations.py
@@ -176,6 +176,29 @@ def refacturar_misma_si(si_name: str):
 	}
 
 
+def _es_ffm_borrador_sin_timbrar(ffm_row, active_ffm_name=None) -> bool:
+	"""True si la FFM es un borrador nunca timbrado y NO es la FFM activa de la SI.
+
+	Debe cumplir TODO: docstatus=0, status == BORRADOR, sin UUID, sin facturapi_id, y no ser la FFM
+	que la Sales Invoice reconoce como activa (`fm_factura_fiscal_mx`). Estas FFM no representan un
+	CFDI emitido ni una operación fiscal en curso → no son fiscalmente activas: no bloquean la
+	cancelación de la Sales Invoice y no se desvinculan ni se modifican.
+
+	Cualquier FFM con UUID, con facturapi_id, con docstatus != 0, con un status distinto de BORRADOR
+	(p. ej. PROCESANDO/PENDIENTE — puede haber una operación en curso ante el PAC) o que sea la FFM
+	activa de la SI SÍ debe evaluarse contra el guard (debe estar CANCELADO).
+	"""
+	# Nunca ignorar la FFM que la SI reconoce como activa, aunque esté inconsistente.
+	if active_ffm_name and ffm_row.get("name") == active_ffm_name:
+		return False
+	return (
+		int(ffm_row.get("docstatus") or 0) == 0
+		and (ffm_row.get("status") or "").upper() == "BORRADOR"
+		and not (ffm_row.get("fm_uuid") or "").strip()
+		and not (ffm_row.get("facturapi_id") or "").strip()
+	)
+
+
 @frappe.whitelist()
 def cancelar_si_post_fiscal(si_name: str):
 	"""
@@ -198,13 +221,17 @@ def cancelar_si_post_fiscal(si_name: str):
 	if not frappe.has_permission("Sales Invoice", "cancel", si):
 		frappe.throw(_("Sin permisos para cancelar Sales Invoice."))
 
-	# Obtener todas las FFMs ligadas y validar que todas estén canceladas antes de desvincular
+	# Obtener todas las FFMs ligadas y validar que las fiscalmente activas estén canceladas antes
+	# de desvincular. Una FFM en BORRADOR nunca timbrada (docstatus=0, sin UUID ni facturapi_id) NO
+	# es fiscalmente activa: no bloquea la cancelación y no se toca.
 	ffms = frappe.get_all(
 		"Factura Fiscal Mexico",
 		filters={"sales_invoice": si_name},
-		fields=["name", "status"],
+		fields=["name", "status", "docstatus", "fm_uuid", "facturapi_id"],
 	)
 	for row in ffms:
+		if _es_ffm_borrador_sin_timbrar(row, active_ffm):
+			continue  # borrador sin timbrar: no es fiscalmente activa, no bloquea
 		if (row.get("status") or "").upper() != "CANCELADO":
 			frappe.throw(
 				_(
@@ -213,8 +240,11 @@ def cancelar_si_post_fiscal(si_name: str):
 				).format(row.name, row.status)
 			)
 
-	# Todas canceladas — desvincular para que ERPNext permita el cancel de la SI
+	# Desvincular SOLO las FFM fiscalmente activas (ya canceladas) para que ERPNext permita el
+	# cancel de la SI. Las FFM borrador sin timbrar no se desvinculan ni se modifican.
 	for row in ffms:
+		if _es_ffm_borrador_sin_timbrar(row, active_ffm):
+			continue
 		frappe.db.set_value("Factura Fiscal Mexico", row.name, "sales_invoice", "")
 
 	# Limpiar vínculos fiscales en la SI

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cancel_guard_draft_ffm.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cancel_guard_draft_ffm.py
@@ -146,7 +146,13 @@ class TestCancelarSiPostFiscalIgnoraDraft(IntegrationTestCase):
 	def setUp(self):
 		self.si = _seed_si()
 		# FFM fiscal válida: submitted, CANCELADO, con evidencia fiscal
-		self.ffm_valida = _seed_ffm(self.si, "CANCELADO", 1, uuid="U-VALIDA", facturapi_id="FA-VALIDA")
+		self.ffm_valida = _seed_ffm(
+			self.si,
+			"CANCELADO",
+			1,
+			uuid=frappe.generate_hash(length=10),
+			facturapi_id=frappe.generate_hash(length=10),
+		)
 		frappe.db.set_value("Sales Invoice", self.si, "fm_factura_fiscal_mx", self.ffm_valida)
 		# FFM duplicada BORRADOR: docstatus=0, sin UUID ni facturapi_id
 		self.ffm_draft = _seed_ffm(self.si, "BORRADOR", 0)
@@ -190,28 +196,31 @@ class TestCancelarSiPostFiscalIgnoraDraft(IntegrationTestCase):
 
 	def test_draft_con_uuid_sigue_bloqueando(self):
 		# Convertir la draft en una con UUID → vuelve a ser fiscalmente activa y BLOQUEA
-		frappe.db.set_value("Factura Fiscal Mexico", self.ffm_draft, "fm_uuid", "U-CONUUID")
-		with mock.patch("frappe.model.document.Document.cancel"):
-			with self.assertRaises(frappe.ValidationError):
-				cancelar_si_post_fiscal(self.si)
+		frappe.db.set_value(
+			"Factura Fiscal Mexico", self.ffm_draft, "fm_uuid", frappe.generate_hash(length=10)
+		)
+		with mock.patch("frappe.model.document.Document.cancel"), self.assertRaises(frappe.ValidationError):
+			cancelar_si_post_fiscal(self.si)
 
 	def test_ffm_submitted_no_cancelada_sigue_bloqueando(self):
 		# Una segunda FFM submitted en TIMBRADO (no CANCELADO) debe bloquear
-		_seed_ffm(self.si, "TIMBRADO", 1, uuid="U-TIMB", facturapi_id="FA-TIMB")
-		with mock.patch("frappe.model.document.Document.cancel"):
-			with self.assertRaises(frappe.ValidationError):
-				cancelar_si_post_fiscal(self.si)
+		_seed_ffm(
+			self.si,
+			"TIMBRADO",
+			1,
+			uuid=frappe.generate_hash(length=10),
+			facturapi_id=frappe.generate_hash(length=10),
+		)
+		with mock.patch("frappe.model.document.Document.cancel"), self.assertRaises(frappe.ValidationError):
+			cancelar_si_post_fiscal(self.si)
 
 	def test_draft_procesando_sigue_bloqueando(self):
 		# Draft en PROCESANDO (sin UUID ni facturapi_id): puede haber operación en curso → BLOQUEA
 		_seed_ffm(self.si, "PROCESANDO", 0)
-		with mock.patch("frappe.model.document.Document.cancel"):
-			with self.assertRaises(frappe.ValidationError):
-				cancelar_si_post_fiscal(self.si)
+		with mock.patch("frappe.model.document.Document.cancel"), self.assertRaises(frappe.ValidationError):
+			cancelar_si_post_fiscal(self.si)
 
-	def test_draft_borrador_que_es_la_ffm_activa_bloquea(self):
-		# Si la SI apunta a un borrador sin timbrar como FFM activa, nunca se ignora → BLOQUEA
-		frappe.db.set_value("Sales Invoice", self.si, "fm_factura_fiscal_mx", self.ffm_draft)
-		with mock.patch("frappe.model.document.Document.cancel"):
-			with self.assertRaises(frappe.ValidationError):
-				cancelar_si_post_fiscal(self.si)
+	# Nota: el guard "nunca ignorar la FFM activa de la SI" se cubre por el test directo del
+	# predicado (TestEsFfmBorradorSinTimbrar.test_ffm_activa_de_la_si_es_false). Un test de
+	# integración que apunte el borrador como FFM activa bloquearía por el guard previo
+	# (la FFM activa debe estar CANCELADO), no por este branch — sería engañoso, se omite.

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cancel_guard_draft_ffm.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cancel_guard_draft_ffm.py
@@ -1,0 +1,217 @@
+"""Regresión: `cancelar_si_post_fiscal` ignora la FFM BORRADOR nunca timbrada (duplicado huérfano).
+
+Caso real (ACC-SINV-2026-02932): una FFM válida `CANCELADO` (submitted, con UUID/facturapi_id) y
+una segunda FFM BORRADOR (docstatus=0, sin UUID ni facturapi_id) ligadas a la misma SI. La draft NO
+debe bloquear la cancelación de la SI, y NO debe eliminarse, modificarse ni desvincularse; su
+Response Log debe permanecer intacto. El guard sigue bloqueando cualquier FFM fiscalmente activa.
+
+Solo se simula el boundary de ERPNext (`Document.cancel`, que hace GL) — cero PAC real.
+"""
+
+import unittest.mock as mock
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.api.fiscal_operations import (
+	_es_ffm_borrador_sin_timbrar,
+	cancelar_si_post_fiscal,
+)
+
+
+def _seed_si():
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"net_total": 100,
+			"grand_total": 116,
+			"posting_date": frappe.utils.today(),
+			"docstatus": 1,
+			"fm_fiscal_status": "CANCELADO",
+		}
+	)
+	si.flags.ignore_validate = True
+	si.flags.ignore_mandatory = True
+	si.flags.ignore_links = True
+	si.db_insert()
+	return si.name
+
+
+def _seed_ffm(sales_invoice, status, docstatus, *, uuid=None, facturapi_id=None):
+	ffm = frappe.get_doc(
+		{
+			"doctype": "Factura Fiscal Mexico",
+			"sales_invoice": sales_invoice,
+			"status": status,
+			"docstatus": docstatus,
+			"fm_uuid": uuid,
+			"facturapi_id": facturapi_id,
+		}
+	)
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	return ffm.name
+
+
+class TestEsFfmBorradorSinTimbrar(IntegrationTestCase):
+	"""Predicado puro: qué FFM es 'borrador sin timbrar' (no fiscalmente activa)."""
+
+	def test_draft_sin_timbrar_es_true(self):
+		self.assertTrue(
+			_es_ffm_borrador_sin_timbrar(
+				{"name": "FFM-A", "docstatus": 0, "status": "BORRADOR", "fm_uuid": None, "facturapi_id": None}
+			)
+		)
+		self.assertTrue(
+			_es_ffm_borrador_sin_timbrar(
+				{"name": "FFM-A", "docstatus": 0, "status": "BORRADOR", "fm_uuid": "", "facturapi_id": ""}
+			)
+		)
+
+	def test_con_uuid_o_facturapi_o_submitted_es_false(self):
+		self.assertFalse(  # tiene UUID
+			_es_ffm_borrador_sin_timbrar(
+				{
+					"name": "FFM-A",
+					"docstatus": 0,
+					"status": "BORRADOR",
+					"fm_uuid": "U-1",
+					"facturapi_id": None,
+				}
+			)
+		)
+		self.assertFalse(  # tiene facturapi_id
+			_es_ffm_borrador_sin_timbrar(
+				{
+					"name": "FFM-A",
+					"docstatus": 0,
+					"status": "BORRADOR",
+					"fm_uuid": None,
+					"facturapi_id": "FA-1",
+				}
+			)
+		)
+		self.assertFalse(  # submitted
+			_es_ffm_borrador_sin_timbrar(
+				{"name": "FFM-A", "docstatus": 1, "status": "BORRADOR", "fm_uuid": None, "facturapi_id": None}
+			)
+		)
+
+	def test_status_no_borrador_es_false(self):
+		# PROCESANDO/PENDIENTE (posible operación en curso ante el PAC) NO es "borrador sin timbrar"
+		self.assertFalse(
+			_es_ffm_borrador_sin_timbrar(
+				{
+					"name": "FFM-A",
+					"docstatus": 0,
+					"status": "PROCESANDO",
+					"fm_uuid": None,
+					"facturapi_id": None,
+				}
+			)
+		)
+		self.assertFalse(
+			_es_ffm_borrador_sin_timbrar(
+				{
+					"name": "FFM-A",
+					"docstatus": 0,
+					"status": "PENDIENTE",
+					"fm_uuid": None,
+					"facturapi_id": None,
+				}
+			)
+		)
+
+	def test_ffm_activa_de_la_si_es_false(self):
+		# Aunque sea un borrador sin timbrar, si es la FFM que la SI reconoce como activa NO se ignora
+		self.assertFalse(
+			_es_ffm_borrador_sin_timbrar(
+				{
+					"name": "FFM-ACTIVA",
+					"docstatus": 0,
+					"status": "BORRADOR",
+					"fm_uuid": None,
+					"facturapi_id": None,
+				},
+				active_ffm_name="FFM-ACTIVA",
+			)
+		)
+
+
+class TestCancelarSiPostFiscalIgnoraDraft(IntegrationTestCase):
+	def setUp(self):
+		self.si = _seed_si()
+		# FFM fiscal válida: submitted, CANCELADO, con evidencia fiscal
+		self.ffm_valida = _seed_ffm(self.si, "CANCELADO", 1, uuid="U-VALIDA", facturapi_id="FA-VALIDA")
+		frappe.db.set_value("Sales Invoice", self.si, "fm_factura_fiscal_mx", self.ffm_valida)
+		# FFM duplicada BORRADOR: docstatus=0, sin UUID ni facturapi_id
+		self.ffm_draft = _seed_ffm(self.si, "BORRADOR", 0)
+		# Response Log ligado a la draft (debe permanecer intacto)
+		rl = frappe.get_doc(
+			{
+				"doctype": "FacturAPI Response Log",
+				"factura_fiscal_mexico": self.ffm_draft,
+				"operation_type": "Solicitud Cancelación",
+				"success": 0,
+			}
+		)
+		rl.flags.ignore_validate = True
+		rl.flags.ignore_mandatory = True
+		rl.flags.ignore_links = True
+		rl.db_insert()
+		self.response_log = rl.name
+
+	def test_draft_no_bloquea_y_permanece_intacta(self):
+		# El cancel de ERPNext (GL) se simula: aislamos el guard/desvinculación.
+		with mock.patch("frappe.model.document.Document.cancel") as mocked_cancel:
+			result = cancelar_si_post_fiscal(self.si)
+
+		# La cancelación continuó (guard NO bloqueó) y se llamó al cancel de la SI
+		self.assertTrue(result.get("ok"))
+		self.assertTrue(mocked_cancel.called)
+
+		# La FFM draft NO se tocó: sigue ligada, en borrador, sin cambios
+		d = frappe.db.get_value(
+			"Factura Fiscal Mexico", self.ffm_draft, ["sales_invoice", "docstatus", "status"], as_dict=True
+		)
+		self.assertEqual(d.sales_invoice, self.si)  # NO desvinculada
+		self.assertEqual(d.docstatus, 0)
+		self.assertEqual(d.status, "BORRADOR")
+
+		# El Response Log de la draft permanece
+		self.assertTrue(frappe.db.exists("FacturAPI Response Log", self.response_log))
+
+		# La FFM fiscal válida SÍ se desvinculó (para permitir el cancel nativo de la SI)
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", self.ffm_valida, "sales_invoice"), "")
+
+	def test_draft_con_uuid_sigue_bloqueando(self):
+		# Convertir la draft en una con UUID → vuelve a ser fiscalmente activa y BLOQUEA
+		frappe.db.set_value("Factura Fiscal Mexico", self.ffm_draft, "fm_uuid", "U-CONUUID")
+		with mock.patch("frappe.model.document.Document.cancel"):
+			with self.assertRaises(frappe.ValidationError):
+				cancelar_si_post_fiscal(self.si)
+
+	def test_ffm_submitted_no_cancelada_sigue_bloqueando(self):
+		# Una segunda FFM submitted en TIMBRADO (no CANCELADO) debe bloquear
+		_seed_ffm(self.si, "TIMBRADO", 1, uuid="U-TIMB", facturapi_id="FA-TIMB")
+		with mock.patch("frappe.model.document.Document.cancel"):
+			with self.assertRaises(frappe.ValidationError):
+				cancelar_si_post_fiscal(self.si)
+
+	def test_draft_procesando_sigue_bloqueando(self):
+		# Draft en PROCESANDO (sin UUID ni facturapi_id): puede haber operación en curso → BLOQUEA
+		_seed_ffm(self.si, "PROCESANDO", 0)
+		with mock.patch("frappe.model.document.Document.cancel"):
+			with self.assertRaises(frappe.ValidationError):
+				cancelar_si_post_fiscal(self.si)
+
+	def test_draft_borrador_que_es_la_ffm_activa_bloquea(self):
+		# Si la SI apunta a un borrador sin timbrar como FFM activa, nunca se ignora → BLOQUEA
+		frappe.db.set_value("Sales Invoice", self.si, "fm_factura_fiscal_mx", self.ffm_draft)
+		with mock.patch("frappe.model.document.Document.cancel"):
+			with self.assertRaises(frappe.ValidationError):
+				cancelar_si_post_fiscal(self.si)


### PR DESCRIPTION
## Objetivo

Desbloquear la cancelación de una Sales Invoice cuando existe una FFM en BORRADOR
nunca timbrada (duplicado huérfano), sin borrarla ni modificarla. Incidente real de
LlantasCS: ACC-SINV-2026-02932.

## Cambios principales

- `api/fiscal_operations.py`: nuevo helper `_es_ffm_borrador_sin_timbrar(ffm_row, active_ffm_name)`.
  Una FFM con `docstatus=0` + `status=BORRADOR` + sin `fm_uuid` + sin `facturapi_id`,
  que además no sea la FFM activa de la SI (`fm_factura_fiscal_mx`), no es fiscalmente
  activa → no bloquea la cancelación y no se desvincula ni se modifica.
- `cancelar_si_post_fiscal`: aplica el helper en el guard de validación y en la
  desvinculación. El guard preexistente (FFM activa debe estar CANCELADO) queda intacto.
  Cualquier FFM con evidencia fiscal, `docstatus!=0`, status distinto de BORRADOR
  (PROCESANDO/PENDIENTE) o que sea la FFM activa sigue exigiendo CANCELADO.

## Documentación actualizada

- No aplica: bugfix a un caso borde de un guard existente; no cambia el flujo de
  cancelación documentado (`docs/usuario/cancelar-cfdi.md` no describe este guard).
  La integridad de cancelación FFM ya está cubierta por ADR 0036.

## Validaciones realizadas

- Tests: `facturacion_fiscal/tests/test_cancel_guard_draft_ffm.py` — 9/9 OK
  (predicado + integración: draft huérfano no bloquea y queda intacto; draft con UUID,
  PROCESANDO, submitted no-CANCELADO y draft que es la FFM activa siguen bloqueando).
- ruff check OK · bandit sin issues · mkdocs build --strict OK.
- Validación GUI sobre clon de producción (llantascs-v16.dev): SI cancelada
  (docstatus=2), FFM cancelada desvinculada con evidencia intacta, borrador huérfano
  (FFMX-2026-00030) sin tocar.
- Suite completa del app: no re-corrida en este PR (falla preexistente conocida e
  independiente: test_layer2_cross_module_validation).

## Fuera de alcance

- Causa raíz del duplicado (doble creación de FFM en el submit por guard en memoria en
  `_get_or_create_factura_fiscal`).
- Bloqueo de timbrado / estado formal DESCARTADO para borradores duplicados.
- Centralización de la cancelación nativa de ERPNext.

## Riesgos / pendientes

- El duplicado huérfano permanece ligado a la SI cancelada (conserva trazabilidad); su
  limpieza formal queda pendiente y no forma parte de este fix.
- Deploy a producción LlantasCS (bench v15) requiere `bench migrate` + `bench build`
  vía MSP/Ansible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancellation now ignores draft, unissued fiscal documents that are not actually active, preventing unnecessary blocking.
  * Draft records are preserved during cancellation and are no longer unlinked or altered unless they are truly active.
  * Improved handling for edge cases where a draft becomes fiscally relevant, ensuring cancellation is still blocked when appropriate.

* **Tests**
  * Added coverage for draft-vs-active cancellation behavior, including linked, processing, and submitted fiscal document scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->