### PR TITLE
fix(cfdi): widget serie+folio y label distinto para columna de reporte CxC

### DIFF
--- a/facturacion_mexico/api/ffm_summary.py
+++ b/facturacion_mexico/api/ffm_summary.py
@@ -38,10 +38,16 @@ def get_ffm_summary(ffm_name: str) -> dict:
 	try:
 		doc = frappe.get_doc(FFM_DOCTYPE, ffm_name).as_dict()
 
-		# Construir folio combinado si existe serie y folio por separado
-		folio_display = _pick(doc, ALIASES["folio"])
-		if not folio_display and doc.get("serie") and doc.get("folio"):
-			folio_display = f"{doc.get('serie')}-{doc.get('folio')}"
+		# "Serie y Folio": preferir el combinado ya persistido; si no, unir serie+folio;
+		# como último recurso, mostrar lo que haya suelto (folio, serie o folio_fiscal).
+		folio_display = (doc.get("fm_serie_folio") or "").strip()
+		if not folio_display:
+			serie = (doc.get("serie") or "").strip()
+			folio = (doc.get("folio") or "").strip()
+			if serie and folio:
+				folio_display = f"{serie}-{folio}"
+			else:
+				folio_display = folio or serie or (doc.get("folio_fiscal") or "").strip() or None
 
 		metodo_pago = doc.get("fm_payment_method_sat") or ""
 		metodo_pago_label = {

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_summary_folio.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_summary_folio.py
@@ -1,0 +1,38 @@
+"""Regresión issue #211: el widget "Serie y Folio" debe mostrar serie+folio, no solo el folio.
+
+`get_ffm_summary` construye `folio`:
+- prefiere `fm_serie_folio` (combinado ya persistido);
+- si no, une `serie`-`folio`;
+- como último recurso, muestra lo suelto.
+
+Seeding directo por DB (sin red).
+"""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from facturacion_mexico.api.ffm_summary import get_ffm_summary
+
+
+def _seed_ffm(**fields):
+	ffm = frappe.get_doc({"doctype": "Factura Fiscal Mexico", "status": "TIMBRADO", "docstatus": 0, **fields})
+	ffm.flags.ignore_validate = True
+	ffm.flags.ignore_mandatory = True
+	ffm.flags.ignore_links = True
+	ffm.db_insert()
+	return ffm.name
+
+
+class TestFfmSummaryFolio(IntegrationTestCase):
+	def test_combina_serie_y_folio(self):
+		# serie + folio separados, sin fm_serie_folio → "F-11679" (no solo el folio)
+		name = _seed_ffm(serie="F", folio="11679")
+		self.assertEqual(get_ffm_summary(name)["folio"], "F-11679")
+
+	def test_prefiere_fm_serie_folio_si_existe(self):
+		name = _seed_ffm(serie="F", folio="11679", fm_serie_folio="F-99999")
+		self.assertEqual(get_ffm_summary(name)["folio"], "F-99999")
+
+	def test_solo_folio_sin_serie(self):
+		name = _seed_ffm(folio="500")
+		self.assertEqual(get_ffm_summary(name)["folio"], "500")

--- a/facturacion_mexico/fixtures/custom_field.json
+++ b/facturacion_mexico/fixtures/custom_field.json
@@ -2756,7 +2756,7 @@
   "insert_after": "fm_fiscal_status",
   "is_system_generated": 0,
   "is_virtual": 0,
-  "label": "Folio Fiscal",
+  "label": "Folio Fiscal FFM",
   "length": 0,
   "link_filters": null,
   "mandatory_depends_on": null,


### PR DESCRIPTION
## Objetivo

Corregir dos defectos de visualización del folio fiscal en Sales Invoice: el widget
"Serie y Folio" y la colisión de label que impedía usar `fm_folio_fiscal` como columna
en el reporte de Cuentas por Cobrar. Closes #211.

## Cambios principales

- `api/ffm_summary.py`: "Serie y Folio" ahora **combina serie+folio** (ej. `F-11679`) en
  vez de mostrar solo el folio. Prefiere `fm_serie_folio`, luego `serie-folio`, luego el suelto.
- **Custom Field `fm_folio_fiscal`: label "Folio Fiscal" → "Folio Fiscal FFM"** para evitar
  colisión con el legacy "Folio Fiscal". El picker de columnas del reporte de CxC identifica
  por label, así que con dos "Folio Fiscal" siempre tomaba el legacy → el campo nuevo salía vacío.
- Test `test_ffm_summary_folio` (3/3).

## Documentación actualizada

- No aplica: bugfix de display + cambio de label + test puro. No hay nuevo flujo, campo ni integración.

## Validaciones realizadas

- Tests: `test_ffm_summary_folio` 3/3 OK.
- `ruff check`/`ruff format` limpios.
- Validado en GUI (clon `llantascs-v16.dev`): el widget muestra `F-11679`; con label distinto,
  la columna `fm_folio_fiscal` jala el folio en el reporte de CxC.
- `bench migrate` corrió limpio en el clon (aplica el label).

## Fuera de alcance

- La configuración del reporte de CxC en sí; el fix es el label del campo.

## Riesgos / pendientes

- Requiere `bench migrate` al instalar (aplica el label nuevo).
- Producción (`erpstar.llantascs.com`) tiene la misma colisión de label → necesita este cambio
  + `bench update --reset` + `bench migrate` para que el reporte de CxC jale el folio nuevo ahí.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the invoice “Folio” is shown, now preferring the saved combined series-and-folio value when available.
  * If no combined value exists, it now formats separate series and folio values more consistently, with better fallback behavior when only one value is present.

* **Tests**
  * Added coverage for the updated folio display behavior to prevent regressions.

* **Style**
  * Updated the field label shown in the interface to “Folio Fiscal FFM”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->