### PR TITLE
fix(sales-invoice): lookups de Customer seguros con caracteres especiales en el nombre

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,79 +1,101 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-06-19
-**Rama activa:** `fix/ffm-cancel-permissions`
-**Tarea actual:** PR #197 — fixes CodeRabbit aplicados (6/6)
+**Fecha:** 2026-07-13
+**Rama activa:** `fix/customer-docname-safe-lookups`
+**Tarea actual:** Fix — lookups de Customer en JS fallan cuando el docname tiene caracteres especiales (comillas)
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Dos correcciones post go-live LlantasCS en la misma rama: (1) permisos de cancelación
-FFM restringidos a 3 roles; (2) cleanup de errores 403/417 al refrescar FFM.
+Corrección del defecto reportado en LlantasCS: el cliente `"LOGISTICA Y TRANSPORTE MAXMEX"`
+(RFC LTM220809E5A) — con comillas dobles como parte del docname — no permitía timbrar la SI,
+mostrando falsamente "el RFC del cliente no está validado con SAT" aunque `fm_rfc_validated=1`.
+Causa raíz: el JS leía Customer con `frappe.db.get_value("Customer", frm.doc.customer, …)`
+pasando el docname como string suelto; en el servidor `get_safe_filters`/orjson interpreta el
+nombre entre comillas como JSON y le quita las comillas → no encuentra al cliente. Fix: filtro
+explícito `{ name: … }`.
 
 Plan que estoy siguiendo:
-Correcciones post go-live LlantasCS. Multi-sucursal fiscal documentado en issue #196.
+Fix de defecto + eliminación de duplicación JS (instrucción del usuario: no limitar a las 3
+llamadas; barrer toda la app, consolidar lógica duplicada, agregar tests de regresión).
 
 Objetivo inmediato:
-Push + PR de esta rama.
+Commit hecho en esta rama (solo commit; sin push). Siguiente paso lo decide el usuario
+(push / PR).
 
 Criterio de avance:
-PR mergeado y cambios en producción vía bench migrate + bench build.
+Tests verdes (10/10) + linters limpios + diff sin cambios funcionales colaterales.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- PR #195 mergeado: fix pdf_custom_section + CodeRabbit
-- PR #193 mergeado: fixes post go-live timbrado + CPMX email
-- PR #192 mergeado: migración Fase 2 FFM + CPMX
-- Issue #196 creado: habilitación explícita multi-sucursal fiscal por Company
+- Diagnóstico probado: `get_safe_filters`/orjson mutila docnames JSON-parseables (envueltos
+  en comillas). Verificado contra `llantascs-v16.dev` (docname real con comillas, `fm_rfc_validated=1`).
+- App afectada confirmada: `facturacion_mexico` (provee el JS vía `doctype_js`). `facturacion_mx`
+  NO afectada (hooks JS comentados, sin el código) — no se toca.
+- 6 call-sites vulnerables corregidos a filtro `{ name }` (2 en `factura_fiscal_mexico.js`,
+  4 en `sales_invoice.js`).
+- Consolidación JS: 2 handlers `customer` duplicados → `apply_customer_defaults(frm)`;
+  eliminado `has_customer_rfc` (doble round-trip); `_check_rfc_and_show_timbrar` hace 1 sola
+  lectura `{name}` de `tax_id`+`fm_rfc_validated`; eliminado handler `cost_center` duplicado
+  redundante (CC-B); alerta roja de error preservada; `.catch` de paridad.
+- 2 tests nuevos: dinámico (borde servidor `frappe.client.get_value`) 6/6 + estático (guarda
+  del código JS contra reintroducir string suelto) 4/4.
+- Linters: prettier@2.7.1 (versión del CI — v3 mete trailing commas espurias), eslint 8.44.0,
+  ruff — todos limpios. `git diff --check` OK.
 
 ### En progreso
-- Rama `fix/ffm-cancel-permissions` (2 commits):
-  - 1452ed5: permisos cancelación FFM (3 roles)
-  - (en curso): cleanup 403/417 JS + prueba estática
+- Commit en `fix/customer-docname-safe-lookups`.
 
 ### Pendiente inmediato
-1. Push de esta rama
-2. Abrir PR
-3. Deploy en producción: `bench migrate` + `bench build`
-4. Configurar textos PUE/PPD en Company Settings de LlantasCS en producción
-5. Ejecutar `fix_fm_tax_regime_from_tax_category.py` en producción cuando esté listo
-6. Multi-sucursal fiscal (issue #196) — implementación fin de semana
+1. Decisión del usuario: push / PR.
+2. Validación GUI del botón Timbrar con el cliente de comillas (los tests NO cubren el JS en
+   navegador — solo el borde servidor y la forma del código fuente).
 
 ### No repetir
-- NO persistir fm_pdf_custom_section en el payload — solo en _process_timbrado_success
-- NO mergear chore/track-working-docs-archive directo — tiene código obsoleto mezclado
-- NO conectar fm_branch al timbrado en esta rama — eso es trabajo del issue #196
-- NO tocar series/folios/lugar_expedicion/payload en esta rama
-
-### No repetir (multi-sucursal — para #196)
-- El timbrado lee `branch` (campo inexistente en SI); SI usa `fm_branch`
-- La serie siempre cae en "F" (timbrado_api.py:698)
-- BranchFolioManager y Configuracion Fiscal Sucursal desconectados del timbrado
-- El indicador debe ser explícito por Company: `multisucursal_fiscal_enabled`
+- NO usar `npx prettier` sin fijar `@2.7.1` — la v3 reformatea trailing commas y ensucia el diff.
+- NO correr `bench run-tests --app … --module …`: el combo ignora el filtro y corre la suite
+  completa. Usar solo `--module` (sin `--app`).
+- NO correr tests de este app sin el seed `facturacion_mexico.tests.ci_pre_tests.run` + `--lightmode`.
+- NO tocar `facturacion_mx` — no está afectada.
 
 ---
 
 ## Decisiones vigentes
-- Solo 3 roles cancelan FFM: System Manager, Facturacion Mexico Manager, Facturacion Mexico System Manager
-- `control_multisucursal_field_visibility` solo oculta campos localmente (sin llamadas servidor)
-- `pdf_custom_section` solo para CFDI tipo I
+- Todo lookup de Customer desde JS debe usar filtro dict `{ name: customer }`, nunca el docname
+  como string suelto. La API Python `frappe.db.get_value` es inmune (param-binding); el defecto
+  es exclusivo del borde HTTP `frappe.client.get_value` (que pasa por `get_safe_filters`/orjson).
+- El servidor mantiene su validación fiscal independiente e inmune a comillas (usa
+  `getattr(customer_doc,…)` y SQL parametrizado).
+- Consolidación permitida solo donde había duplicación real de lógica de negocio; no crear
+  abstracción genérica que envuelva `get_value`.
 
 ---
 
 ## Archivos relevantes ahora
 
+### Leer primero
+- `facturacion_mexico/public/js/sales_invoice.js` — `apply_customer_defaults`,
+  `_check_rfc_and_show_timbrar`, handler `cost_center` (CC-A).
+- `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js`
+  — lookups `fm_uso_cfdi_default`, `fm_allow_generic_rfc`.
+
+### Probablemente editar
+- (ninguno — fix cerrado, salvo feedback de revisión/PR)
+
 ### No tocar
-- `patches.txt` — vacío por diseño (RG-010b)
-- `one_offs/fix_fm_tax_regime_from_tax_category.py` — pendiente ejecución producción
-- `timbrado_api.py` — NO modificar en esta rama (es trabajo de #196)
+- `facturacion_mexico/one_offs/*` — nunca commitear
+- `working_docs/active/*` — no van en este fix
+- `facturacion_mx` (otra app) — no afectada
 
 ---
 
 ## Riesgos / cuidados
-- Producción necesita `bench migrate` + `bench build` para activar permisos y JS nuevos
-- `chore/track-working-docs-archive` tiene código obsoleto — no mergear sin cherry-pick
+- Los tests dinámicos requieren las instancias Redis del bench (13001 cache / 11001 queue) y el
+  seed `ci_pre_tests.run`; sin Redis fallan en el bootstrap de test-records de erpnext.
+- La cobertura de tests NO incluye el JS en navegador: si alguien revierte el JS a string suelto,
+  el test dinámico seguiría verde — por eso existe el test estático que sí lo detecta.

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -9,8 +9,8 @@
 ## Recuperación rápida
 
 Estoy trabajando en:
-Corrección del defecto reportado en LlantasCS: el cliente `"LOGISTICA Y TRANSPORTE MAXMEX"`
-(RFC LTM220809E5A) — con comillas dobles como parte del docname — no permitía timbrar la SI,
+Corrección de un defecto reportado: un cliente cuyo docname va entre comillas dobles (ejemplo
+ficticio `"EMPRESA DEMO SA"`) — con las comillas como parte del docname — no permitía timbrar la SI,
 mostrando falsamente "el RFC del cliente no está validado con SAT" aunque `fm_rfc_validated=1`.
 Causa raíz: el JS leía Customer con `frappe.db.get_value("Customer", frm.doc.customer, …)`
 pasando el docname como string suelto; en el servidor `get_safe_filters`/orjson interpreta el
@@ -22,12 +22,13 @@ Fix de defecto + eliminación de duplicación JS (instrucción del usuario: no l
 llamadas; barrer toda la app, consolidar lógica duplicada, agregar tests de regresión).
 
 Objetivo inmediato:
-Commit `fc3f208` (fix) + commit de supresión `# nosemgrep` ya en la rama (pusheado el primero).
-Siguiente paso del flujo: `/ship push` y luego `/ship pr` hacia `main`.
+PR #213 abierto (base `main`), CI verde. Commits en rama: `fc3f208` (fix) + `572f93d` (nosemgrep)
++ commit de scrub de PII y rename CodeRabbit (este). Falta: push del último commit, quitar el
+nombre de ejemplo de la descripción del PR, y squash-merge (el merge lo ejecuta el usuario).
 
 Criterio de avance:
-Tests verdes (10/10) + linters limpios + `/pr-ready` sin bloqueos (semgrep `frappe-manual-commit`
-suprimido con `# nosemgrep` en el test dinámico) + diff sin cambios funcionales colaterales.
+Tests verdes (10/10) + linters limpios + CI del PR en verde + ninguna aparición del nombre real
+de la empresa de ejemplo en archivos ni en la descripción del PR.
 
 ---
 
@@ -45,7 +46,10 @@ suprimido con `# nosemgrep` en el test dinámico) + diff sin cambios funcionales
   lectura `{name}` de `tax_id`+`fm_rfc_validated`; eliminado handler `cost_center` duplicado
   redundante (CC-B); alerta roja de error preservada; `.catch` de paridad.
 - 2 tests nuevos: dinámico (borde servidor `frappe.client.get_value`) 6/6 + estático (guarda
-  del código JS contra reintroducir string suelto) 4/4.
+  del código JS contra reintroducir string suelto) 4/4. Re-verificados 10/10 tras el scrub.
+- PR #213 abierto y con CI verde. CodeRabbit: 1 nota Minor (variable de test en español) — aplicada.
+- Scrub de PII: el nombre real de la empresa de ejemplo y su RFC se reemplazaron por
+  `"EMPRESA DEMO SA"` en tests, comentario JS y CONTINUITY (no debe aparecer en búsquedas).
 - Linters: prettier@2.7.1 (versión del CI — v3 mete trailing commas espurias), eslint 8.44.0,
   ruff — todos limpios. `git diff --check` OK.
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-07-13
 **Rama activa:** `fix/customer-docname-safe-lookups`
-**Tarea actual:** Fix — lookups de Customer en JS fallan cuando el docname tiene caracteres especiales (comillas)
+**Tarea actual:** Fix — lookups de Customer en JS fallan cuando el docname tiene caracteres especiales (comillas). En fase de PR (flujo `/ship`).
 
 ---
 
@@ -22,11 +22,12 @@ Fix de defecto + eliminación de duplicación JS (instrucción del usuario: no l
 llamadas; barrer toda la app, consolidar lógica duplicada, agregar tests de regresión).
 
 Objetivo inmediato:
-Commit hecho en esta rama (solo commit; sin push). Siguiente paso lo decide el usuario
-(push / PR).
+Commit `fc3f208` (fix) + commit de supresión `# nosemgrep` ya en la rama (pusheado el primero).
+Siguiente paso del flujo: `/ship push` y luego `/ship pr` hacia `main`.
 
 Criterio de avance:
-Tests verdes (10/10) + linters limpios + diff sin cambios funcionales colaterales.
+Tests verdes (10/10) + linters limpios + `/pr-ready` sin bloqueos (semgrep `frappe-manual-commit`
+suprimido con `# nosemgrep` en el test dinámico) + diff sin cambios funcionales colaterales.
 
 ---
 
@@ -49,10 +50,11 @@ Tests verdes (10/10) + linters limpios + diff sin cambios funcionales colaterale
   ruff — todos limpios. `git diff --check` OK.
 
 ### En progreso
-- Commit en `fix/customer-docname-safe-lookups`.
+- Rama `fix/customer-docname-safe-lookups`: commit `fc3f208` (fix, pusheado) + commit de
+  supresión `# nosemgrep` (recién creado). Falta `/ship push` del segundo + `/ship pr`.
 
 ### Pendiente inmediato
-1. Decisión del usuario: push / PR.
+1. `/ship push` (2º commit) y `/ship pr` hacia `main`.
 2. Validación GUI del botón Timbrar con el cliente de comillas (los tests NO cubren el JS en
    navegador — solo el borde servidor y la forma del código fuente).
 

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -673,7 +673,7 @@
 		);
 
 		frappe.db
-			.get_value("Customer", customer, "fm_uso_cfdi_default")
+			.get_value("Customer", { name: customer }, "fm_uso_cfdi_default")
 			.then((r) => {
 				console.log("📥 Response from Customer.fm_uso_cfdi_default:", r);
 
@@ -2640,7 +2640,7 @@ function validate_billing_data_visual(frm) {
 
 		const currentCustomer = frm.doc.customer;
 		frappe.db
-			.get_value("Customer", currentCustomer, "fm_allow_generic_rfc")
+			.get_value("Customer", { name: currentCustomer }, "fm_allow_generic_rfc")
 			.then((r) => {
 				if (frm.doc.customer !== currentCustomer) {
 					frm._vm_loaded_for = null; // customer changed during load — reset

--- a/facturacion_mexico/public/js/sales_invoice.js
+++ b/facturacion_mexico/public/js/sales_invoice.js
@@ -507,7 +507,7 @@ function _check_rfc_and_show_timbrar(frm) {
 	if (!frm.doc.customer) return;
 
 	// Una sola lectura del Customer: tax_id (RFC presente) + fm_rfc_validated (validado SAT).
-	// Filtro { name } explícito: un docname con comillas ("LOGISTICA Y TRANSPORTE MAXMEX") pasado
+	// Filtro { name } explícito: un docname con comillas (p. ej. un nombre entre comillas dobles) pasado
 	// como string suelto es mutilado por get_safe_filters/orjson en el servidor y no encontraría
 	// al cliente, mostrando falsamente "RFC no validado".
 	frappe.db

--- a/facturacion_mexico/public/js/sales_invoice.js
+++ b/facturacion_mexico/public/js/sales_invoice.js
@@ -53,31 +53,6 @@ frappe.ui.form.on("Sales Invoice", {
 	},
 });
 
-function has_customer_rfc(frm, callback) {
-	// Verificar si el cliente tiene RFC configurado - RFC está en Customer, no en Sales Invoice
-	if (!frm.doc.customer) {
-		callback(false);
-		return;
-	}
-
-	// Obtener RFC del Customer vinculado
-	frappe.call({
-		method: "frappe.client.get_value",
-		args: {
-			doctype: "Customer",
-			filters: { name: frm.doc.customer },
-			fieldname: "tax_id",
-		},
-		callback: function (r) {
-			const has_rfc = !!(r.message && r.message.tax_id);
-			callback(has_rfc);
-		},
-		error: function (err) {
-			callback(false);
-		},
-	});
-}
-
 function is_already_timbrada(frm) {
 	// Función "no-op" segura para evitar referencias a campos obsoletos.
 	// Mantiene compatibilidad con tests que verifican su existencia/uso.
@@ -283,60 +258,8 @@ frappe.ui.form.on("Sales Invoice", {
 		});
 	},
 
-	// AJUSTES UX - Propuesta ChatGPT: avisos 6-7s, mensajes negocio, condicionalidad correcta
-	async customer(frm) {
-		if (!frm.doc.customer) return;
-
-		try {
-			// Obtener configuración del Customer
-			const customer_data = await frappe.db.get_value("Customer", frm.doc.customer, [
-				"fm_customer_default_cost_center",
-				"default_price_list",
-			]);
-
-			if (customer_data && customer_data.message) {
-				const { fm_customer_default_cost_center } = customer_data.message;
-
-				// Condicionalidad correcta según configuración Customer
-				if (fm_customer_default_cost_center) {
-					await frm.set_value("cost_center", fm_customer_default_cost_center);
-					// Mensaje negocio sin referencias técnicas, 6-7 segundos
-					frappe.show_alert(
-						{
-							message: __("Centro de Costos asignado automáticamente."),
-							indicator: "green",
-						},
-						6
-					);
-
-					// Disparar evento cost_center para que recalcule Branch/Price List
-					// (El handler cost_center() ya existe y maneja esto)
-				} else {
-					// Solo avisar cuando NO hay CC por defecto, 6-7 segundos
-					frappe.show_alert(
-						{
-							message: __(
-								"Este cliente no tiene Centro de Costos configurado. Selecciónalo para continuar."
-							),
-							indicator: "orange",
-						},
-						6
-					);
-				}
-			}
-		} catch (e) {
-			console.error("Error al cargar configuración del cliente:", e);
-			frappe.show_alert(
-				{
-					message: __(
-						"Error al cargar configuración del cliente. Configura manualmente."
-					),
-					indicator: "red",
-				},
-				6
-			);
-		}
-	},
+	// NOTA: el handler `customer` duplicado se consolidó en `apply_customer_defaults()`
+	// (ver bloque inferior). Aquí solo queda la lógica de cost_center.
 
 	// Si el usuario cambia el cost_center manualmente, refrescar Branch/Price List en UI
 	cost_center: async function (frm) {
@@ -366,7 +289,7 @@ frappe.ui.form.on("Sales Invoice", {
 			if (frm.doc.customer) {
 				const cust = await frappe.db.get_value(
 					"Customer",
-					frm.doc.customer,
+					{ name: frm.doc.customer },
 					"default_price_list"
 				);
 				if (cust && cust.message && cust.message.default_price_list) {
@@ -486,77 +409,14 @@ frappe.ui.form.on("Sales Invoice", {
 	},
 
 	customer: async function (frm) {
-		if (!frm.doc.customer) return;
-
-		// 1) Cargar CC por defecto del cliente
-		try {
-			const { message } = await frappe.db.get_value("Customer", frm.doc.customer, [
-				"fm_customer_default_cost_center",
-				"default_price_list",
-			]);
-			const cc = message ? message.fm_customer_default_cost_center : null;
-			const pl = message ? message.default_price_list : null;
-
-			if (cc) {
-				await frm.set_value("cost_center", cc);
-				frappe.show_alert(
-					{ message: "Centro de Costos asignado automáticamente.", indicator: "green" },
-					6
-				);
-			} else {
-				frappe.show_alert(
-					{
-						message: "El cliente no tiene Centro de Costos por defecto.",
-						indicator: "orange",
-					},
-					6
-				);
-			}
-
-			// 2) Price List por prioridad (si no está ya)
-			if (!frm.doc.selling_price_list) {
-				if (pl) {
-					await frm.set_value("selling_price_list", pl);
-				} else {
-					// si no hay en Customer, cuando setee cost_center se recalculará abajo
-				}
-			}
-
-			// 3) Resolver STCT por sucursal emisora, si taxes_and_charges está vacío
-			await _fm_apply_branch_tax_template(frm);
-		} catch (e) {
-			console.log("customer handler error", e);
-		}
+		// Handler único de cliente: carga de defaults consolidada (antes duplicada en dos bloques).
+		await apply_customer_defaults(frm);
 	},
 
-	cost_center: async function (frm) {
-		if (!frm.doc.cost_center) return;
-
-		// 1) Resolver Branch y STCT por sucursal (si no hay STCT ya)
-		await _fm_apply_branch_tax_template(frm);
-
-		// 2) Price List por prioridad si sigue vacío
-		if (!frm.doc.selling_price_list) {
-			try {
-				const { message: ccRow } = await frappe.db.get_value(
-					"Cost Center",
-					frm.doc.cost_center,
-					["fm_default_selling_price_list"]
-				);
-				if (ccRow && ccRow.fm_default_selling_price_list) {
-					await frm.set_value("selling_price_list", ccRow.fm_default_selling_price_list);
-				} else {
-					const companyPL = await frappe.db.get_single_value(
-						"Selling Settings",
-						"selling_price_list"
-					);
-					if (companyPL) await frm.set_value("selling_price_list", companyPL);
-				}
-			} catch (e) {
-				console.log("cost_center handler price list error", e);
-			}
-		}
-	},
+	// NOTA: el handler `cost_center` de este bloque se eliminó por ser un duplicado redundante
+	// del handler `cost_center` del bloque superior (que ya resuelve fm_branch + Price List con
+	// cascada Customer → Cost Center → Selling Settings). Su única acción propia era un no-op
+	// (_fm_apply_branch_tax_template); su cascada Price List era subconjunto de la otra.
 
 	before_save(frm) {
 		if (!frm.doc.cost_center) {
@@ -577,6 +437,61 @@ async function _fm_apply_branch_tax_template(frm) {
 	return;
 }
 
+// Carga de defaults del Customer (Centro de Costos + Price List) y resolución STCT.
+// Consolida los dos handlers `customer` que antes ejecutaban esta misma lógica por separado.
+// Usa filtro { name } para que docnames con comillas/caracteres especiales lleguen intactos
+// al servidor (un string suelto lo mutila `get_safe_filters`/orjson).
+async function apply_customer_defaults(frm) {
+	if (!frm.doc.customer) return;
+
+	try {
+		const { message } = await frappe.db.get_value("Customer", { name: frm.doc.customer }, [
+			"fm_customer_default_cost_center",
+			"default_price_list",
+		]);
+		const cc = message ? message.fm_customer_default_cost_center : null;
+		const pl = message ? message.default_price_list : null;
+
+		// 1) Centro de Costos por defecto del cliente
+		if (cc) {
+			await frm.set_value("cost_center", cc);
+			frappe.show_alert(
+				{ message: __("Centro de Costos asignado automáticamente."), indicator: "green" },
+				6
+			);
+		} else {
+			frappe.show_alert(
+				{
+					message: __("El cliente no tiene Centro de Costos por defecto."),
+					indicator: "orange",
+				},
+				6
+			);
+		}
+
+		// 2) Price List del cliente si aún no hay una asignada
+		if (!frm.doc.selling_price_list && pl) {
+			await frm.set_value("selling_price_list", pl);
+		}
+
+		// 3) Resolver STCT por sucursal emisora (lógica en Python hook)
+		await _fm_apply_branch_tax_template(frm);
+	} catch (e) {
+		console.log("apply_customer_defaults error", e);
+		// Notificación visible ante fallo de lectura del Customer (conserva el aviso que daba
+		// el handler previo; una sola alerta, no duplicada).
+		frappe.show_alert(
+			{
+				message: __(
+					"Error al cargar la configuración del cliente. Configúrala manualmente."
+				),
+				indicator: "red",
+			},
+			6
+		);
+	}
+}
+
 function cint(v) {
 	try {
 		return parseInt(v, 10) || 0;
@@ -589,14 +504,23 @@ function cint(v) {
 // Llamado desde sales_invoice_block_cancel.js después de resolver estado de cancelación.
 function _check_rfc_and_show_timbrar(frm) {
 	if (!frm.doc || frm.doc.docstatus !== 1) return;
+	if (!frm.doc.customer) return;
 
-	has_customer_rfc(frm, function (has_rfc) {
-		if (!has_rfc) return;
-		frappe.db.get_value("Customer", frm.doc.customer, ["fm_rfc_validated"]).then((r) => {
-			const is_validated = !!(
-				r.message &&
-				(r.message.fm_rfc_validated === 1 || r.message.fm_rfc_validated === "1")
-			);
+	// Una sola lectura del Customer: tax_id (RFC presente) + fm_rfc_validated (validado SAT).
+	// Filtro { name } explícito: un docname con comillas ("LOGISTICA Y TRANSPORTE MAXMEX") pasado
+	// como string suelto es mutilado por get_safe_filters/orjson en el servidor y no encontraría
+	// al cliente, mostrando falsamente "RFC no validado".
+	frappe.db
+		.get_value("Customer", { name: frm.doc.customer }, ["tax_id", "fm_rfc_validated"])
+		.then((r) => {
+			const msg = (r && r.message) || {};
+
+			// RFC presente: sin RFC no se muestra botón ni alerta (comportamiento previo).
+			if (!msg.tax_id) return;
+
+			// Validación SAT: solo un flag explícito = 1 habilita el botón; vacío/0 nunca se
+			// interpreta como validado.
+			const is_validated = msg.fm_rfc_validated === 1 || msg.fm_rfc_validated === "1";
 			if (is_validated) {
 				if (should_show_timbrar_button(frm)) {
 					add_timbrar_button(frm);
@@ -610,6 +534,8 @@ function _check_rfc_and_show_timbrar(frm) {
 						"orange"
 					);
 			}
+		})
+		.catch(() => {
+			// Error de servidor: no mostrar boton ni alerta (paridad con el manejo previo).
 		});
-	});
 }

--- a/facturacion_mexico/tests/test_customer_docname_safe_lookup.py
+++ b/facturacion_mexico/tests/test_customer_docname_safe_lookup.py
@@ -5,7 +5,7 @@ Bug original: varios lookups en JS leían campos del Customer con
 `frappe.db.get_value("Customer", frm.doc.customer, [...])` pasando el docname como
 STRING suelto. En el servidor, `frappe.client.get_value` pasa ese string por
 `get_safe_filters()` → `orjson.loads()`. Si el docname es JSON válido (p.ej. envuelto en
-comillas dobles: `"LOGISTICA Y TRANSPORTE MAXMEX"`), orjson lo interpreta como string JSON
+comillas dobles: `"EMPRESA DEMO SA"`), orjson lo interpreta como string JSON
 y le QUITA las comillas → el `name` resultante ya no existe → resultado vacío. Efectos:
     - botón Timbrar oculto + "el RFC del cliente no está validado con SAT" (aunque =1);
     - defaults de Centro de Costos / Price List no se autollenan;
@@ -51,10 +51,10 @@ class TestCustomerDocnameSafeLookup(FrappeTestCase):
 	# NOTA: el hash {h} va DENTRO de las comillas de cierre en el caso "envuelto" para que el
 	# docname completo sea un string JSON válido ("...")— así reproduce la trampa real de orjson
 	# (que solo mutila nombres JSON-parseables de extremo a extremo, como el docname productivo
-	# "LOGISTICA Y TRANSPORTE MAXMEX"). Si el hash quedara fuera de la comilla, ya no sería JSON.
+	# "EMPRESA DEMO SA"). Si el hash quedara fuera de la comilla, ya no sería JSON.
 	NAME_TEMPLATES: ClassVar[list] = [
 		"CLIENTE NORMAL {h}",
-		'"LOGISTICA Y TRANSPORTE MAXMEX {h}"',
+		'"EMPRESA DEMO SA {h}"',
 		'CLIENTE "SUCURSAL NORTE" {h}',
 		"O'CONNOR TRANSPORTES {h}",
 		"ACME & ASOCIADOS {h}",
@@ -83,7 +83,7 @@ class TestCustomerDocnameSafeLookup(FrappeTestCase):
 		self.price_list = frappe.db.get_value("Price List", {"selling": 1}, "name") or frappe.db.get_value(
 			"Price List", {}, "name"
 		)
-		self.uso_cfdi = frappe.db.get_value("Uso CFDI SAT", {}, "name")
+		self.cfdi_use = frappe.db.get_value("Uso CFDI SAT", {}, "name")
 
 		# Valores esperados que se fijan en CADA customer (para aserciones de igualdad exacta).
 		self.expected = {
@@ -92,7 +92,7 @@ class TestCustomerDocnameSafeLookup(FrappeTestCase):
 			"fm_allow_generic_rfc": 1,
 			"fm_customer_default_cost_center": self.cost_center,
 			"default_price_list": self.price_list,
-			"fm_uso_cfdi_default": self.uso_cfdi,
+			"fm_uso_cfdi_default": self.cfdi_use,
 		}
 
 		self.names = []
@@ -147,7 +147,7 @@ class TestCustomerDocnameSafeLookup(FrappeTestCase):
 	def test_string_suelto_pierde_nombre_entre_comillas(self):
 		"""TRAMPA/REGRESIÓN: el docname envuelto en comillas dobles, como string suelto, es
 		mutilado por get_safe_filters/orjson → vacío. Este es el bug que el fix elimina."""
-		quoted = f'"LOGISTICA Y TRANSPORTE MAXMEX {self.h}"'
+		quoted = f'"EMPRESA DEMO SA {self.h}"'
 		self.assertIn(quoted, self.names)
 
 		r_bad = client_get_value("Customer", "fm_rfc_validated", filters=quoted)

--- a/facturacion_mexico/tests/test_customer_docname_safe_lookup.py
+++ b/facturacion_mexico/tests/test_customer_docname_safe_lookup.py
@@ -117,7 +117,7 @@ class TestCustomerDocnameSafeLookup(FrappeTestCase):
 				frappe.db.set_value("Customer", target, field, value)
 			self.names.append(target)
 
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
 
 	# ------------------------------------------------------------------ CENTRAL
 
@@ -179,7 +179,7 @@ class TestCustomerDocnameSafeLookup(FrappeTestCase):
 		"""fm_rfc_validated=0 debe devolver 0 (no habilita el botón)."""
 		name = self.names[0]
 		frappe.db.set_value("Customer", name, "fm_rfc_validated", 0)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
 		r = client_get_value("Customer", "fm_rfc_validated", filters=_filters_dict(name))
 		self.assertEqual(cint(r.get("fm_rfc_validated")), 0)
 
@@ -192,7 +192,7 @@ class TestCustomerDocnameSafeLookup(FrappeTestCase):
 		"""Sin RFC (tax_id vacío) el flujo del botón corta antes de evaluar validación."""
 		name = self.names[2]
 		frappe.db.set_value("Customer", name, "tax_id", "")
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
 		r = client_get_value(
 			"Customer", _fields_arg(["tax_id", "fm_rfc_validated"]), filters=_filters_dict(name)
 		)

--- a/facturacion_mexico/tests/test_customer_docname_safe_lookup.py
+++ b/facturacion_mexico/tests/test_customer_docname_safe_lookup.py
@@ -1,0 +1,199 @@
+"""Regresión: lookups de Customer cuando el docname contiene comillas u otros
+caracteres especiales — cubre TODOS los call-sites detectados.
+
+Bug original: varios lookups en JS leían campos del Customer con
+`frappe.db.get_value("Customer", frm.doc.customer, [...])` pasando el docname como
+STRING suelto. En el servidor, `frappe.client.get_value` pasa ese string por
+`get_safe_filters()` → `orjson.loads()`. Si el docname es JSON válido (p.ej. envuelto en
+comillas dobles: `"LOGISTICA Y TRANSPORTE MAXMEX"`), orjson lo interpreta como string JSON
+y le QUITA las comillas → el `name` resultante ya no existe → resultado vacío. Efectos:
+    - botón Timbrar oculto + "el RFC del cliente no está validado con SAT" (aunque =1);
+    - defaults de Centro de Costos / Price List no se autollenan;
+    - Uso CFDI default no se asigna;
+    - visibilidad de venta mostrador (fm_allow_generic_rfc) mal calculada.
+
+Fix: pasar el filtro como dict explícito `{ name: customer }`. `frappe.call` lo serializa a
+JSON escapando las comillas, y `orjson` lo reconstruye intacto.
+
+Estas pruebas reproducen fielmente el borde HTTP (`frappe.client.get_value`), que es la
+función whitelisted donde vive `get_safe_filters`. La API Python directa
+`frappe.db.get_value` NO pasa por ahí (usa param-binding) y es inmune — no se prueba aquí.
+
+Call-sites cubiertos (post-fix, todos con filtro dict):
+    sales_invoice.js  _check_rfc_and_show_timbrar   -> tax_id, fm_rfc_validated
+    sales_invoice.js  apply_customer_defaults       -> fm_customer_default_cost_center, default_price_list
+    sales_invoice.js  cost_center handler           -> default_price_list
+    factura_fiscal_mexico.js  auto_assign_cfdi      -> fm_uso_cfdi_default
+    factura_fiscal_mexico.js  venta mostrador       -> fm_allow_generic_rfc
+"""
+
+from typing import ClassVar
+
+import frappe
+from frappe.client import get_value as client_get_value
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import cint
+
+
+def _filters_dict(name):
+	"""Filtro tal como lo envía el JS corregido: dict serializado a JSON (comillas escapadas)."""
+	return frappe.as_json({"name": name})
+
+
+def _fields_arg(fields):
+	"""fieldname tal como lo envía frappe.db.get_value cuando recibe una lista."""
+	return frappe.as_json(fields) if isinstance(fields, list) else fields
+
+
+class TestCustomerDocnameSafeLookup(FrappeTestCase):
+	# Docnames a cubrir: normal, envuelto-en-comillas (caso reportado), comillas embebidas,
+	# apóstrofo, ampersand y acentos.
+	# NOTA: el hash {h} va DENTRO de las comillas de cierre en el caso "envuelto" para que el
+	# docname completo sea un string JSON válido ("...")— así reproduce la trampa real de orjson
+	# (que solo mutila nombres JSON-parseables de extremo a extremo, como el docname productivo
+	# "LOGISTICA Y TRANSPORTE MAXMEX"). Si el hash quedara fuera de la comilla, ya no sería JSON.
+	NAME_TEMPLATES: ClassVar[list] = [
+		"CLIENTE NORMAL {h}",
+		'"LOGISTICA Y TRANSPORTE MAXMEX {h}"',
+		'CLIENTE "SUCURSAL NORTE" {h}',
+		"O'CONNOR TRANSPORTES {h}",
+		"ACME & ASOCIADOS {h}",
+		"CAFÉ MAÑANA SA {h}",
+	]
+
+	# Campos leídos por cada call-site (los que el fix debe devolver intactos).
+	SCENARIO_FIELDS: ClassVar[dict] = {
+		"boton_timbrar (tax_id + fm_rfc_validated)": ["tax_id", "fm_rfc_validated"],
+		"apply_customer_defaults (CC + price list)": [
+			"fm_customer_default_cost_center",
+			"default_price_list",
+		],
+		"cost_center handler (default_price_list)": ["default_price_list"],
+		"auto_assign_cfdi (fm_uso_cfdi_default)": ["fm_uso_cfdi_default"],
+		"venta_mostrador (fm_allow_generic_rfc)": ["fm_allow_generic_rfc"],
+	}
+
+	def setUp(self):
+		self.h = frappe.generate_hash()[:6]
+		self.customer_group = frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+		self.territory = frappe.db.get_value("Territory", {"is_group": 0}, "name")
+
+		# Valores concretos existentes para los campos Link (si el site los tiene).
+		self.cost_center = frappe.db.get_value("Cost Center", {"is_group": 0}, "name")
+		self.price_list = frappe.db.get_value("Price List", {"selling": 1}, "name") or frappe.db.get_value(
+			"Price List", {}, "name"
+		)
+		self.uso_cfdi = frappe.db.get_value("Uso CFDI SAT", {}, "name")
+
+		# Valores esperados que se fijan en CADA customer (para aserciones de igualdad exacta).
+		self.expected = {
+			"tax_id": "XAXX010101000",
+			"fm_rfc_validated": 1,
+			"fm_allow_generic_rfc": 1,
+			"fm_customer_default_cost_center": self.cost_center,
+			"default_price_list": self.price_list,
+			"fm_uso_cfdi_default": self.uso_cfdi,
+		}
+
+		self.names = []
+		for i, tpl in enumerate(self.NAME_TEMPLATES):
+			target = tpl.format(h=self.h)
+			# Insertar con nombre plano y renombrar al docname objetivo: el docname queda con
+			# los caracteres especiales sin depender de la config de naming de Customer.
+			doc = frappe.get_doc(
+				{
+					"doctype": "Customer",
+					"customer_name": f"TMP-{self.h}-{i}",
+					"customer_type": "Company",
+					"customer_group": self.customer_group,
+					"territory": self.territory,
+				}
+			).insert(ignore_permissions=True)
+			frappe.rename_doc("Customer", doc.name, target, force=True, show_alert=False)
+
+			# Fijar valores por db.set_value (evita validación de formato RFC del controller).
+			updates = {k: v for k, v in self.expected.items() if v is not None}
+			for field, value in updates.items():
+				frappe.db.set_value("Customer", target, field, value)
+			self.names.append(target)
+
+		frappe.db.commit()
+
+	# ------------------------------------------------------------------ CENTRAL
+
+	def test_todos_los_campos_por_escenario_con_dict(self):
+		"""CENTRAL: para cada call-site y cada docname especial, el filtro dict encuentra al
+		cliente y devuelve los campos con el valor fijado (nombre llega intacto)."""
+		for scenario, fields in self.SCENARIO_FIELDS.items():
+			for name in self.names:
+				r = client_get_value("Customer", _fields_arg(fields), filters=_filters_dict(name))
+				self.assertTrue(r, f"[{scenario}] lookup dict vacío para docname {name!r}")
+				for field in fields:
+					self.assertIn(field, r, f"[{scenario}] falta campo {field} para {name!r}")
+					expected = self.expected.get(field)
+					if expected is None:
+						continue  # sin valor de referencia en el site; basta con haber encontrado al cliente
+					got = r.get(field)
+					if field in ("fm_rfc_validated", "fm_allow_generic_rfc"):
+						got = cint(got)
+					self.assertEqual(
+						got,
+						expected,
+						f"[{scenario}] {field}={got!r} != esperado {expected!r} para {name!r}",
+					)
+
+	# ------------------------------------------------------------------ TRAMPA
+
+	def test_string_suelto_pierde_nombre_entre_comillas(self):
+		"""TRAMPA/REGRESIÓN: el docname envuelto en comillas dobles, como string suelto, es
+		mutilado por get_safe_filters/orjson → vacío. Este es el bug que el fix elimina."""
+		quoted = f'"LOGISTICA Y TRANSPORTE MAXMEX {self.h}"'
+		self.assertIn(quoted, self.names)
+
+		r_bad = client_get_value("Customer", "fm_rfc_validated", filters=quoted)
+		self.assertFalse(
+			r_bad,
+			"El string suelto encontró al cliente: get_safe_filters ya no muta el nombre. "
+			"Si esto cambió, revalidar si el fix de filtro dict sigue siendo necesario.",
+		)
+
+		r_ok = client_get_value("Customer", "fm_rfc_validated", filters=_filters_dict(quoted))
+		self.assertEqual(cint(r_ok.get("fm_rfc_validated")), 1)
+
+	def test_string_suelto_no_afecta_nombres_no_json(self):
+		"""Docnames con apóstrofo/ampersand/acentos NO son JSON válido: el string suelto los
+		deja pasar. Documenta que el defecto es específico de nombres JSON-parseables."""
+		for name in self.names:
+			if name.lstrip().startswith('"'):
+				continue  # los envueltos en comillas sí se rompen (cubierto arriba)
+			r = client_get_value("Customer", "fm_rfc_validated", filters=name)
+			self.assertEqual(
+				cint(r.get("fm_rfc_validated")),
+				1,
+				f"docname no-JSON {name!r} debería resolverse aún como string suelto",
+			)
+
+	# ------------------------------------------------------------------ BORDES
+
+	def test_cliente_no_validado_sigue_bloqueado(self):
+		"""fm_rfc_validated=0 debe devolver 0 (no habilita el botón)."""
+		name = self.names[0]
+		frappe.db.set_value("Customer", name, "fm_rfc_validated", 0)
+		frappe.db.commit()
+		r = client_get_value("Customer", "fm_rfc_validated", filters=_filters_dict(name))
+		self.assertEqual(cint(r.get("fm_rfc_validated")), 0)
+
+	def test_resultado_vacio_no_es_validado(self):
+		"""Docname inexistente → {} — nunca debe interpretarse como validado."""
+		r = client_get_value("Customer", "fm_rfc_validated", filters=_filters_dict(f"NO-EXISTE-{self.h}"))
+		self.assertFalse(r.get("fm_rfc_validated"))
+
+	def test_sin_tax_id_no_muestra_boton(self):
+		"""Sin RFC (tax_id vacío) el flujo del botón corta antes de evaluar validación."""
+		name = self.names[2]
+		frappe.db.set_value("Customer", name, "tax_id", "")
+		frappe.db.commit()
+		r = client_get_value(
+			"Customer", _fields_arg(["tax_id", "fm_rfc_validated"]), filters=_filters_dict(name)
+		)
+		self.assertFalse(r.get("tax_id"))

--- a/facturacion_mexico/tests/test_sales_invoice_js_customer_lookups.py
+++ b/facturacion_mexico/tests/test_sales_invoice_js_customer_lookups.py
@@ -1,0 +1,136 @@
+"""Guarda ESTÁTICA (análisis de código fuente) contra la regresión del patrón vulnerable
+de lookups de Customer en el JavaScript del app.
+
+NO es una prueba funcional de navegador: no ejecuta JavaScript, no renderiza el formulario
+ni verifica que el botón Timbrar aparezca. Lee los archivos `.js` como texto y valida, por
+expresiones regulares, que los call-sites de Customer usen filtros `{ name: ... }` y no el
+docname como string suelto.
+
+Complementa a `test_customer_docname_safe_lookup.py` (que prueba el borde del servidor): esa
+prueba dinámica quedaría verde aunque alguien revirtiera el JS a `get_value("Customer", frm.doc.customer, …)`.
+Esta prueba estática es la que fallaría en ese caso.
+
+Cubre:
+  - que NO exista `frappe.db.get_value`/`frappe.client.get_value` sobre Customer pasando el
+    nombre como string suelto (en `sales_invoice.js` y `factura_fiscal_mexico.js`);
+  - que los call-sites corregidos usen filtro con `name`;
+  - que `_check_rfc_and_show_timbrar` consulte `tax_id` y `fm_rfc_validated` en una sola lectura.
+"""
+
+import re
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+JS_FILES = {
+	"sales_invoice.js": ("public", "js", "sales_invoice.js"),
+	"factura_fiscal_mexico.js": (
+		"facturacion_fiscal",
+		"doctype",
+		"factura_fiscal_mexico",
+		"factura_fiscal_mexico.js",
+	),
+}
+
+# .get_value("Customer", <arg2>, ...  — captura el 2º argumento (posiblemente multilínea).
+DB_GETVALUE_CUSTOMER = re.compile(r'\.get_value\(\s*(["\'])Customer\1\s*,\s*(.+?)\s*,', re.S)
+# method: "frappe.client.get_value"
+CLIENT_GETVALUE = re.compile(r'method:\s*["\']frappe\.client\.get_value["\']')
+
+
+def _read(rel_parts):
+	path = frappe.get_app_path("facturacion_mexico", *rel_parts)
+	with open(path, encoding="utf-8") as fh:
+		return fh.read()
+
+
+def _func_body(src, name):
+	m = re.search(r"function\s+" + re.escape(name) + r"\s*\(", src)
+	if not m:
+		return ""
+	nxt = src.find("\nfunction ", m.end())
+	return src[m.start() : nxt if nxt != -1 else len(src)]
+
+
+class TestSalesInvoiceJsCustomerLookups(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.sources = {name: _read(parts) for name, parts in JS_FILES.items()}
+
+	def test_db_get_value_customer_usa_filtro_dict(self):
+		"""Todo `frappe.db.get_value("Customer", X, …)` debe pasar X como dict `{ name: … }`,
+		nunca como string suelto (que get_safe_filters/orjson mutila para docnames con comillas)."""
+		offenders = []
+		for fname, src in self.sources.items():
+			for m in DB_GETVALUE_CUSTOMER.finditer(src):
+				arg2 = m.group(2).strip()
+				if not arg2.startswith("{"):
+					line = src.count("\n", 0, m.start()) + 1
+					offenders.append(f'{fname}:{line} -> get_value("Customer", {arg2!r}, …)')
+		self.assertEqual(
+			offenders,
+			[],
+			"Lookups de Customer con nombre como string suelto (usar { name: … }):\n" + "\n".join(offenders),
+		)
+
+	def test_client_get_value_customer_usa_filtro_name(self):
+		"""Todo `frappe.client.get_value` sobre Customer debe usar `filters: { name: … }`."""
+		offenders = []
+		for fname, src in self.sources.items():
+			for m in CLIENT_GETVALUE.finditer(src):
+				block = src[m.start() : m.start() + 600]
+				if not re.search(r'doctype:\s*["\']Customer["\']', block):
+					continue
+				fm = re.search(r"filters:\s*([^\n]+)", block)
+				filt = fm.group(1).strip() if fm else "(sin filters)"
+				if "{" not in filt or "name" not in filt:
+					line = src.count("\n", 0, m.start()) + 1
+					offenders.append(f"{fname}:{line} -> filters: {filt}")
+		self.assertEqual(
+			offenders,
+			[],
+			"client.get_value sobre Customer sin filtro { name: … }:\n" + "\n".join(offenders),
+		)
+
+	def test_check_rfc_lee_tax_id_y_fm_rfc_validated_juntos(self):
+		"""`_check_rfc_and_show_timbrar` debe hacer UNA sola lectura del Customer con filtro
+		{ name } que traiga `tax_id` y `fm_rfc_validated` — no dos consultas ni string suelto."""
+		body = _func_body(self.sources["sales_invoice.js"], "_check_rfc_and_show_timbrar")
+		self.assertTrue(body, "No se encontró _check_rfc_and_show_timbrar en sales_invoice.js")
+
+		# Debe existir el get_value sobre Customer con filtro dict { name ... }.
+		self.assertRegex(
+			body,
+			r'get_value\(\s*"Customer"\s*,\s*\{\s*name',
+			"_check_rfc_and_show_timbrar no usa filtro { name } sobre Customer",
+		)
+		# Debe leer ambos campos en la misma llamada.
+		self.assertIn("tax_id", body, "_check_rfc_and_show_timbrar no consulta tax_id")
+		self.assertIn("fm_rfc_validated", body, "_check_rfc_and_show_timbrar no consulta fm_rfc_validated")
+		# Ya no debe depender del doble round-trip vía has_customer_rfc.
+		self.assertNotIn(
+			"has_customer_rfc(",
+			body,
+			"_check_rfc_and_show_timbrar sigue llamando has_customer_rfc (doble consulta)",
+		)
+
+	def test_callsites_corregidos_usan_name(self):
+		"""Los call-sites concretos que se corrigieron deben verse con filtro { name }."""
+		si = self.sources["sales_invoice.js"]
+		ffm = self.sources["factura_fiscal_mexico.js"]
+
+		expected = [
+			(ffm, r'get_value\(\s*"Customer"\s*,\s*\{\s*name:\s*customer\s*\}\s*,\s*"fm_uso_cfdi_default"'),
+			(
+				ffm,
+				r'get_value\(\s*"Customer"\s*,\s*\{\s*name:\s*currentCustomer\s*\}\s*,\s*"fm_allow_generic_rfc"',
+			),
+			(
+				si,
+				r'get_value\(\s*"Customer"\s*,\s*\{\s*name:\s*frm\.doc\.customer\s*\}\s*,\s*"default_price_list"',
+			),
+			(si, r'get_value\(\s*"Customer"\s*,\s*\{\s*name:\s*frm\.doc\.customer\s*\}\s*,\s*\['),
+		]
+		for src, pattern in expected:
+			self.assertRegex(src, pattern, f"No se encontró call-site corregido: {pattern}")


### PR DESCRIPTION
## Objetivo
Corregir que clientes cuyo docname contiene comillas (p. ej. "EMPRESA DEMO SA")
no permitían timbrar la Sales Invoice: mostraba falsamente "el RFC del cliente no está validado
con SAT" aunque el RFC sí estuviera validado (fm_rfc_validated=1).

## Causa raíz
El JS leía el Customer con `frappe.db.get_value("Customer", frm.doc.customer, …)` pasando el
docname como string suelto. En el servidor, `frappe.client.get_value` lo pasa por
`get_safe_filters`/orjson; un nombre envuelto en comillas es JSON válido y orjson le quita las
comillas → el `name` resultante no existe → resultado vacío → se interpreta como "no validado".
(La API Python `frappe.db.get_value` es inmune: usa param-binding; el defecto es exclusivo del
borde HTTP.)

## Cambios principales
- `fc3f208` — fix:
  - Uso consistente de filtros `{ name: customer_name }` en los 6 call-sites de Customer
    (2 en factura_fiscal_mexico.js, 4 en sales_invoice.js).
  - Consolidación de los 2 handlers `customer` duplicados en `apply_customer_defaults(frm)`.
  - Eliminación del handler `cost_center` duplicado redundante (sin comportamiento exclusivo).
  - `_check_rfc_and_show_timbrar`: una sola lectura `{ name }` de `tax_id` + `fm_rfc_validated`
    (elimina la doble consulta vía `has_customer_rfc`).
  - Se conserva el bloqueo del botón para clientes sin RFC o sin validación SAT, más una alerta
    visible ante error de lectura del Customer.
  - Tests: 6 dinámicos (borde servidor) + 4 estáticos (guarda del código JS).
- `572f93d` — test:
  - Supresión `# nosemgrep: frappe-manual-commit` en los `frappe.db.commit()` del test dinámico
    (convención del repo; exigido por el gate semgrep de /pr-ready).

## Documentación actualizada
Ninguna. No aplica — corrección de defecto y refactor interno, sin flujo/estado/funcionalidad
nueva visible al usuario. Sin ADR, sin cambios de MkDocs.

## Validaciones realizadas
- Tests aplicables: 6 dinámicos + 4 estáticos = 10/10 en test-facturacion.localhost
  (seed ci_pre_tests + --lightmode).
- Linters: ruff, prettier@2.7.1, eslint 8.44.0 — limpios. mkdocs build --strict — OK.
- No se ejecutó la suite completa del app (tiene fallas pre-existentes ajenas a este cambio).

## Fuera de alcance
- Validación funcional en navegador (no hay e2e); los tests cubren el borde servidor y la forma
  del código fuente JS, no el render del botón.
- Otras duplicaciones JS no relacionadas con lookups de Customer.

## Riesgos / pendientes
- La cobertura no incluye JS en navegador; el test estático es la salvaguarda contra regresión
  del patrón vulnerable en el código.

Ref: defecto de docnames de Customer con caracteres especiales (sin issue asociado).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Customer lookups to reliably resolve records even when docnames include quotes/special characters, by using explicit `{ name: ... }` filters.
  * Corrected RFC validation and stamping/visibility checks for Sales and Fiscal Invoices, ensuring tax ID and validation status are evaluated consistently.
  * Improved application of Customer defaults in the Sales Invoice UI, consolidating duplicated handlers and improving server query reliability.

* **Tests**
  * Added regression tests for safe Customer docname lookups across edge cases.
  * Added static JS tests to prevent unsafe Customer lookup patterns from reappearing.

* **Documentation**
  * Updated continuity guidance to reflect the active fix and operational testing constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->