### PR TITLE
fix(cfdi): resiliencia de cancelación de sustitución motivo 01 ante 404 transitorio del PAC

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,107 +1,64 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-07-13
-**Rama activa:** `fix/customer-docname-safe-lookups`
-**Tarea actual:** Fix — lookups de Customer en JS fallan cuando el docname tiene caracteres especiales (comillas). En fase de PR (flujo `/ship`).
+**Fecha:** 2026-07-17
+**Rama activa:** `fix/cascade-cancel-01-transient-404-and-doc-reconcile`
+**Tarea actual:** Fix — resiliencia de la cancelación de sustitución (motivo 01) ante fallos transitorios del PAC. En fase de commit (flujo `/ship`).
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Corrección de un defecto reportado: un cliente cuyo docname va entre comillas dobles (ejemplo
-ficticio `"EMPRESA DEMO SA"`) — con las comillas como parte del docname — no permitía timbrar la SI,
-mostrando falsamente "el RFC del cliente no está validado con SAT" aunque `fm_rfc_validated=1`.
-Causa raíz: el JS leía Customer con `frappe.db.get_value("Customer", frm.doc.customer, …)`
-pasando el docname como string suelto; en el servidor `get_safe_filters`/orjson interpreta el
-nombre entre comillas como JSON y le quita las comillas → no encuentra al cliente. Fix: filtro
-explícito `{ name: … }`.
+Corrección de un defecto real en el flujo de sustitución motivo 01. Al timbrar el CFDI sustituto (B),
+la cascada cancela el original (A) con `TipoRelación = 04`; un `404 invoice_not_found` transitorio del
+PAC (consistencia eventual justo tras timbrar B) rompía el flujo y presentaba el timbrado exitoso de B
+como error. La prueba de integración real (par A=`FFMX-2026-00045` / B=`FFMX-2026-00046`, FacturAPI TEST)
+reprodujo el 404 de forma natural y destapó **tres defectos**: (1) B mostrado como error; (2) la
+recuperación diferida no cancelaba nunca porque `cancelar_factura` exige `TIMBRADO` y devolvía
+`{success: False}` sin excepción; (3) `run_auto_reconciliation` revertía `PENDIENTE_CANCELACION → TIMBRADO`
+(valid/none) destruyendo la cancelación en curso.
 
 Plan que estoy siguiendo:
-Fix de defecto + eliminación de duplicación JS (instrucción del usuario: no limitar a las 3
-llamadas; barrer toda la app, consolidar lógica duplicada, agregar tests de regresión).
+Fix mínimo y proporcionado (sin campos nuevos, sin contadores, un solo scheduler): reintentos inmediatos
+(0.5s/1s) → `PENDIENTE_CANCELACION` sin falsear el timbrado → scheduler cada minuto con throttle escalonado
+y corte 2h → guard interno `_allow_pending_cancellation` (manual sigue exigiendo TIMBRADO) + manejo de
+`{success: False}` → protección Gap 2 en reconciliación (no revertir sustitución vigente) → convergencia
+documental idempotente. UX: mensaje amarillo, nunca falso error. Detalle en ADR-0037.
 
 Objetivo inmediato:
-PR #213 abierto (base `main`), CI verde. Commits en rama: `fc3f208` (fix) + `572f93d` (nosemgrep)
-+ commit de scrub de PII y rename CodeRabbit (este). Falta: push del último commit, quitar el
-nombre de ejemplo de la descripción del PR, y squash-merge (el merge lo ejecuta el usuario).
+Commit en la rama (flujo `/ship commit`), con código + tests + documentación exigida por el gate.
+Sin push, sin PR (pendientes de autorización separada).
 
 Criterio de avance:
-Tests verdes (10/10) + linters limpios + CI del PR en verde + ninguna aparición del nombre real
-de la empresa de ejemplo en archivos ni en la descripción del PR.
+Tests específicos verdes (`test_cascade_cancel_01_recovery` 15/15, `test_cancelacion_integridad` 37/37,
+Gap 2 en `test_ffm_reconciliation`) + linters limpios + `mkdocs build --strict` limpio + validación real
+en sandbox (A convergió a CANCELADO/docstatus=2, B TIMBRADO, XML `04 → UUID_A` PASS, local==PAC).
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- Diagnóstico probado: `get_safe_filters`/orjson mutila docnames JSON-parseables (envueltos
-  en comillas). Verificado contra `llantascs-v16.dev` (docname real con comillas, `fm_rfc_validated=1`).
-- App afectada confirmada: `facturacion_mexico` (provee el JS vía `doctype_js`). `facturacion_mx`
-  NO afectada (hooks JS comentados, sin el código) — no se toca.
-- 6 call-sites vulnerables corregidos a filtro `{ name }` (2 en `factura_fiscal_mexico.js`,
-  4 en `sales_invoice.js`).
-- Consolidación JS: 2 handlers `customer` duplicados → `apply_customer_defaults(frm)`;
-  eliminado `has_customer_rfc` (doble round-trip); `_check_rfc_and_show_timbrar` hace 1 sola
-  lectura `{name}` de `tax_id`+`fm_rfc_validated`; eliminado handler `cost_center` duplicado
-  redundante (CC-B); alerta roja de error preservada; `.catch` de paridad.
-- 2 tests nuevos: dinámico (borde servidor `frappe.client.get_value`) 6/6 + estático (guarda
-  del código JS contra reintroducir string suelto) 4/4. Re-verificados 10/10 tras el scrub.
-- PR #213 abierto y con CI verde. CodeRabbit: 1 nota Minor (variable de test en español) — aplicada.
-- Scrub de PII: el nombre real de la empresa de ejemplo y su RFC se reemplazaron por
-  `"EMPRESA DEMO SA"` en tests, comentario JS y CONTINUITY (no debe aparecer en búsquedas).
-- Linters: prettier@2.7.1 (versión del CI — v3 mete trailing commas espurias), eslint 8.44.0,
-  ruff — todos limpios. `git diff --check` OK.
+- **Cascada:** reintentos inmediatos transitorios (0.5s/1s); si se agotan, A → `PENDIENTE_CANCELACION`
+  + `fm_sync_status=pending` + `fm_sync_error`, sin `frappe.throw` (B queda TIMBRADO).
+- **Scheduler** `retry_pending_substitution_cancellations` (cron `* * * * *` en `hooks.py`): GET-first,
+  throttle escalonado anclado en `B.fecha_timbrado` + `fm_last_pac_sync` (rápido 5 min → ~5 min → corte 2h),
+  batch 50. Solo procesa orígenes de sustitución reales.
+- **Guard acotado:** `cancelar_factura(..., _allow_pending_cancellation=True)` (keyword-only) para el
+  reintento automático; manual intacto. Scheduler maneja excepción **y** `{success: False}`.
+- **Gap 2:** `_es_origen_sustitucion_vigente` en `ffm_reconciliation`; la reconciliación (solo-lectura)
+  no revierte `PENDIENTE_CANCELACION → TIMBRADO` de una sustitución con B TIMBRADO vigente.
+- **Gap 3 / documental:** `_complete_documental_cancellation` única e idempotente (cascada/scheduler/reconcile).
+- **UX:** `base_result.cancelacion_previa_pendiente` → mensaje amarillo en `factura_fiscal_mexico.js`.
+- **Tests:** nuevo `test_cascade_cancel_01_recovery.py` (15) + Gap 2 en `test_ffm_reconciliation.py` (2)
+  + adaptación de `test_cancelacion_integridad` al nuevo contrato.
+- **Docs (gate):** ADR-0037, `docs/usuario/cancelar-cfdi.md`, `docs/tecnico/arquitectura.md`,
+  `mkdocs.yml`, `docs/adr/index.md`.
+- **Validación real (sandbox FacturAPI TEST):** flujo completo verificado end-to-end.
 
-### En progreso
-- Rama `fix/customer-docname-safe-lookups`: commit `fc3f208` (fix, pusheado) + commit de
-  supresión `# nosemgrep` (recién creado). Falta `/ship push` del segundo + `/ship pr`.
-
-### Pendiente inmediato
-1. `/ship push` (2º commit) y `/ship pr` hacia `main`.
-2. Validación GUI del botón Timbrar con el cliente de comillas (los tests NO cubren el JS en
-   navegador — solo el borde servidor y la forma del código fuente).
-
-### No repetir
-- NO usar `npx prettier` sin fijar `@2.7.1` — la v3 reformatea trailing commas y ensucia el diff.
-- NO correr `bench run-tests --app … --module …`: el combo ignora el filtro y corre la suite
-  completa. Usar solo `--module` (sin `--app`).
-- NO correr tests de este app sin el seed `facturacion_mexico.tests.ci_pre_tests.run` + `--lightmode`.
-- NO tocar `facturacion_mx` — no está afectada.
-
----
-
-## Decisiones vigentes
-- Todo lookup de Customer desde JS debe usar filtro dict `{ name: customer }`, nunca el docname
-  como string suelto. La API Python `frappe.db.get_value` es inmune (param-binding); el defecto
-  es exclusivo del borde HTTP `frappe.client.get_value` (que pasa por `get_safe_filters`/orjson).
-- El servidor mantiene su validación fiscal independiente e inmune a comillas (usa
-  `getattr(customer_doc,…)` y SQL parametrizado).
-- Consolidación permitida solo donde había duplicación real de lógica de negocio; no crear
-  abstracción genérica que envuelva `get_value`.
-
----
-
-## Archivos relevantes ahora
-
-### Leer primero
-- `facturacion_mexico/public/js/sales_invoice.js` — `apply_customer_defaults`,
-  `_check_rfc_and_show_timbrar`, handler `cost_center` (CC-A).
-- `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js`
-  — lookups `fm_uso_cfdi_default`, `fm_allow_generic_rfc`.
-
-### Probablemente editar
-- (ninguno — fix cerrado, salvo feedback de revisión/PR)
-
-### No tocar
-- `facturacion_mexico/one_offs/*` — nunca commitear
-- `working_docs/active/*` — no van en este fix
-- `facturacion_mx` (otra app) — no afectada
-
----
-
-## Riesgos / cuidados
-- Los tests dinámicos requieren las instancias Redis del bench (13001 cache / 11001 queue) y el
-  seed `ci_pre_tests.run`; sin Redis fallan en el bootstrap de test-records de erpnext.
-- La cobertura de tests NO incluye el JS en navegador: si alguien revierte el JS a string suelto,
-  el test dinámico seguiría verde — por eso existe el test estático que sí lo detecta.
+### Pendiente / siguiente paso
+- Push + PR: requieren autorización explícita separada.
+- Incidentes **separados** (no en este fix): duplicación de nodos `cfdi:Traslado` (IVA 0%); sistema de
+  alertas en tiempo real; "error visual al timbrar hasta refresh".
+- Artefactos locales sin commitear (correcto): `one_offs/` de validación, `poc-playwright-demo/val01/`.
+- Servidor dev `facturacion-v16.dev:8888` levantado en tmux `serve_facturacion-v16_dev`.

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-07-17
 **Rama activa:** `fix/cascade-cancel-01-transient-404-and-doc-reconcile`
-**Tarea actual:** Fix — resiliencia de la cancelación de sustitución (motivo 01) ante fallos transitorios del PAC. En fase de commit (flujo `/ship`).
+**Tarea actual:** Fix — resiliencia de la cancelación de sustitución (motivo 01) ante fallos transitorios del PAC. **PR #214 abierto**; aplicando fixes post-review de CodeRabbit antes del merge.
 
 ---
 
@@ -39,6 +39,7 @@ en sandbox (A convergió a CANCELADO/docstatus=2, B TIMBRADO, XML `04 → UUID_A
 ## Estado actual
 
 ### Ya cerrado
+
 - **Cascada:** reintentos inmediatos transitorios (0.5s/1s); si se agotan, A → `PENDIENTE_CANCELACION`
   + `fm_sync_status=pending` + `fm_sync_error`, sin `frappe.throw` (B queda TIMBRADO).
 - **Scheduler** `retry_pending_substitution_cancellations` (cron `* * * * *` en `hooks.py`): GET-first,
@@ -55,10 +56,21 @@ en sandbox (A convergió a CANCELADO/docstatus=2, B TIMBRADO, XML `04 → UUID_A
 - **Docs (gate):** ADR-0037, `docs/usuario/cancelar-cfdi.md`, `docs/tecnico/arquitectura.md`,
   `mkdocs.yml`, `docs/adr/index.md`.
 - **Validación real (sandbox FacturAPI TEST):** flujo completo verificado end-to-end.
+- **Fix CI (commit `039a18f`):** `si.currency` en el test de recuperación (mismatch MXN/INR en `_Test Company`).
+- **Post-review CodeRabbit (PR #214):** aplicados 12 de 17 — company en cliente PAC (cascada y scheduler),
+  `{success: False}` en reintentos inmediatos, reconcile exige B TIMBRADO, lock `ffm:cascade` compartido en
+  reconciliación, pre-filtro de sustituciones antes del batch (anti-inanición), retorno documental veraz
+  (`completed`/`incomplete`), `canceled_at` real, rename a inglés, IDs únicos en test, docs (docstatus=2 en
+  usuario, MD040 en ADR).
 
 ### Pendiente / siguiente paso
-- Push + PR: requieren autorización explícita separada.
-- Incidentes **separados** (no en este fix): duplicación de nodos `cfdi:Traslado` (IVA 0%); sistema de
-  alertas en tiempo real; "error visual al timbrar hasta refresh".
-- Artefactos locales sin commitear (correcto): `one_offs/` de validación, `poc-playwright-demo/val01/`.
+
+- **Push** de estos fixes a la rama del PR #214 → luego **re-correr la prueba GUI** para confirmar que los
+  cambios de CodeRabbit no rompieron el flujo.
+- **Fuera de alcance / posible issue separado (CodeRabbit):** #6 clasificación estructural de errores PAC;
+  #8 defensa ante fallo de persistencia; #11 limpieza exhaustiva de fixtures de tests; #12 aislamiento de
+  tests con selector global.
+- Otros incidentes separados: duplicación `cfdi:Traslado` (IVA 0%); alertas en tiempo real; error visual al
+  timbrar hasta refresh.
+- Artefactos locales sin commitear (correcto): `one_offs/`, `poc-playwright-demo/val01/`.
 - Servidor dev `facturacion-v16.dev:8888` levantado en tmux `serve_facturacion-v16_dev`.

--- a/docs/adr/0037-resiliencia-cancelacion-sustitucion-motivo-01.md
+++ b/docs/adr/0037-resiliencia-cancelacion-sustitucion-motivo-01.md
@@ -1,0 +1,140 @@
+# ADR-0037 — Resiliencia de la cancelación de sustitución (motivo 01) ante fallos transitorios del PAC
+
+- **Estado:** Propuesto
+- **Fecha:** 2026-07-17
+- **Rama:** `fix/cascade-cancel-01-transient-404-and-doc-reconcile`
+- **Relacionado:** [[0013-arquitectura-sistema-cancelaciones-cfdi]] · [[0035-motor-reconciliacion-ffm]] (motor de reconciliación) · [[0036-integridad-proyeccion-cancelacion]] (clasificación fail-closed de cancelación)
+- **Extiende/corrige:** ADR-0035 y ADR-0036. No los reemplaza.
+
+---
+
+## 1. Contexto y defecto real observado
+
+En el flujo de sustitución motivo 01, tras timbrar el CFDI sustituto (B), una cascada cancela
+automáticamente el CFDI original (A) con `TipoRelación = 04` y `FolioSustitución = UUID_B`.
+
+En una prueba de integración real contra FacturAPI TEST (par A=`FFMX-2026-00045` / B=`FFMX-2026-00046`)
+se reprodujo **de forma natural** el defecto: el `DELETE` de A inmediatamente después de timbrar B
+devolvió **HTTP 404 `invoice_not_found`** (consistencia eventual del PAC: A existe y está timbrado,
+pero el PAC no lo resuelve por unos instantes). Evidencia en `FacturAPI Response Log` de A:
+
+- `00:52:02` Timbrado de B → 200
+- `00:52:08` Solicitud Cancelación de A → **404 `invoice_not_found`** (transitorio)
+- `01:21:21` Solicitud Cancelación de A → **200** (cuando el PAC ya lo resolvía)
+
+El diseño previo trataba ese 404 como fallo terminal y, peor, presentaba el timbrado **exitoso** de B
+como si hubiera fallado. Además, la prueba real destapó **tres defectos** que los tests con mock no
+podían ver:
+
+1. **Timbrado de B presentado como error** por un fallo que era solo de la cancelación de A.
+2. **La recuperación diferida no cancelaba nunca:** el guard de `cancelar_factura` exige
+   `fm_fiscal_status == TIMBRADO`; al reintentar A ya estaba en `PENDIENTE_CANCELACION`, el guard la
+   rechazaba y **devolvía `{success: False}` sin lanzar excepción**, que el scheduler ignoraba.
+3. **La reconciliación pasiva destruía la cancelación en curso:** `run_auto_reconciliation` veía A
+   `valid/none` (el DELETE no se había registrado) y `derive_cancellation_reconciliation` la revertía
+   `PENDIENTE_CANCELACION → TIMBRADO`, sacándola de la cola del scheduler → cancelación perdida y
+   **A y B ambos vigentes** (doble CFDI).
+
+## 2. Decisión
+
+### 2.1 Reintentos inmediatos acotados en la cascada
+
+Al timbrar B, la cancelación de A se intenta con reintentos **inmediatos y cortos** solo ante errores
+**transitorios** (`404 invoice_not_found`, `429`, `5xx`, timeouts, errores de conexión):
+
+```
+intento 1 (t0) → +0.5 s → +1.0 s     (ventana total ≤ ~1.5 s, dentro del request)
+```
+
+Si el error no es transitorio, no se reintenta.
+
+### 2.2 Transición a `PENDIENTE_CANCELACION` sin falsear el timbrado
+
+Si los reintentos inmediatos se agotan, la cascada **no lanza error** (el timbrado de B fue real y
+exitoso). A queda en `PENDIENTE_CANCELACION` + `fm_sync_status = pending` + `fm_sync_error` explicativo.
+B permanece `TIMBRADO`; SI/FFM de A intactos (docstatus sin tocar).
+
+### 2.3 Recuperación programada (scheduler dedicado)
+
+Una tarea `cron` **cada 1 minuto** (`retry_pending_substitution_cancellations`) redescubre los casos
+pendientes desde el estado en BD (no usa contadores ni jobs efímeros; sobrevive reinicios). Por cada A:
+
+- **GET-first**: consulta el estado remoto real de A.
+  - Si el PAC ya la reporta `canceled` → no reenvía DELETE; reconcilia + completa documental.
+  - Si sigue `valid` → envía **un** DELETE motivo 01 + `UUID_B` (vía `cancelar_factura` con el flag
+    interno `_allow_pending_cancellation`, ver §2.5).
+- Solo actúa si A es **origen de sustitución real**: existe una SI con
+  `ffm_substitution_source_uuid == A.fm_uuid` y su FFM está `TIMBRADO`. Cualquier cancelación ajena
+  (motivos 02/03/04, o pendientes sin sustituto) se ignora sin efectos.
+
+### 2.4 Throttle escalonado y corte temporal (anti-bloqueo del PAC)
+
+Anclados en `fecha_timbrado` de B (momento real en que A pasó a pendiente) y en `fm_last_pac_sync`:
+
+- **Ventana rápida** (primeros 5 min): 1 intento por tick de 1 minuto.
+- **Después**: 1 intento cada ~5 min (throttle vía `fm_last_pac_sync`).
+- **Corte total ~2 h**: pasada la ventana se abandona el ciclo automático → `fm_sync_status = error` +
+  `fm_sync_error` accionable (intervención manual). Evita ~120 DELETE para un caso prolongado.
+
+Cronología: `t0 → +0.5 s → +1 s → +1 → +2 → +3 → +4 → +5 min → luego ~cada 5 min → corte 2 h`.
+
+### 2.5 Guard acotado sin abrir el flujo manual
+
+La cancelación manual sigue exigiendo `TIMBRADO`. **Solo** el reintento automático pasa el flag
+keyword-only `_allow_pending_cancellation=True`, que permite reintentar una FFM en
+`PENDIENTE_CANCELACION`. El scheduler además maneja **ambas** formas de fallo: excepción **y** retorno
+`{success: False}` — clasificando transitorio (conservar pendiente) vs definitivo (salir del ciclo);
+nunca interpreta un fallo como éxito.
+
+### 2.6 Protección de la reconciliación (no revertir una sustitución en curso)
+
+En `run_auto_reconciliation` (que **sigue siendo estrictamente de solo lectura** ante el PAC: no envía
+DELETE, no cancela, no cambia su contrato), cuando A está `PENDIENTE_CANCELACION`, es origen de
+sustitución con B `TIMBRADO` vigente, y el PAC responde `valid/none`, **se conserva
+`PENDIENTE_CANCELACION`** en vez de aplicar la transición genérica `valid/none → TIMBRADO`. Así el
+scheduler dedicado puede seguir reintentando. La excepción está acotada exclusivamente a sustituciones
+motivo 01 verificables (`_es_origen_sustitucion_vigente`), no se generaliza a cualquier pendiente.
+
+### 2.7 Convergencia documental
+
+La cancelación fiscal (`status = CANCELADO`) y la documental (`docstatus = 2` de SI y FFM) están
+separadas. `_complete_documental_cancellation` es la **única** implementación (reutilizada por cascada,
+scheduler y reconciliación), idempotente: si ambos ya están en `docstatus = 2` no hace nada. Si A queda
+`CANCELADO` con `docstatus = 1` (p. ej. proceso interrumpido), la reconciliación completa el documental
+sin reenviar DELETE.
+
+### 2.8 UX
+
+El timbrado de B se reporta **siempre como éxito**. Cuando A queda pendiente, la respuesta al frontend
+incluye `cancelacion_previa_pendiente = true` y el formulario muestra un mensaje **amarillo** (no un
+error): *"Factura sustituta timbrada correctamente. La cancelación del CFDI anterior quedó pendiente y
+el sistema continuará reintentándola automáticamente."* La fuente de verdad es el estado del documento
+(A en `PENDIENTE_CANCELACION`).
+
+## 3. Alternativas descartadas
+
+- **Reintento ciego con `sleep` fijo (1.5 s / 3 s):** arbitrario y bloquea el request; rechazado.
+- **Diseño durable sobredimensionado:** máquina de estados multinivel con campos nuevos
+  (`cancellation_retry_count`, `last_retry_at`, `next_retry_at`), múltiples schedulers (30 s / 60 s /
+  5 min) y persistencia de acuses. **Desproporcionado** para un 404 intermitente y raro. Se descartó a
+  favor del diseño mínimo actual: sin campos nuevos, sin contadores, un solo scheduler, durabilidad vía
+  el estado ya persistido (`PENDIENTE_CANCELACION` / `fm_sync_status = pending`).
+- **Validar el XML timbrado antes de cancelar A:** requeriría una descarga extra justo en la ventana de
+  consistencia eventual (reintroduce el 404) y añade latencia/timeout de UX. Se prefiere validar contra
+  la respuesta de `create_invoice` (coste ~0) y dejar la validación del XML como verificación posterior.
+
+## 4. Consecuencias
+
+- El timbrado de B nunca se presenta como error por un fallo de cancelación de A.
+- La cancelación de A es **fail-closed**: nunca se marca `CANCELADO` en falso; converge cuando el PAC lo
+  permite, o sale a intervención tras ~2 h.
+- La reconciliación pasiva ya no destruye una cancelación de sustitución en curso.
+- Sin cambios de esquema (no requiere `bench migrate`). Requiere que el scheduler esté activo para la
+  recuperación diferida.
+
+## 5. Fuera de alcance (incidentes separados)
+
+- Duplicación de nodos `cfdi:Traslado` (IVA 0%) observada en A y B — problema general de generación de
+  impuestos, ajeno a este fix.
+- Sistema de alertas en tiempo real de facturación.
+- "Error visual al timbrar hasta refrescar" reportado en producción.

--- a/docs/adr/0037-resiliencia-cancelacion-sustitucion-motivo-01.md
+++ b/docs/adr/0037-resiliencia-cancelacion-sustitucion-motivo-01.md
@@ -42,8 +42,9 @@ podían ver:
 Al timbrar B, la cancelación de A se intenta con reintentos **inmediatos y cortos** solo ante errores
 **transitorios** (`404 invoice_not_found`, `429`, `5xx`, timeouts, errores de conexión):
 
-```
-intento 1 (t0) → +0.5 s → +1.0 s     (ventana total ≤ ~1.5 s, dentro del request)
+```text
+intento 1 (t0) → espera 0.5 s → intento 2 → espera 1.0 s → intento 3 (≈ +1.5 s acumulado)
+(3 intentos, ventana total ≈ 1.5 s, dentro del request)
 ```
 
 Si el error no es transitorio, no se reintenta.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -40,3 +40,4 @@ Registro permanente de decisiones de arquitectura. Un ADR nunca se modifica — 
 | [0034](0034-integridad-correlacion-ffm.md) | Integridad y correlación de Factura Fiscal Mexico |
 | [0035](0035-motor-reconciliacion-ffm.md) | Motor de reconciliación FFM ↔ FacturAPI |
 | [0036](0036-integridad-proyeccion-cancelacion.md) | Integridad de la proyección de cancelación y consolidación del flujo manual |
+| [0037](0037-resiliencia-cancelacion-sustitucion-motivo-01.md) | Resiliencia de la cancelación de sustitución (motivo 01) ante fallos transitorios del PAC |

--- a/docs/tecnico/arquitectura.md
+++ b/docs/tecnico/arquitectura.md
@@ -149,6 +149,37 @@ Campos relevantes definidos directamente en el JSON del DocType (no como Custom 
 - **Guard de cancelación de la SI:** `cancelar_si_post_fiscal` valida el estado **real** de la FFM activa,
   no el snapshot derivado `SI.fm_fiscal_status`.
 
+### Resiliencia de la cancelación de sustitución (motivo 01)
+
+> Decisiones y detalle en [ADR-0037](../adr/0037-resiliencia-cancelacion-sustitucion-motivo-01.md).
+
+Al timbrar el CFDI sustituto (B), la cascada cancela el original (A) con `TipoRelación = 04`. Ante un
+fallo **transitorio** del PAC (p. ej. `404 invoice_not_found` por consistencia eventual justo tras
+timbrar B), el flujo es resiliente **sin falsear el timbrado de B**:
+
+- **Reintentos inmediatos** en la cascada: intento `t0` → `+0.5 s` → `+1 s`, solo para errores
+  transitorios (`_is_transient_pac_error`: `404 invoice_not_found`, `429`, `5xx`, timeouts, conexión).
+- Si se agotan, A queda **`PENDIENTE_CANCELACION`** + `fm_sync_status = pending` + `fm_sync_error`; B
+  permanece `TIMBRADO` y la cascada **no lanza error** (nunca usa `frappe.throw`).
+- **Scheduler dedicado** (`retry_pending_substitution_cancellations`, cron `* * * * *` en `hooks.py`):
+  GET-first del estado real de A → si `canceled` reconcilia + completa documental; si `valid` envía **un**
+  DELETE motivo 01 + `UUID_B`. Solo procesa A que sea **origen de sustitución real** (existe SI con
+  `ffm_substitution_source_uuid == A.fm_uuid` y su FFM `TIMBRADO`); cualquier cancelación ajena se ignora.
+- **Throttle escalonado** anclado en `B.fecha_timbrado` y `fm_last_pac_sync`: ventana rápida (1/min los
+  primeros 5 min) → luego ~1 intento/5 min → **corte a ~2 h** (`fm_sync_status = error`, intervención).
+- **Guard acotado:** `cancelar_factura(..., _allow_pending_cancellation=True)` (flag interno keyword-only)
+  permite reintentar una FFM `PENDIENTE_CANCELACION`; la cancelación **manual** sigue exigiendo `TIMBRADO`.
+  El scheduler maneja **excepción** y **retorno `{success: False}`** (nunca interpreta un fallo como éxito).
+- **Protección de la reconciliación (Gap 2):** `run_auto_reconciliation` sigue **solo-lectura** (no envía
+  DELETE ni cancela), pero **no revierte** `PENDIENTE_CANCELACION → TIMBRADO` cuando A es origen de
+  sustitución con B `TIMBRADO` vigente y el PAC responde `valid/none` (`_es_origen_sustitucion_vigente`),
+  para que el scheduler pueda seguir reintentando.
+- **Convergencia documental (fail-closed e idempotente):** `_complete_documental_cancellation` es la única
+  implementación (cascada, scheduler y reconciliación); baja SI y FFM a `docstatus = 2` solo tras `CANCELADO`
+  real, y no hace nada si ya está convergido. Nunca se marca `CANCELADO` sin confirmación del PAC.
+
+Sin cambios de esquema (no requiere `bench migrate`); la recuperación diferida exige el scheduler activo.
+
 ## Integraciones externas
 
 | Sistema | Uso | Configuración |

--- a/docs/usuario/cancelar-cfdi.md
+++ b/docs/usuario/cancelar-cfdi.md
@@ -79,6 +79,28 @@ El sistema envía la cancelación con `TipoRelación = 04` (sustitución).
 
 La cancelación motivo 01 generalmente es inmediata (`CANCELADO`). El SAT vincula ambos CFDIs mediante la relación.
 
+#### Si la cancelación del CFDI anterior queda pendiente
+
+A veces el PAC no procesa la cancelación del CFDI original en el mismo instante en que se timbra el
+sustituto (un desfase momentáneo del servicio). En ese caso verás un mensaje **amarillo** (no un error):
+
+> **Factura sustituta timbrada correctamente. La cancelación del CFDI anterior quedó pendiente y el
+> sistema continuará reintentándola automáticamente.**
+
+Qué significa:
+
+- **La factura sustituta SÍ quedó timbrada** correctamente. No es un error de timbrado.
+- El CFDI **anterior** queda en **`PENDIENTE_CANCELACION`**: su cancelación se solicitó pero el PAC aún
+  no la confirmó.
+- **No tienes que hacer nada.** El sistema reintenta la cancelación automáticamente (con más frecuencia
+  en los primeros minutos y luego cada pocos minutos). Cuando el PAC la confirma, el CFDI anterior pasa
+  a `CANCELADO` solo.
+- Si tras un periodo prolongado no se logra, el CFDI anterior se marca para **revisión manual** (queda
+  con un mensaje indicando que requiere intervención).
+
+> El sistema **nunca** marca un CFDI como cancelado sin la confirmación real del PAC: mientras esté
+> `PENDIENTE_CANCELACION`, el CFDI anterior sigue vigente ante el SAT.
+
 ---
 
 ## Estado después de cancelar

--- a/docs/usuario/cancelar-cfdi.md
+++ b/docs/usuario/cancelar-cfdi.md
@@ -107,7 +107,9 @@ Qué significa:
 
 El campo `fm_fiscal_status` en el Sales Invoice cambia a `CANCELADO` (o `PENDIENTE_CANCELACION` mientras espera al receptor).
 
-El Sales Invoice permanece en ERPNext — la cancelación fiscal no implica cancelar el documento ERPNext.
+En general, el Sales Invoice **permanece** en ERPNext — la cancelación fiscal no implica cancelar el documento ERPNext.
+
+**Excepción — sustitución (motivo 01):** cuando el CFDI anterior se cancela por sustitución, al confirmarse la cancelación el sistema **sí cancela también el documento ERPNext**: el Sales Invoice y su Factura Fiscal Mexico originales pasan a `docstatus = 2` (cancelados). Si la cancelación quedó `PENDIENTE_CANCELACION`, esto ocurre cuando la cancelación se confirma (de inmediato o por el reintento automático).
 
 ---
 

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -898,6 +898,17 @@
 							},
 							ALERT_DURATION_DEFAULT
 						);
+						// Sustitución (motivo 01): B timbró OK pero la cancelación del CFDI anterior
+						// quedó pendiente. NO es un error de timbrado; se informa en amarillo.
+						if (r.message.cancelacion_previa_pendiente) {
+							frappe.msgprint({
+								title: __("Cancelación anterior pendiente"),
+								indicator: "yellow",
+								message: __(
+									"Factura sustituta timbrada correctamente. La cancelación del CFDI anterior quedó pendiente y el sistema continuará reintentándola automáticamente."
+								),
+							});
+						}
 						frm.reload_doc();
 					} else if (r.message && r.message.user_error) {
 						// Mostrar error amigable del PAC

--- a/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
@@ -241,7 +241,11 @@ def _reconcile_ffm(ffm_name: str) -> dict:
 			# docstatus=1, completar la cancelación DOCUMENTAL pendiente (idempotente, sin tocar el PAC).
 			if fiscal_status == FiscalStates.CANCELADO:
 				try:
-					_reconcile_substitution_documental(ffm)
+					# Serializar con cascada/scheduler: el helper documental hace clear-links + cancel().
+					# Se usa el MISMO lock por-documento que ellos (`ffm:cascade:{ffm}`) para evitar
+					# carreras (dos flujos cancelando/limpiando links del mismo caso a la vez).
+					with frappe.cache().lock(f"ffm:cascade:{ffm.name}", timeout=30):
+						_reconcile_substitution_documental(ffm)
 				except Exception as e:
 					frappe.logger().error(f"Reconcile documental sustitución {ffm.name}: {e}")
 
@@ -296,15 +300,16 @@ def _reconcile_substitution_documental(ffm):
 	"""Completa la cancelación DOCUMENTAL de una FFM que es ORIGEN de una sustitución motivo 01,
 	cuando ya está fiscalmente CANCELADA pero sus documentos siguen docstatus=1.
 
-	Acotado y seguro: solo actúa si existe un CFDI (Sales Invoice) que la relaciona vía
-	`ffm_substitution_source_uuid = ffm.fm_uuid`. NO llama al PAC. Idempotente. No aplica a
-	cancelaciones normales (02/03/04) porque estas no dejan un CFDI sustituto relacionado.
+	Acotado y seguro: solo actúa si existe un CFDI sustituto (B) **TIMBRADO** que la relaciona vía
+	`ffm_substitution_source_uuid = ffm.fm_uuid` (mismo criterio que `_es_origen_sustitucion_vigente`,
+	para no cancelar documentalmente A por un sustituto en borrador o fallido). NO llama al PAC.
+	Idempotente. No aplica a cancelaciones normales (02/03/04).
 	"""
 	uuid = (getattr(ffm, "fm_uuid", "") or "").strip()
 	if not uuid:
 		return
-	if not frappe.db.exists("Sales Invoice", {"ffm_substitution_source_uuid": uuid}):
-		return  # no es origen de sustitución → no tocar documentos
+	if not _es_origen_sustitucion_vigente(ffm):
+		return  # no es origen de una sustitución con B TIMBRADO vigente → no tocar documentos
 
 	si_name = ffm.sales_invoice or frappe.db.get_value(
 		"Sales Invoice", {"fm_factura_fiscal_mx": ffm.name}, "name"

--- a/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/services/ffm_reconciliation.py
@@ -202,6 +202,21 @@ def _reconcile_ffm(ffm_name: str) -> dict:
 		else:
 			fiscal_status, sync_status = derive_pac_reconciliation(remote_status, cancellation_status)
 
+		# GAP 2: no dejar que la reconciliación PASIVA destruya una cancelación de SUSTITUCIÓN en curso.
+		# Si A está PENDIENTE_CANCELACION, es ORIGEN de una sustitución motivo 01 con sustituto (B)
+		# TIMBRADO vigente, y la reconciliación derivaría TIMBRADO (valid/none = el DELETE aún no se
+		# registró en el PAC), se CONSERVA PENDIENTE_CANCELACION + pending para que el scheduler dedicado
+		# siga reintentando. run_auto_reconciliation NO envía DELETE ni cancela nada: solo evita borrar
+		# un estado de cancelación activa con evidencia de sustitución. Acotado a este caso exacto.
+		if (
+			is_cancellation
+			and fiscal_status == FiscalStates.TIMBRADO
+			and ffm.status == FiscalStates.PENDIENTE_CANCELACION
+			and _es_origen_sustitucion_vigente(ffm)
+		):
+			fiscal_status = FiscalStates.PENDIENTE_CANCELACION
+			sync_status = SyncStates.PENDING
+
 		status_changed = fiscal_status is not None and fiscal_status != ffm.status
 		sync_changed = sync_status != ffm.fm_sync_status
 
@@ -220,6 +235,15 @@ def _reconcile_ffm(ffm_name: str) -> dict:
 			repaired = apply_cancellation_state(
 				ffm.name, fiscal_status, sync_status=sync_status, cancellation_date=_cdate
 			)
+
+			# Sustitución motivo 01: si el CFDI quedó CANCELADO y es ORIGEN de una sustitución (existe
+			# un CFDI que lo relaciona vía ffm_substitution_source_uuid) con documentos aún en
+			# docstatus=1, completar la cancelación DOCUMENTAL pendiente (idempotente, sin tocar el PAC).
+			if fiscal_status == FiscalStates.CANCELADO:
+				try:
+					_reconcile_substitution_documental(ffm)
+				except Exception as e:
+					frappe.logger().error(f"Reconcile documental sustitución {ffm.name}: {e}")
 
 		if status_changed or sync_changed or repaired:
 			# El writer crea el Response Log correlacionado. En cancelación NO persiste el estado
@@ -249,6 +273,51 @@ def _reconcile_ffm(ffm_name: str) -> dict:
 		return {"ffm": ffm_name, "outcome": "unchanged"}
 	finally:
 		_release_lock(lock, token)
+
+
+def _es_origen_sustitucion_vigente(ffm) -> bool:
+	"""True si esta FFM es ORIGEN de una sustitución motivo 01 con sustituto (B) TIMBRADO vigente:
+	existe un Sales Invoice cuyo ffm_substitution_source_uuid == ffm.fm_uuid y cuya FFM está TIMBRADO.
+	Acotado: NO aplica a cancelaciones normales (02/03/04), que no dejan un sustituto relacionado."""
+	uuid = (getattr(ffm, "fm_uuid", "") or "").strip()
+	if not uuid:
+		return False
+	b_si = frappe.db.get_value("Sales Invoice", {"ffm_substitution_source_uuid": uuid}, "name")
+	if not b_si:
+		return False
+	return bool(
+		frappe.db.get_value(
+			"Factura Fiscal Mexico", {"sales_invoice": b_si, "status": FiscalStates.TIMBRADO}, "name"
+		)
+	)
+
+
+def _reconcile_substitution_documental(ffm):
+	"""Completa la cancelación DOCUMENTAL de una FFM que es ORIGEN de una sustitución motivo 01,
+	cuando ya está fiscalmente CANCELADA pero sus documentos siguen docstatus=1.
+
+	Acotado y seguro: solo actúa si existe un CFDI (Sales Invoice) que la relaciona vía
+	`ffm_substitution_source_uuid = ffm.fm_uuid`. NO llama al PAC. Idempotente. No aplica a
+	cancelaciones normales (02/03/04) porque estas no dejan un CFDI sustituto relacionado.
+	"""
+	uuid = (getattr(ffm, "fm_uuid", "") or "").strip()
+	if not uuid:
+		return
+	if not frappe.db.exists("Sales Invoice", {"ffm_substitution_source_uuid": uuid}):
+		return  # no es origen de sustitución → no tocar documentos
+
+	si_name = ffm.sales_invoice or frappe.db.get_value(
+		"Sales Invoice", {"fm_factura_fiscal_mx": ffm.name}, "name"
+	)
+	si_ds = frappe.db.get_value("Sales Invoice", si_name, "docstatus") if si_name else 2
+	if ffm.docstatus == 2 and si_ds in (2, None):
+		return  # ya convergido
+
+	from facturacion_mexico.facturacion_fiscal.timbrado_api import (
+		_complete_documental_cancellation,
+	)
+
+	_complete_documental_cancellation(ffm.name, si_name)
 
 
 @frappe.whitelist()

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cancelacion_integridad.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cancelacion_integridad.py
@@ -633,12 +633,14 @@ class TestCancelacionIntegridad(IntegrationTestCase):
 		frappe.db.set_value("Sales Invoice", new_si, "ffm_substitution_source_uuid", src_uuid)
 		frappe.db.commit()
 
-		# PAC deja la cancelación NO terminal (no marca CANCELADO la FFM previa).
+		# PAC deja la cancelación NO terminal (no marca CANCELADO la FFM previa). Con el diseño
+		# simplificado, la cascada NO rompe el timbrado de B: deja A en PENDIENTE_CANCELACION para el
+		# reintento diferido (scheduler). Garantías core intactas: A no se cancela falsamente, SI viva.
 		with patch.object(
 			tmod.TimbradoAPI, "cancelar_factura", return_value={"status_ffm": "PENDIENTE_CANCELACION"}
 		):
 			res = tmod._cascade_cancel_previous_after_substitute(new_ffm)
-		self.assertEqual(res.get("cascade"), "halted_not_terminal")
+		self.assertEqual(res.get("cascade"), "pending_cancellation")
 		self.assertNotEqual(self._status(orig_ffm), FiscalStates.CANCELADO)
 		self.assertEqual(frappe.db.get_value("Sales Invoice", orig_si, "docstatus"), 1)  # SI NO cancelada
 

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cascade_cancel_01_recovery.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cascade_cancel_01_recovery.py
@@ -63,6 +63,11 @@ class TestCascadeCancel01Recovery(FrappeTestCase):
 		)
 		self.company = self.debit_to.company
 		self.debit_to = self.debit_to.name
+		# Moneda del documento = moneda de la cuenta por cobrar (o la de la empresa). Evita el
+		# mismatch "currency (MXN) vs document currency (INR)" en CI, donde la SI defaultea a INR.
+		self.si_currency = frappe.db.get_value(
+			"Account", self.debit_to, "account_currency"
+		) or frappe.db.get_value("Company", self.company, "default_currency")
 		self.income_acc = frappe.db.get_value(
 			"Account", {"company": self.company, "root_type": "Income", "is_group": 0}, "name"
 		)
@@ -139,6 +144,7 @@ class TestCascadeCancel01Recovery(FrappeTestCase):
 				"doctype": "Sales Invoice",
 				"company": self.company,
 				"customer": self.customer.name,
+				"currency": self.si_currency,
 				"cost_center": self.cc,
 				"debit_to": self.debit_to,
 				"items": [

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cascade_cancel_01_recovery.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cascade_cancel_01_recovery.py
@@ -1,0 +1,504 @@
+"""Regresión del fix (SIMPLIFICADO) de recuperación de la cascada de sustitución motivo 01.
+
+Cronología del fix: intento inmediato → +0.5s → +1.0s (solo errores transitorios) dentro del
+request; si se agota, A queda PENDIENTE_CANCELACION + fm_sync_status='pending' SIN falsear el
+timbrado de B; un scheduler (cada 1 min) la retoma con GET-first.
+
+Cubre:
+  (1) cancelación inmediata OK;
+  (2) transitorio recuperado por reintento inmediato;
+  (3) reintentos inmediatos agotados → PENDIENTE (sin falso error de timbrado);
+  (4) cancelación fiscal ya ocurrida → reconciliar documentos;
+  (5) idempotencia;
+  (6) scheduler: A 'valid' → reenvía 1 DELETE y cancela;
+  (7) scheduler: A ya 'canceled' → no reenvía, reconcilia;
+  (8) scheduler: error definitivo → sale del ciclo automático (fm_sync_status='error');
+  (9) unidad: clasificación de errores transitorios.
+
+Único boundary mockeado: el PAC (`TimbradoAPI` y sus métodos, que en producción llaman a
+FacturAPI). Todo lo demás usa el código real. `time.sleep` se neutraliza para no ralentizar.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.config.fiscal_states_config import FiscalStates
+from facturacion_mexico.facturacion_fiscal import timbrado_api as T
+
+
+def _codigo(v):
+	return str(v).split(" - ")[0].split(" ")[0].strip()
+
+
+class _FakeCancelClient:
+	"""Cliente FacturAPI falso SOLO en el boundary HTTP: deja correr el código real de
+	cancelar_factura (incluido su guard de estado). GET->valid, DELETE->canceled/accepted."""
+
+	def __init__(self):
+		self.cancel_calls = []
+
+	def get_invoice(self, fid):
+		return {"raw_response": {"status": "valid"}}
+
+	def cancel_invoice(self, fid, motivo, uuid):
+		self.cancel_calls.append((fid, motivo, uuid))
+		return {"raw_response": {"status": "canceled", "cancellation_status": "accepted"}}
+
+	# El acuse se descarga best-effort (try/except en el código); no es parte de la aserción.
+	def download_cancellation_receipt_pdf(self, fid):
+		raise Exception("no-op en test")
+
+	def download_cancellation_receipt_xml(self, fid):
+		raise Exception("no-op en test")
+
+
+class TestCascadeCancel01Recovery(FrappeTestCase):
+	def setUp(self):
+		self.h = frappe.generate_hash()[:6]
+		# Company con cuenta por cobrar configurada (para poder crear/submit SI).
+		self.debit_to = frappe.db.get_value(
+			"Account", {"account_type": "Receivable", "is_group": 0}, ["name", "company"], as_dict=True
+		)
+		self.company = self.debit_to.company
+		self.debit_to = self.debit_to.name
+		self.income_acc = frappe.db.get_value(
+			"Account", {"company": self.company, "root_type": "Income", "is_group": 0}, "name"
+		)
+		self.cg = frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+		self.terr = frappe.db.get_value("Territory", {"is_group": 0}, "name")
+		self.cc = frappe.db.get_value("Cost Center", {"is_group": 0, "company": self.company}, "name")
+		# Ítem determinista: grupo garantizado por el seed ("Products") + clave SAT válida.
+		# Evita ítems basura de otras suites que referencian Item Groups inexistentes.
+		self.item = f"FM-CASCADE-{self.h}"
+		if not frappe.db.exists("Item", self.item):
+			ig = frappe.db.get_value("Item Group", "Products", "name") or frappe.db.get_value(
+				"Item Group", {"is_group": 0}, "name"
+			)
+			frappe.get_doc(
+				{
+					"doctype": "Item",
+					"item_code": self.item,
+					"item_name": self.item,
+					"item_group": ig,
+					"stock_uom": "Nos",
+					"is_stock_item": 0,
+					"is_sales_item": 1,
+					"fm_producto_servicio_sat": "84111506",
+				}
+			).insert(ignore_permissions=True)
+		# Catálogos SAT reales del site (fm_cfdi_use=Link Uso CFDI SAT; fm_forma_pago_timbrado=Link Mode of Payment).
+		self.uso_cfdi = frappe.db.get_value("Uso CFDI SAT", "G03", "name") or frappe.db.get_value(
+			"Uso CFDI SAT", {}, "name"
+		)
+		self.forma_pago = frappe.db.get_value("Mode of Payment", {}, "name")
+
+		self.customer = frappe.get_doc(
+			{
+				"doctype": "Customer",
+				"customer_name": f"CLI-{self.h}",
+				"customer_type": "Company",
+				"customer_group": self.cg,
+				"territory": self.terr,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value(
+			"Customer",
+			self.customer.name,
+			{
+				"tax_id": "XAXX010101000",
+				"fm_rfc_validated": 1,
+				"fm_uso_cfdi_default": "G03",
+				"fm_tax_regime": "601",
+			},
+		)
+
+		self.A_uuid = f"AAAA{self.h}-0000-0000-0000-000000000001".lower()
+		self.B_uuid = f"BBBB{self.h}-0000-0000-0000-000000000002".lower()
+
+	def tearDown(self):
+		# Limpieza dura: estos tests hacen commit (helpers + código productivo bajo prueba), así que
+		# las filas sobreviven al rollback de FrappeTestCase. Sin esto, las FFM que quedan en
+		# PENDIENTE_CANCELACION/pending contaminarían la suite de reconciliación.
+		super().tearDown()
+		for ffm in [getattr(self, "A_ffm", None), getattr(self, "B_ffm", None)]:
+			if ffm:
+				frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in [getattr(self, "A_si", None), getattr(self, "B_si", None)]:
+			if si:
+				frappe.db.delete("Sales Invoice Item", {"parent": si})
+				frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
+
+	# ---------------- helpers ----------------
+
+	def _mk_si(self, src_uuid=None):
+		si = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"company": self.company,
+				"customer": self.customer.name,
+				"cost_center": self.cc,
+				"debit_to": self.debit_to,
+				"items": [
+					{
+						"item_code": self.item,
+						"qty": 1,
+						"rate": 100,
+						"cost_center": self.cc,
+						"income_account": self.income_acc,
+					}
+				],
+			}
+		)
+		if src_uuid:
+			si.set("ffm_substitution_source_uuid", src_uuid)
+		si.insert(ignore_permissions=True)
+		si.submit()
+		return si.name
+
+	def _mk_ffm_timbrado(self, si_name, uuid):
+		"""FFM submitted en estado TIMBRADO con UUID/facturapi_id (sin llamar al PAC)."""
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			get_or_create_active_ffm,
+		)
+
+		ffm_name = get_or_create_active_ffm(si_name)
+		ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
+		if not ffm.get("fm_cfdi_use") and self.uso_cfdi:
+			ffm.fm_cfdi_use = self.uso_cfdi
+		if not ffm.get("fm_tax_system"):
+			ffm.fm_tax_system = "601"
+		if not ffm.get("fm_forma_pago_timbrado") and self.forma_pago:
+			ffm.fm_forma_pago_timbrado = self.forma_pago
+		ffm.fm_payment_method_sat = "PPD"
+		ffm.save(ignore_permissions=True)
+		if ffm.docstatus == 0:
+			ffm.submit()
+		frappe.db.set_value(
+			"Factura Fiscal Mexico",
+			ffm_name,
+			{
+				"status": FiscalStates.TIMBRADO,
+				"fm_uuid": uuid,
+				"facturapi_id": f"fapi_{uuid[:12]}",
+				"fecha_timbrado": frappe.utils.now_datetime(),
+			},
+		)
+		frappe.db.commit()
+		return ffm_name
+
+	def _build_A_B(self):
+		self.A_si = self._mk_si()
+		self.A_ffm = self._mk_ffm_timbrado(self.A_si, self.A_uuid)
+		self.B_si = self._mk_si(src_uuid=self.A_uuid)
+		self.B_ffm = self._mk_ffm_timbrado(self.B_si, self.B_uuid)
+
+	def _pac_ok(self, *a, **k):
+		"""Mock: PAC acepta → deja A en CANCELADO (como haría apply_cancellation_state).
+		Sin commit: en la misma transacción el set_value ya es visible para la cascada."""
+		frappe.db.set_value("Factura Fiscal Mexico", self.A_ffm, "status", FiscalStates.CANCELADO)
+		return {"status": "accepted"}
+
+	def _pac_404(self, *a, **k):
+		raise frappe.ValidationError("Error FacturAPI 404: invoice_not_found - No se encontró la factura.")
+
+	def _ds(self, doctype, name):
+		return frappe.db.get_value(doctype, name, "docstatus")
+
+	# ---------------- TESTS ----------------
+
+	def test_1_cancelacion_inmediata_ok(self):
+		self._build_A_B()
+		with patch.object(T, "TimbradoAPI") as MockAPI:
+			MockAPI.return_value.cancelar_factura.side_effect = self._pac_ok
+			res = T._cascade_cancel_previous_after_substitute(self.B_ffm)
+		self.assertEqual(res.get("cascade"), "completed")
+		self.assertEqual(self._ds("Sales Invoice", self.A_si), 2, "SI A debe quedar docstatus=2")
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 2, "FFM A debe quedar docstatus=2")
+
+	def test_2_404_transitorio_reintento_ok(self):
+		self._build_A_B()
+		seq = [self._pac_404, self._pac_ok]
+
+		def side(*a, **k):
+			return seq.pop(0)(*a, **k)
+
+		with (
+			patch("facturacion_mexico.facturacion_fiscal.timbrado_api.time.sleep"),
+			patch.object(T, "TimbradoAPI") as MockAPI,
+		):
+			MockAPI.return_value.cancelar_factura.side_effect = side
+			res = T._cascade_cancel_previous_after_substitute(self.B_ffm)
+		self.assertEqual(res.get("cascade"), "completed")
+		self.assertEqual(self._ds("Sales Invoice", self.A_si), 2)
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 2)
+
+	def test_3_reintentos_inmediatos_agotados_deja_pendiente(self):
+		"""404 transitorio persistente en la ventana inmediata: NO se falsea el timbrado de B.
+		A queda PENDIENTE_CANCELACION + fm_sync_status='pending' (para el scheduler), docstatus intactos."""
+		self._build_A_B()
+		with (
+			patch("facturacion_mexico.facturacion_fiscal.timbrado_api.time.sleep"),
+			patch.object(T, "TimbradoAPI") as MockAPI,
+		):
+			MockAPI.return_value.cancelar_factura.side_effect = self._pac_404
+			res = T._cascade_cancel_previous_after_substitute(self.B_ffm)
+		self.assertEqual(res.get("cascade"), "pending_cancellation")
+		self.assertEqual(self._ds("Sales Invoice", self.A_si), 1, "SI A NO debe cancelarse")
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 1, "FFM A NO debe cancelarse")
+		a = frappe.db.get_value(
+			"Factura Fiscal Mexico", self.A_ffm, ["status", "fm_sync_status", "fm_sync_error"], as_dict=True
+		)
+		self.assertEqual(a.status, FiscalStates.PENDIENTE_CANCELACION)
+		self.assertEqual(a.fm_sync_status, "pending", "debe quedar en la cola del scheduler")
+		self.assertTrue(a.fm_sync_error, "debe explicar por qué quedó pendiente")
+
+	def test_4_cancelacion_fiscal_ya_ocurrida_reconcilia_documentos(self):
+		self._build_A_B()
+		# Fiscal ya CANCELADO (por reconcile/reintento previo) pero documentos aún docstatus=1.
+		frappe.db.set_value("Factura Fiscal Mexico", self.A_ffm, "status", FiscalStates.CANCELADO)
+		frappe.db.commit()
+		called = {"n": 0}
+
+		def spy(*a, **k):
+			called["n"] += 1
+			return {"status": "accepted"}
+
+		with patch.object(T.TimbradoAPI, "cancelar_factura", side_effect=spy):
+			res = T._cascade_cancel_previous_after_substitute(self.B_ffm)
+		self.assertEqual(res.get("cascade"), "documental_completed")
+		self.assertEqual(called["n"], 0, "no debe re-llamar al PAC si ya está CANCELADO")
+		self.assertEqual(self._ds("Sales Invoice", self.A_si), 2)
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 2)
+
+	def test_5_idempotencia_ya_todo_cancelado(self):
+		self._build_A_B()
+		frappe.db.set_value("Factura Fiscal Mexico", self.A_ffm, "status", FiscalStates.CANCELADO)
+		frappe.db.commit()
+		with patch.object(T.TimbradoAPI, "cancelar_factura", side_effect=self._pac_ok):
+			T._cascade_cancel_previous_after_substitute(self.B_ffm)  # 1ª: baja a docstatus=2
+			res2 = T._cascade_cancel_previous_after_substitute(self.B_ffm)  # 2ª: no-op
+		self.assertEqual(res2.get("skipped"), "already_cancelled")
+		self.assertEqual(self._ds("Sales Invoice", self.A_si), 2)
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 2)
+
+	# ---------------- SCHEDULER: retry_pending_substitution_cancellations ----------------
+
+	def _set_A_pending(self):
+		"""Simula el estado dejado por la cascada tras agotar los reintentos inmediatos.
+		Incluye el snapshot fm_fiscal_status en la SI (es lo que evalúa el guard de cancelar_factura)."""
+		frappe.db.set_value(
+			"Factura Fiscal Mexico",
+			self.A_ffm,
+			{"status": FiscalStates.PENDIENTE_CANCELACION, "fm_sync_status": "pending"},
+		)
+		frappe.db.set_value(
+			"Sales Invoice", self.A_si, "fm_fiscal_status", FiscalStates.PENDIENTE_CANCELACION
+		)
+		frappe.db.commit()
+
+	def test_6_scheduler_A_valida_reenvia_delete_y_cancela(self):
+		"""A sigue 'valid' en el PAC: el scheduler reenvía UN DELETE motivo 01 y completa documental."""
+		self._build_A_B()
+		self._set_A_pending()
+		with patch.object(T, "TimbradoAPI") as MockAPI:
+			MockAPI.return_value.client.get_invoice.return_value = {"raw_response": {"status": "valid"}}
+			MockAPI.return_value.cancelar_factura.side_effect = self._pac_ok
+			T.retry_pending_substitution_cancellations()
+		self.assertEqual(MockAPI.return_value.cancelar_factura.call_count, 1, "debe reenviar 1 DELETE")
+		self.assertEqual(self._ds("Sales Invoice", self.A_si), 2)
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 2)
+
+	def test_7_scheduler_A_ya_cancelada_no_reenvia_delete(self):
+		"""A ya 'canceled' en el PAC: NO se reenvía DELETE; solo reconcilia + completa documental."""
+		self._build_A_B()
+		self._set_A_pending()
+		with patch.object(T, "TimbradoAPI") as MockAPI:
+			MockAPI.return_value.client.get_invoice.return_value = {"raw_response": {"status": "canceled"}}
+			T.retry_pending_substitution_cancellations()
+		self.assertEqual(
+			MockAPI.return_value.cancelar_factura.call_count, 0, "no reenviar si ya está cancelada"
+		)
+		self.assertEqual(
+			frappe.db.get_value("Factura Fiscal Mexico", self.A_ffm, "status"), FiscalStates.CANCELADO
+		)
+		self.assertEqual(self._ds("Sales Invoice", self.A_si), 2)
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 2)
+
+	def test_8_scheduler_error_definitivo_sale_del_ciclo(self):
+		"""Error NO transitorio al reenviar: A sale del ciclo automático (fm_sync_status='error')."""
+		self._build_A_B()
+		self._set_A_pending()
+
+		def _pac_definitivo(*a, **k):
+			raise frappe.ValidationError("Error FacturAPI 422: unprocessable - motivo inválido")
+
+		with patch.object(T, "TimbradoAPI") as MockAPI:
+			MockAPI.return_value.client.get_invoice.return_value = {"raw_response": {"status": "valid"}}
+			MockAPI.return_value.cancelar_factura.side_effect = _pac_definitivo
+			T.retry_pending_substitution_cancellations()
+		a = frappe.db.get_value(
+			"Factura Fiscal Mexico", self.A_ffm, ["fm_sync_status", "status"], as_dict=True
+		)
+		self.assertEqual(a.fm_sync_status, "error", "debe salir del ciclo automático")
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 1, "documentos intactos")
+
+	def _age_B(self, minutes):
+		"""Envejece el ancla real (fecha_timbrado de B) `minutes` minutos hacia atrás."""
+		from frappe.utils import add_to_date
+
+		frappe.db.set_value(
+			"Factura Fiscal Mexico",
+			self.B_ffm,
+			"fecha_timbrado",
+			add_to_date(frappe.utils.now_datetime(), minutes=-minutes),
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+	def test_10_scheduler_abandona_tras_ventana_maxima(self):
+		"""Cota anti-bloqueo: pasada la ventana máxima (desde fecha_timbrado de B), el scheduler
+		abandona el caso SIN llamar al PAC (ni GET ni DELETE) y lo deja como error accionable."""
+		self._build_A_B()
+		self._set_A_pending()
+		self._age_B(T._SUBSTITUTION_CANCEL_MAX_AGE_MIN + 5)
+		with patch.object(T, "TimbradoAPI") as MockAPI:
+			T.retry_pending_substitution_cancellations()
+			MockAPI.return_value.client.get_invoice.assert_not_called()
+			MockAPI.return_value.cancelar_factura.assert_not_called()
+		self.assertEqual(
+			frappe.db.get_value("Factura Fiscal Mexico", self.A_ffm, "fm_sync_status"),
+			"error",
+			"debe salir del ciclo automático",
+		)
+
+	def test_11_scheduler_throttle_fuera_de_ventana_rapida(self):
+		"""Throttle escalonado: pasada la ventana rápida, si el último contacto con el PAC
+		(fm_last_pac_sync) es reciente (<5 min), el tick se salta SIN llamar al PAC."""
+		from frappe.utils import add_to_date
+
+		self._build_A_B()
+		self._set_A_pending()
+		self._age_B(10)  # fuera de la ventana rápida (>5 min)
+		# Contacto reciente con el PAC → debe enfriar.
+		frappe.db.set_value(
+			"Factura Fiscal Mexico",
+			self.A_ffm,
+			"fm_last_pac_sync",
+			add_to_date(frappe.utils.now_datetime(), minutes=-1),
+			update_modified=False,
+		)
+		frappe.db.commit()
+		with patch.object(T, "TimbradoAPI") as MockAPI:
+			T.retry_pending_substitution_cancellations()
+			MockAPI.return_value.client.get_invoice.assert_not_called()
+			MockAPI.return_value.cancelar_factura.assert_not_called()
+		self.assertEqual(
+			frappe.db.get_value("Factura Fiscal Mexico", self.A_ffm, "status"),
+			FiscalStates.PENDIENTE_CANCELACION,
+			"sigue pendiente para el próximo tick elegible",
+		)
+
+	def test_12_scheduler_cancela_con_guard_real(self):
+		"""Integración SIN mockear cancelar_factura: el flujo REAL (incluido el guard de estado)
+		permite el retry interno sobre A en PENDIENTE_CANCELACION y converge a CANCELADO.
+		Este test es el que faltaba: los mocks previos ocultaban el guard que rompía la recuperación."""
+		self._build_A_B()
+		self._set_A_pending()
+		fake = _FakeCancelClient()
+		with patch.object(T, "get_facturapi_client", return_value=fake):
+			T.retry_pending_substitution_cancellations()
+		self.assertEqual(len(fake.cancel_calls), 1, "debe enviar exactamente 1 DELETE (sin duplicados)")
+		self.assertEqual(fake.cancel_calls[0][1], "01", "motivo 01")
+		self.assertEqual(fake.cancel_calls[0][2], self.B_uuid, "folio sustitución = UUID_B")
+		self.assertEqual(
+			frappe.db.get_value("Factura Fiscal Mexico", self.A_ffm, "status"), FiscalStates.CANCELADO
+		)
+		self.assertEqual(self._ds("Sales Invoice", self.A_si), 2, "SI A documental cancelada")
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 2, "FFM A documental cancelada")
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.B_ffm), 1, "B permanece timbrada")
+
+	def test_13_scheduler_success_false_transitorio_conserva(self):
+		"""cancelar_factura devuelve {success:False} con error transitorio → conservar PENDIENTE."""
+		self._build_A_B()
+		self._set_A_pending()
+		with patch.object(T, "TimbradoAPI") as MockAPI:
+			MockAPI.return_value.client.get_invoice.return_value = {"raw_response": {"status": "valid"}}
+			MockAPI.return_value.cancelar_factura.return_value = {
+				"success": False,
+				"error": "Error FacturAPI 404: invoice_not_found",
+			}
+			T.retry_pending_substitution_cancellations()
+		a = frappe.db.get_value(
+			"Factura Fiscal Mexico", self.A_ffm, ["status", "fm_sync_status"], as_dict=True
+		)
+		self.assertEqual(a.status, FiscalStates.PENDIENTE_CANCELACION, "transitorio → sigue pendiente")
+		self.assertEqual(a.fm_sync_status, "pending", "no sale del ciclo por un transitorio")
+
+	def test_14_scheduler_success_false_definitivo_sale(self):
+		"""cancelar_factura devuelve {success:False} con error definitivo → sale del ciclo (error)."""
+		self._build_A_B()
+		self._set_A_pending()
+		with patch.object(T, "TimbradoAPI") as MockAPI:
+			MockAPI.return_value.client.get_invoice.return_value = {"raw_response": {"status": "valid"}}
+			MockAPI.return_value.cancelar_factura.return_value = {
+				"success": False,
+				"error": "Error 422 unprocessable: motivo inválido",
+			}
+			T.retry_pending_substitution_cancellations()
+		self.assertEqual(
+			frappe.db.get_value("Factura Fiscal Mexico", self.A_ffm, "fm_sync_status"),
+			"error",
+			"un {success:False} definitivo NO se interpreta como éxito",
+		)
+
+	def test_15_gap3_reconcile_completa_documental_cancelado(self):
+		"""Gap 3: A ya CANCELADO fiscal pero docstatus=1 (documental incompleto), origen de sustitución.
+		La reconciliación NO reenvía DELETE y completa el documental (SI y FFM → docstatus=2). Idempotente."""
+		from facturacion_mexico.facturacion_fiscal.services import ffm_reconciliation as R
+
+		self._build_A_B()
+		frappe.db.set_value(
+			"Factura Fiscal Mexico",
+			self.A_ffm,
+			{"status": FiscalStates.CANCELADO, "fm_sync_status": "synced"},
+		)
+		frappe.db.commit()
+		a_fapi = frappe.db.get_value("Factura Fiscal Mexico", self.A_ffm, "facturapi_id")
+		client = MagicMock()
+		client.get_invoice.return_value = {
+			"success": True,
+			"status_code": 200,
+			"raw_response": {
+				"id": a_fapi,
+				"uuid": self.A_uuid,
+				"status": "canceled",
+				"cancellation_status": "accepted",
+			},
+		}
+		mod = "facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.get_facturapi_client"
+		with patch(mod, return_value=client):
+			R._reconcile_ffm(self.A_ffm)
+		client.cancel_invoice.assert_not_called()
+		self.assertEqual(self._ds("Sales Invoice", self.A_si), 2, "SI A documental cancelada")
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 2, "FFM A documental cancelada")
+		# Idempotencia: una segunda reconciliación no cambia nada ni falla.
+		with patch(mod, return_value=client):
+			R._reconcile_ffm(self.A_ffm)
+		self.assertEqual(self._ds("Factura Fiscal Mexico", self.A_ffm), 2)
+
+	def test_9_clasificacion_error_transitorio(self):
+		"""Unidad pura: qué errores se consideran transitorios."""
+		for msg in [
+			"Error FacturAPI 404: invoice_not_found",
+			"HTTP 429",
+			"500 server",
+			"502 bad gateway",
+			"Timeout al conectar",
+			"Error de conexión con FacturAPI",
+		]:
+			self.assertTrue(T._is_transient_pac_error(Exception(msg)), msg)
+		for msg in ["Error FacturAPI 422: unprocessable", "RFC inválido", "400 bad request"]:
+			self.assertFalse(T._is_transient_pac_error(Exception(msg)), msg)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
@@ -214,10 +214,12 @@ class TestFFMReconciliation(IntegrationTestCase):
 		conserva PENDIENTE + pending para que el scheduler siga seleccionándola. Reconciliación NO cancela."""
 		a_si = self._si()
 		a = self._ffm(a_si, "PENDIENTE_CANCELACION", sync="pending")  # uuid=_UUID
-		# B: sustituto timbrado que relaciona a A por ffm_substitution_source_uuid == A.fm_uuid
+		# B: sustituto timbrado que relaciona a A por ffm_substitution_source_uuid == A.fm_uuid.
+		# IDs únicos por corrida para no colisionar en el site compartido.
+		b_ids = frappe.generate_hash()[:8]
 		b_si = self._si()
 		frappe.db.set_value("Sales Invoice", b_si, "ffm_substitution_source_uuid", _UUID)
-		self._ffm(b_si, "TIMBRADO", facturapi_id="FA-B", uuid="U-B")
+		self._ffm(b_si, "TIMBRADO", facturapi_id=f"FA-B-{b_ids}", uuid=f"U-B-{b_ids}")
 		frappe.db.commit()
 		_res, client, _ = self._reconciliar(
 			a, get_return=_ok({"status": "valid", "cancellation_status": "none"})

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_reconciliation.py
@@ -208,6 +208,35 @@ class TestFFMReconciliation(IntegrationTestCase):
 		self._reconciliar(ffm, get_return=_ok({"status": "valid", "cancellation_status": "expired"}))
 		self.assertEqual(self._status(ffm), "TIMBRADO")
 
+	def test_gap2_no_revierte_sustitucion_pendiente(self):
+		"""Gap 2: una FFM ORIGEN de sustitución (con B timbrado) en PENDIENTE_CANCELACION NO debe
+		revertirse a TIMBRADO al reconciliar con PAC valid/none (el DELETE aún no se registró):
+		conserva PENDIENTE + pending para que el scheduler siga seleccionándola. Reconciliación NO cancela."""
+		a_si = self._si()
+		a = self._ffm(a_si, "PENDIENTE_CANCELACION", sync="pending")  # uuid=_UUID
+		# B: sustituto timbrado que relaciona a A por ffm_substitution_source_uuid == A.fm_uuid
+		b_si = self._si()
+		frappe.db.set_value("Sales Invoice", b_si, "ffm_substitution_source_uuid", _UUID)
+		self._ffm(b_si, "TIMBRADO", facturapi_id="FA-B", uuid="U-B")
+		frappe.db.commit()
+		_res, client, _ = self._reconciliar(
+			a, get_return=_ok({"status": "valid", "cancellation_status": "none"})
+		)
+		self.assertEqual(self._status(a), "PENDIENTE_CANCELACION", "no revertir cancelación en curso")
+		self.assertEqual(self._sync(a), "pending", "sigue seleccionable por el scheduler")
+		self.assertIn(a, mod._select_candidates())
+		client.cancel_invoice.assert_not_called()
+
+	def test_gap2_control_ffm_normal_si_transiciona(self):
+		"""Control Gap 2: una FFM SIN sustituto vigente conserva la transición genérica valid/none→TIMBRADO."""
+		si = self._si()
+		a = self._ffm(si, "PENDIENTE_CANCELACION", sync="synced")
+		_res, client, _ = self._reconciliar(
+			a, get_return=_ok({"status": "valid", "cancellation_status": "none"})
+		)
+		self.assertEqual(self._status(a), "TIMBRADO", "sin sustitución: transición genérica intacta")
+		client.cancel_invoice.assert_not_called()
+
 	def test_remoto_pending_conserva_estado_y_pending(self):
 		si = self._si()
 		ffm = self._ffm(si, "TIMBRADO", sync="synced")

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -1482,10 +1482,10 @@ class TimbradoAPI:
 			# AUTOMÁTICO de sustitución motivo 01 (que ya verificó que A es origen de sustitución con
 			# B timbrado) puede reintentar una FFM ya en PENDIENTE_CANCELACION vía el flag interno
 			# keyword-only; esto NO abre la puerta al flujo manual, que nunca pasa el flag.
-			_estados_cancelables = {FiscalStates.TIMBRADO}
+			cancelable_states = {FiscalStates.TIMBRADO}
 			if _allow_pending_cancellation:
-				_estados_cancelables.add(FiscalStates.PENDIENTE_CANCELACION)
-			if sales_invoice.fm_fiscal_status not in _estados_cancelables:
+				cancelable_states.add(FiscalStates.PENDIENTE_CANCELACION)
+			if sales_invoice.fm_fiscal_status not in cancelable_states:
 				frappe.throw(_("Solo se pueden cancelar facturas timbradas"))
 
 			if not sales_invoice.fm_factura_fiscal_mx:
@@ -3323,7 +3323,15 @@ def _complete_documental_cancellation(orig_ffm_name: str, orig_si_name: str | No
 
 	si_ds = frappe.db.get_value("Sales Invoice", orig_si_name, "docstatus") if orig_si_name else 2
 	ffm_ds = frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "docstatus")
-	return {"documental": "completed", "si_docstatus": si_ds, "ffm_docstatus": ffm_ds}
+	# Veraz: solo "completed" si AMBOS quedaron realmente en docstatus=2. Si un cancel() falló, se
+	# reporta "incomplete" para no declarar una convergencia que no ocurrió (la reconciliación
+	# horaria la reintentará vía el hook documental).
+	done = (si_ds in (2, None)) and (ffm_ds == 2)
+	return {
+		"documental": "completed" if done else "incomplete",
+		"si_docstatus": si_ds,
+		"ffm_docstatus": ffm_ds,
+	}
 
 
 def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
@@ -3380,16 +3388,33 @@ def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
 			# CORTOS ante errores TRANSITORIOS (p.ej. 404 invoice_not_found por inconsistencia
 			# momentánea del PAC justo tras timbrar el sustituto). Ventana total ≤ ~1.5s dentro del
 			# request. Si el error NO es transitorio, no se reintenta.
-			#   intento 1 = t0 · intento 2 = +0.5s · intento 3 = +1.0s
+			#   intento 1 (t0) · espera 0.5s · intento 2 · espera 1.0s · intento 3 (≈+1.5s acumulado)
 			max_intentos = 3
 			last_error = None
+			# Company de la FFM/SI original: el cliente PAC DEBE usar las credenciales de esa empresa
+			# (no la default) para no cancelar contra otra cuenta en entornos multiempresa.
+			orig_company = frappe.db.get_value("Sales Invoice", orig_si_name, "company")
 			for intento in range(1, max_intentos + 1):
 				try:
-					api = TimbradoAPI()
+					api = TimbradoAPI(company=orig_company)
 					cancel_result = api.cancelar_factura(orig_si_name, "01", new_uuid)
 					frappe.logger().info(
 						f"Cancelación fiscal PAC (intento inmediato {intento}): {cancel_result}"
 					)
+					# cancelar_factura puede FALLAR devolviendo {success: False} SIN lanzar excepción.
+					# Tratarlo como fallo: transitorio → reintentar; definitivo → salir del loop.
+					if isinstance(cancel_result, dict) and cancel_result.get("success") is False:
+						last_error = (
+							cancel_result.get("error")
+							or cancel_result.get("message")
+							or "cancelación no exitosa"
+						)
+						transitorio = _is_transient_pac_error(last_error)
+						cancel_result = None
+						if transitorio and intento < max_intentos:
+							time.sleep(0.5 * intento)  # 0.5s, 1.0s
+							continue
+						break
 					break
 				except Exception as e:
 					last_error = e
@@ -3498,13 +3523,32 @@ def retry_pending_substitution_cancellations():
 
 	ACOTADO para no bloquear la API del PAC: a lo sumo _SUBSTITUTION_CANCEL_BATCH casos por tick
 	(el resto se retoma en el siguiente minuto), y cada caso se abandona pasada _SUBSTITUTION_CANCEL_MAX_AGE_MIN."""
-	pendientes = frappe.db.count(
-		"Factura Fiscal Mexico",
-		{"status": FiscalStates.PENDIENTE_CANCELACION, "fm_sync_status": "pending"},
-	)
+	# La promesa del retry diferido es SOLO para cancelaciones de SUSTITUCIÓN. Se filtra por el UUID
+	# del CFDI original (A) que tiene un sustituto (B) ANTES del límite del batch, para que un backlog
+	# de pendientes NO-sustitución (motivos 02/03/04) no consuma el cupo e inanicione a las
+	# sustituciones reales. `_retry_one` reverifica luego que B esté TIMBRADO.
+	source_uuids = [
+		u
+		for u in set(
+			frappe.get_all(
+				"Sales Invoice",
+				filters={"ffm_substitution_source_uuid": ["!=", ""]},
+				pluck="ffm_substitution_source_uuid",
+			)
+		)
+		if u
+	]
+	if not source_uuids:
+		return
+	base_filters = {
+		"status": FiscalStates.PENDIENTE_CANCELACION,
+		"fm_sync_status": "pending",
+		"fm_uuid": ["in", source_uuids],
+	}
+	pendientes = frappe.db.count("Factura Fiscal Mexico", base_filters)
 	candidates = frappe.get_all(
 		"Factura Fiscal Mexico",
-		filters={"status": FiscalStates.PENDIENTE_CANCELACION, "fm_sync_status": "pending"},
+		filters=base_filters,
 		order_by="modified asc",  # los más antiguos primero
 		limit=_SUBSTITUTION_CANCEL_BATCH,
 		pluck="name",
@@ -3577,7 +3621,7 @@ def _retry_one_substitution_cancellation(orig_ffm_name):
 			frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "status") or ""
 		).upper() != FiscalStates.PENDIENTE_CANCELACION:
 			return
-		api = TimbradoAPI()
+		api = TimbradoAPI(company=frappe.db.get_value("Sales Invoice", orig.sales_invoice, "company"))
 
 		# Sello de contacto con el PAC para el throttling (marca este tick como intento consumido,
 		# aunque el GET falle). update_modified=False para no alterar el orden del selector.
@@ -3604,12 +3648,16 @@ def _retry_one_substitution_cancellation(orig_ffm_name):
 			from facturacion_mexico.facturacion_fiscal.cancellation_state import apply_cancellation_state
 
 			apply_cancellation_state(
-				orig_ffm_name, FiscalStates.CANCELADO, sync_status="synced", cancellation_date=now_datetime()
+				orig_ffm_name,
+				FiscalStates.CANCELADO,
+				sync_status="synced",
+				cancellation_date=extract_canceled_at({"raw_response": raw}) or now_datetime(),
 			)
-			_complete_documental_cancellation(orig_ffm_name, orig.sales_invoice)
-			frappe.db.set_value("Factura Fiscal Mexico", orig_ffm_name, "fm_sync_error", "")
+			doc_res = _complete_documental_cancellation(orig_ffm_name, orig.sales_invoice)
+			if doc_res.get("documental") == "completed":
+				frappe.db.set_value("Factura Fiscal Mexico", orig_ffm_name, "fm_sync_error", "")
 			frappe.logger().info(
-				f"Scheduled retry: A {orig_ffm_name} ya 'canceled' en PAC -> reconciliado + documental."
+				f"Scheduled retry: A {orig_ffm_name} ya 'canceled' en PAC -> reconciliado + documental ({doc_res.get('documental')})."
 			)
 			return
 
@@ -3639,8 +3687,9 @@ def _retry_one_substitution_cancellation(orig_ffm_name):
 				frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "status")
 				== FiscalStates.CANCELADO
 			):
-				_complete_documental_cancellation(orig_ffm_name, orig.sales_invoice)
-				frappe.db.set_value("Factura Fiscal Mexico", orig_ffm_name, "fm_sync_error", "")
+				doc_res = _complete_documental_cancellation(orig_ffm_name, orig.sales_invoice)
+				if doc_res.get("documental") == "completed":
+					frappe.db.set_value("Factura Fiscal Mexico", orig_ffm_name, "fm_sync_error", "")
 			return  # si quedó pending en PAC, conservar y reintentar en el siguiente ciclo
 
 		# Estado remoto inesperado/incompatible -> intervención (sale del ciclo automático).

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -1,12 +1,13 @@
 import json
 import re
+import time
 import traceback
 import unicodedata
 from typing import Any
 
 import frappe
 from frappe import _
-from frappe.utils import flt, fmt_money, format_date, now_datetime, today
+from frappe.utils import flt, fmt_money, format_date, now_datetime, time_diff_in_seconds, today
 
 from facturacion_mexico.config.sat_objeto_impuesto import SATObjetoImpuesto
 from facturacion_mexico.config.sat_tax_rates import FacturAPITaxRates
@@ -478,6 +479,15 @@ class TimbradoAPI:
 					"factura_fiscal": factura_fiscal.name,
 					"message": "Factura timbrada exitosamente",  # Mensaje para UI
 				}
+				# Propagar el desenlace de la cascada de sustitución (si aplica) para que el frontend
+				# distinga inequívocamente: B timbrado OK vs cancelación de A pendiente. NO es un error
+				# de timbrado; es información complementaria.
+				_cascade = getattr(self, "_last_cascade_result", None)
+				if _cascade:
+					base_result["cascade"] = _cascade.get("cascade")
+					if _cascade.get("cascade") == "pending_cancellation":
+						base_result["cancelacion_previa_pendiente"] = True
+						base_result["pending_cancellation_ffm"] = _cascade.get("ffm")
 				# Corrección 6B2: si la persistencia principal del writer falló (PAC OK), verificar
 				# con lectura nueva de BD si la FASE 3 recuperó el estado. No se re-llama al PAC.
 				if _writer_persistence_failed(writer_result):
@@ -1249,12 +1259,16 @@ class TimbradoAPI:
 			else:
 				pass
 
-			# [Milestone 3] Cascada post-timbrado: cancelar CFDI previo y SI original si es sustitución
+			# [Milestone 3] Cascada post-timbrado: cancelar CFDI previo y SI original si es sustitución.
+			# El resultado se guarda en self para propagarlo al frontend (distingue B timbrado OK vs
+			# cancelación de A pendiente), sin romper nunca el éxito del timbrado de B.
+			self._last_cascade_result = None
 			try:
 				# Solo si hay UUID de origen en la SI (indica sustitución 01)
 				si = frappe.get_doc("Sales Invoice", sales_invoice.name)
 				if (getattr(si, "ffm_substitution_source_uuid", "") or "").strip():
 					cascade_result = _cascade_cancel_previous_after_substitute(factura_fiscal.name)
+					self._last_cascade_result = cascade_result
 					if cascade_result.get("cascade") == "completed":
 						frappe.logger().info(f"Cascada sustitución completada para FFM {factura_fiscal.name}")
 					else:
@@ -1425,7 +1439,12 @@ class TimbradoAPI:
 			frappe.logger().error(f"Error descargando archivos de acuse de cancelación: {e!s}")
 
 	def cancelar_factura(
-		self, sales_invoice_name: str, motivo: str, substitution_uuid: str | None = None
+		self,
+		sales_invoice_name: str,
+		motivo: str,
+		substitution_uuid: str | None = None,
+		*,
+		_allow_pending_cancellation: bool = False,
 	) -> dict[str, Any]:
 		"""Cancelar factura timbrada con arquitectura resiliente de 3 fases.
 
@@ -1459,8 +1478,14 @@ class TimbradoAPI:
 			# FASE 1: PREPARACIÓN Y VALIDACIONES
 			sales_invoice = frappe.get_doc("Sales Invoice", sales_invoice_name)
 
-			# Validar que se pueda cancelar
-			if sales_invoice.fm_fiscal_status != FiscalStates.TIMBRADO:
+			# Validar que se pueda cancelar. La ruta MANUAL exige TIMBRADO. SOLO el reintento
+			# AUTOMÁTICO de sustitución motivo 01 (que ya verificó que A es origen de sustitución con
+			# B timbrado) puede reintentar una FFM ya en PENDIENTE_CANCELACION vía el flag interno
+			# keyword-only; esto NO abre la puerta al flujo manual, que nunca pasa el flag.
+			_estados_cancelables = {FiscalStates.TIMBRADO}
+			if _allow_pending_cancellation:
+				_estados_cancelables.add(FiscalStates.PENDIENTE_CANCELACION)
+			if sales_invoice.fm_fiscal_status not in _estados_cancelables:
 				frappe.throw(_("Solo se pueden cancelar facturas timbradas"))
 
 			if not sales_invoice.fm_factura_fiscal_mx:
@@ -3193,10 +3218,116 @@ def create_substitution_si(si_name: str):
 	return {"new_si": new_si.name, "src_uuid": ffm["fm_uuid"]}
 
 
-def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
-	"""Post-éxito: cancelar CFDI previo con motivo 01 y cancelar SI/FFM originales."""
+# Marcadores de errores del PAC considerados TRANSITORIOS SOLO en el contexto de la cascada de
+# sustitución (el CFDI original existe, fue timbrado y tiene UUID/facturapi_id). En ese contexto,
+# un 404 invoice_not_found inmediato tras timbrar el sustituto es consistencia eventual del PAC.
+_TRANSIENT_PAC_MARKERS = (
+	"invoice_not_found",
+	"404",
+	"429",
+	"500",
+	"502",
+	"503",
+	"504",
+	"timeout",
+	"conexión",
+	"connection",
+)
+
+
+def _is_transient_pac_error(exc) -> bool:
+	s = str(exc or "").lower()
+	return any(m in s for m in _TRANSIENT_PAC_MARKERS)
+
+
+# Cotas del reintento automático diferido (scheduler cada minuto). Existen para que un caso
+# atascado NO golpee la API del PAC indefinidamente:
+#   - MAX_AGE: ventana total de reintento. Pasada esta antigüedad (medida desde que se creó el
+#     CFDI sustituto B), se abandona el ciclo automático → fm_sync_status='error' → intervención.
+#   - BATCH: tope de casos procesados por tick, para que un backlog no dispare una ráfaga de
+#     llamadas al PAC en un solo minuto. El excedente se retoma en el siguiente ciclo (se loguea).
+#   - FAST_WINDOW: durante los primeros minutos tras timbrar B (periodo crítico) se permite un
+#     intento por tick de 1 min (recuperación rápida del 404 transitorio prolongado).
+#   - SLOW_INTERVAL: pasada la ventana rápida, solo se reintenta si transcurrieron ≥5 min desde el
+#     último contacto con el PAC (fm_last_pac_sync). Esto escalona a ~1 intento/5 min y evita
+#     ~120 DELETE para un caso prolongado, sin campos ni contadores nuevos.
+_SUBSTITUTION_CANCEL_MAX_AGE_MIN = 120  # corte total (~2 h desde fecha_timbrado de B)
+_SUBSTITUTION_CANCEL_FAST_WINDOW_MIN = 5  # ventana rápida inicial: 1 intento por minuto
+_SUBSTITUTION_CANCEL_SLOW_INTERVAL_MIN = 5  # después: 1 intento cada ~5 min
+_SUBSTITUTION_CANCEL_BATCH = 50
+
+
+def _complete_documental_cancellation(orig_ffm_name: str, orig_si_name: str | None = None) -> dict:
+	"""Completa la cancelación DOCUMENTAL (docstatus=2) de la Sales Invoice y la Factura Fiscal
+	Mexico ORIGINALES cuando el CFDI ya está fiscalmente CANCELADO. NO llama al PAC.
+
+	Idempotente y fail-safe ante reintentos:
+	  - si ambos ya están docstatus=2 -> no-op;
+	  - si solo uno quedó pendiente -> completa el que falta;
+	  - usa el mecanismo documental normal de Frappe (doc.cancel(), con los overrides existentes),
+	    nunca db_set de docstatus.
+	Reproduce el mismo hardening preventivo de links que hacía la cascada inline.
+	"""
 	from frappe.utils import cstr
 
+	if not orig_si_name:
+		orig_si_name = frappe.db.get_value(
+			"Factura Fiscal Mexico", orig_ffm_name, "sales_invoice"
+		) or frappe.db.get_value("Sales Invoice", {"fm_factura_fiscal_mx": orig_ffm_name}, "name")
+
+	orig_ffm = frappe.get_doc("Factura Fiscal Mexico", orig_ffm_name)
+	orig_si = frappe.get_doc("Sales Invoice", orig_si_name) if orig_si_name else None
+
+	if (orig_si is None or orig_si.docstatus == 2) and orig_ffm.docstatus == 2:
+		return {"documental": "already_done"}
+
+	# Hardening preventivo: limpiar links SI<->FFM antes de cancelar (evita LinkExistsError).
+	try:
+		if orig_si is not None:
+			orig_si.reload()
+			if getattr(orig_si, "fm_factura_fiscal_mx", None):
+				orig_si.db_set("fm_factura_fiscal_mx", "")
+				frappe.db.commit()  # nosemgrep: frappe-manual-commit
+		orig_ffm.reload()
+		if getattr(orig_ffm, "sales_invoice", None):
+			orig_ffm.db_set("sales_invoice", "")
+			frappe.db.commit()  # nosemgrep: frappe-manual-commit
+	except Exception as e:
+		frappe.logger().error(f"Hardening preventivo documental: {e}")
+
+	# Cancelar SI original (docstatus=2) si sigue submitted.
+	if orig_si is not None:
+		try:
+			orig_si.reload()
+			if cstr(orig_si.docstatus) == "1":
+				orig_si.cancel()
+				frappe.logger().info(f"SI {orig_si_name} cancelado (docstatus=2)")
+		except Exception as e:
+			frappe.logger().error(f"Error cancelando SI original: {e}")
+
+	# Restaurar link sales_invoice en la FFM (limpiado por el hardening).
+	if orig_si_name:
+		try:
+			orig_ffm.db_set("sales_invoice", orig_si_name)
+		except Exception as e:
+			frappe.logger().warning(f"No se pudo restaurar link sales_invoice: {e}")
+
+	# Cancelar FFM original (docstatus=2) si sigue submitted.
+	try:
+		orig_ffm.reload()
+		if cstr(orig_ffm.docstatus) == "1":
+			orig_ffm.cancel()
+			frappe.logger().info(f"FFM {orig_ffm_name} cancelada (docstatus=2)")
+	except Exception as e:
+		frappe.logger().error(f"Error cancelando FFM original: {e}")
+
+	si_ds = frappe.db.get_value("Sales Invoice", orig_si_name, "docstatus") if orig_si_name else 2
+	ffm_ds = frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "docstatus")
+	return {"documental": "completed", "si_docstatus": si_ds, "ffm_docstatus": ffm_ds}
+
+
+def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
+	"""Post-éxito: cancelar CFDI previo con motivo 01 y cancelar SI/FFM originales."""
 	try:
 		new_ffm = frappe.get_doc("Factura Fiscal Mexico", new_ffm_name)
 		new_uuid = (new_ffm.get("fm_uuid") or "").strip()
@@ -3230,7 +3361,11 @@ def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
 
 		orig_status = frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "status")
 		if (orig_status or "").upper() in {"CANCELADO", "CANCELADA"}:
-			return {"skipped": "already_cancelled"}
+			# Fiscal YA cancelado (por reconciliación o reintento previo) pero SI o FFM siguen
+			# docstatus=1: completar SOLO la cancelación DOCUMENTAL pendiente (sin PAC, idempotente).
+			with frappe.cache().lock(f"ffm:cascade:{orig_ffm_name}", timeout=30):
+				doc_res = _complete_documental_cancellation(orig_ffm_name, orig_si_name)
+			return {"cascade": "documental_completed", **doc_res}
 
 		# CONCURRENCY FIX: Lock per-document para evitar race conditions
 		lock_key = f"ffm:cascade:{orig_ffm_name}"
@@ -3241,104 +3376,275 @@ def _cascade_cancel_previous_after_substitute(new_ffm_name: str):
 
 			cancel_result = None
 
-			# 1) Cancelar fiscalmente el CFDI previo con motivo 01 (PAC)
-			try:
-				api = TimbradoAPI()
-				# CRITICAL FIX: Usar orig_si_name en lugar de orig_ffm_name
-				cancel_result = api.cancelar_factura(orig_si_name, "01", new_uuid)
-				frappe.logger().info(f"Cancelación fiscal PAC: {cancel_result}")
-			except Exception as e:
-				frappe.logger().error(f"Error cancelando CFDI previo en PAC: {e}")
-				# No fallar toda la operación por error en cancelación PAC
-				cancel_result = None
+			# 1) Cancelar fiscalmente el CFDI previo con motivo 01 (PAC), con reintentos INMEDIATOS y
+			# CORTOS ante errores TRANSITORIOS (p.ej. 404 invoice_not_found por inconsistencia
+			# momentánea del PAC justo tras timbrar el sustituto). Ventana total ≤ ~1.5s dentro del
+			# request. Si el error NO es transitorio, no se reintenta.
+			#   intento 1 = t0 · intento 2 = +0.5s · intento 3 = +1.0s
+			max_intentos = 3
+			last_error = None
+			for intento in range(1, max_intentos + 1):
+				try:
+					api = TimbradoAPI()
+					cancel_result = api.cancelar_factura(orig_si_name, "01", new_uuid)
+					frappe.logger().info(
+						f"Cancelación fiscal PAC (intento inmediato {intento}): {cancel_result}"
+					)
+					break
+				except Exception as e:
+					last_error = e
+					transitorio = _is_transient_pac_error(e)
+					frappe.logger().error(
+						f"Error cancelando CFDI previo en PAC (intento inmediato {intento}/{max_intentos}, "
+						f"transitorio={transitorio}): {e}"
+					)
+					cancel_result = None
+					if transitorio and intento < max_intentos:
+						time.sleep(0.5 * intento)  # 0.5s, 1.0s
+						continue
+					break
 
-			# 2) GUARDA FAIL-CLOSED: relectura autoritativa del estado real (misma transacción, sin
-			# commit extra). La operación interna ya aplicó el estado vía apply_cancellation_state.
-			# Solo se continúa la cancelación DOCUMENTAL si el CFDI previo quedó realmente CANCELADO.
-			# Si el PAC falló / quedó pending/verifying / no terminal, NO se cancela SI ni FFM.
+			# 2) GUARDA FAIL-CLOSED: relectura autoritativa del estado real. Solo se continúa la
+			# cancelación DOCUMENTAL si el CFDI previo quedó realmente CANCELADO.
 			orig_status = frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "status")
 			if orig_status != FiscalStates.CANCELADO:
+				# Los reintentos inmediatos no confirmaron. NO se rompe el timbrado de B (que fue
+				# exitoso): se deja A en PENDIENTE_CANCELACION para que el reintento automático diferido
+				# (scheduler cada minuto) la retome. B permanece TIMBRADO; SI/FFM de A intactos.
+				_mark_substitution_cancellation_pending(orig_ffm_name, orig_si_name, last_error)
 				frappe.logger().warning(
-					f"Cascada detenida: CFDI previo no terminal "
-					f"(FFM {orig_ffm_name} status={orig_status}). No se cancela SI/FFM."
+					f"Cascada: cancelación de A no confirmada tras reintentos inmediatos "
+					f"(FFM {orig_ffm_name} status={orig_status}). Marcada PENDIENTE_CANCELACION."
 				)
 				return {
-					"cascade": "halted_not_terminal",
+					"cascade": "pending_cancellation",
 					"ffm": orig_ffm_name,
-					"status": orig_status,
+					"status": FiscalStates.PENDIENTE_CANCELACION,
 				}
 			frappe.logger().info(f"FFM {orig_ffm_name} CANCELADO confirmado; continúa cancelación documental")
 
-			# 2.5) HARDENING PREVENTIVO - ANTES de cancelar (CONFIRMADO POR EXPERTO)
-			try:
-				orig_si.reload()
-				orig_ffm.reload()
+			# 3) Completar la cancelación DOCUMENTAL (idempotente): baja SI y FFM a docstatus=2.
+			doc_res = _complete_documental_cancellation(orig_ffm_name, orig_si_name)
 
-				# Limpiar SI → FFM link ANTES de cancel()
-				if getattr(orig_si, "fm_factura_fiscal_mx", None):
-					ffm_ref = orig_si.fm_factura_fiscal_mx
-					orig_si.db_set("fm_factura_fiscal_mx", "")
-					frappe.db.commit()  # Forzar commit inmediato
-					orig_si.add_comment("Info", f"Link FFM limpiado preventivo: {ffm_ref}")
-					frappe.logger().info(f"Hardening preventivo 1: SI {orig_si_name} → FFM link limpiado")
-
-				# Limpiar FFM → SI link ANTES de cancel()
-				if getattr(orig_ffm, "sales_invoice", None):
-					si_ref = orig_ffm.sales_invoice
-					orig_ffm.db_set("sales_invoice", "")
-					frappe.db.commit()  # Forzar commit inmediato
-					orig_ffm.add_comment("Info", f"Link SI limpiado preventivo: {si_ref}")
-					frappe.logger().info(f"Hardening preventivo 2: FFM {orig_ffm_name} → SI link limpiado")
-
-			except Exception as e:
-				frappe.logger().error(f"Error en hardening preventivo: {e}")
-
-			# 3) REORDER: Cancelar SI original PRIMERO (sin links que validen)
-			try:
-				orig_si.reload()  # CONCURRENCY FIX: reload antes de cancelar
-				if cstr(orig_si.docstatus) == "1":
-					orig_si.cancel()
-					frappe.logger().info(f"SI {orig_si_name} cancelado (docstatus=2)")
-			except Exception as e:
-				frappe.logger().error(f"Error cancelando SI original: {e}")
-
-			# Restaurar link sales_invoice en FFM original (limpiado por hardening preventivo)
-			try:
-				orig_ffm.db_set("sales_invoice", orig_si_name)
-				frappe.logger().info(f"Link sales_invoice restaurado en FFM {orig_ffm_name} → {orig_si_name}")
-			except Exception as e:
-				frappe.logger().warning(f"No se pudo restaurar link sales_invoice en FFM: {e}")
-
-			# 4) REORDER: Cancelar FFM original DESPUÉS (con reload)
-			try:
-				orig_ffm.reload()  # CONCURRENCY FIX: reload antes de cancelar
-				if cstr(orig_ffm.docstatus) == "1":
-					orig_ffm.cancel()
-					frappe.logger().info(f"FFM {orig_ffm_name} cancelada (docstatus=2)")
-			except Exception as e:
-				frappe.logger().error(f"Error cancelando FFM original: {e}")
-
-			# 5) Garantizar acuse de cancelación en FFM original (tras cancelar FFM)
+			# 4) Garantizar acuse de cancelación en la FFM original (si el PAC lo aceptó en este intento).
 			if cancel_result and cancel_result.get("status") in ["accepted", "accepted_with_details"]:
 				try:
 					_download_and_attach_cancellation_ack(
 						ffm_name=orig_ffm_name,
-						uuid=getattr(orig_ffm, "fm_uuid", src_uuid),
+						uuid=frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "fm_uuid")
+						or src_uuid,
 						cancel_result=cancel_result,
 					)
 				except Exception as e:
 					frappe.log_error(f"Acuse cancelación pendiente o error descarga: {e}", "FFM Cancel Ack")
-					# Marcar como pendiente para reintento manual
 					try:
-						orig_ffm.db_set("ack_pending", 1)
+						frappe.db.set_value("Factura Fiscal Mexico", orig_ffm_name, "ack_pending", 1)
 					except Exception:
 						pass
 
-		return {"cascade": "completed"}
+		return {"cascade": "completed", **doc_res}
 
 	except Exception as e:
 		frappe.logger().error(f"Error en cascada de cancelación: {e}")
 		return {"cascade": "error", "message": str(e)}
+
+
+def _mark_substitution_cancellation_pending(orig_ffm_name, orig_si_name, error=None):
+	"""Deja A en PENDIENTE_CANCELACION (fiscal) + fm_sync_status='pending' + fm_sync_error, SIN tocar
+	docstatus ni el timbrado de B. Reutiliza apply_cancellation_state (writer autoritativo). El
+	scheduler `retry_pending_substitution_cancellations` la retomará (durabilidad vía estado en BD)."""
+	from facturacion_mexico.facturacion_fiscal.cancellation_state import apply_cancellation_state
+
+	try:
+		apply_cancellation_state(orig_ffm_name, FiscalStates.PENDIENTE_CANCELACION, sync_status="pending")
+	except Exception as e:
+		frappe.logger().error(f"No se pudo marcar PENDIENTE_CANCELACION {orig_ffm_name}: {e}")
+	msg = (
+		"Sustitución 01: el CFDI sustituto quedó timbrado, pero la cancelación del CFDI anterior "
+		"quedó pendiente porque el PAC no la procesó en el intento inmediato. El sistema la "
+		"reintentará automáticamente."
+	)
+	if error:
+		msg += f" Último error: {str(error)[:200]}"
+	try:
+		frappe.db.set_value("Factura Fiscal Mexico", orig_ffm_name, "fm_sync_error", msg)
+	except Exception:
+		pass
+
+
+def _mark_substitution_cancellation_definitive_error(orig_ffm_name, detail):
+	"""Saca a A del ciclo de reintento automático (fm_sync_status='error') y deja mensaje accionable."""
+	frappe.db.set_value(
+		"Factura Fiscal Mexico",
+		orig_ffm_name,
+		{
+			"fm_sync_status": "error",
+			"fm_sync_error": (
+				f"Cancelación de sustitución (motivo 01) no recuperable automáticamente: "
+				f"{str(detail)[:200]}. Requiere intervención manual."
+			),
+		},
+	)
+	frappe.logger().error(f"Substitution cancel definitivo {orig_ffm_name}: {detail}")
+
+
+def retry_pending_substitution_cancellations():
+	"""Scheduler (cada 1 min): reintenta cancelaciones motivo 01 de SUSTITUCIÓN que quedaron
+	PENDIENTE_CANCELACION tras fallar el intento inmediato de la cascada.
+
+	Idempotente y durable: el estado vive en BD (PENDIENTE_CANCELACION + fm_sync_status='pending');
+	tras un reinicio de workers/Redis/bench, el siguiente ciclo redescubre el caso. NO usa contadores
+	ni jobs efímeros. NO altera el contrato de run_auto_reconciliation (que sigue siendo solo lectura).
+
+	ACOTADO para no bloquear la API del PAC: a lo sumo _SUBSTITUTION_CANCEL_BATCH casos por tick
+	(el resto se retoma en el siguiente minuto), y cada caso se abandona pasada _SUBSTITUTION_CANCEL_MAX_AGE_MIN."""
+	pendientes = frappe.db.count(
+		"Factura Fiscal Mexico",
+		{"status": FiscalStates.PENDIENTE_CANCELACION, "fm_sync_status": "pending"},
+	)
+	candidates = frappe.get_all(
+		"Factura Fiscal Mexico",
+		filters={"status": FiscalStates.PENDIENTE_CANCELACION, "fm_sync_status": "pending"},
+		order_by="modified asc",  # los más antiguos primero
+		limit=_SUBSTITUTION_CANCEL_BATCH,
+		pluck="name",
+	)
+	if pendientes > len(candidates):
+		frappe.logger().warning(
+			f"retry_pending_substitution_cancellations: {pendientes} pendientes, procesando "
+			f"{len(candidates)} este tick; el resto se retoma en el siguiente ciclo."
+		)
+	for ffm_name in candidates:
+		try:
+			_retry_one_substitution_cancellation(ffm_name)
+		except Exception as e:
+			frappe.logger().error(f"retry_pending_substitution_cancellations {ffm_name}: {e}")
+
+
+def _retry_one_substitution_cancellation(orig_ffm_name):
+	"""Procesa UNA A pendiente: GET-first (canceled->reconcilia; valid->1 DELETE; definitivo->sale).
+	Solo actúa si A es ORIGEN de una sustitución real (existe B timbrado que la relaciona)."""
+	orig = frappe.db.get_value(
+		"Factura Fiscal Mexico",
+		orig_ffm_name,
+		["sales_invoice", "fm_uuid", "facturapi_id", "status", "fm_last_pac_sync"],
+		as_dict=True,
+	)
+	if not orig or (orig.status or "").upper() != FiscalStates.PENDIENTE_CANCELACION:
+		return
+	a_uuid = (orig.fm_uuid or "").strip()
+	if not a_uuid or not orig.facturapi_id:
+		return
+	# Debe ser origen de sustitución real: existe B (Sales Invoice) que la relaciona y está timbrado.
+	b_si = frappe.db.get_value("Sales Invoice", {"ffm_substitution_source_uuid": a_uuid}, "name")
+	if not b_si:
+		return
+	b = frappe.db.get_value(
+		"Factura Fiscal Mexico",
+		{"sales_invoice": b_si, "status": FiscalStates.TIMBRADO},
+		["fm_uuid", "fecha_timbrado", "creation"],
+		as_dict=True,
+	)
+	if not b or not b.fm_uuid:
+		return
+	b_uuid = b.fm_uuid
+
+	# ANCLA correcta: momento en que A pasó a PENDIENTE_CANCELACION = instante del timbrado de B
+	# (la cascada corre ahí). fecha_timbrado es inmutable tras timbrar; fallback a creation por si
+	# faltara. NO se usa B.creation directo: B puede vivir como borrador horas antes de timbrarse.
+	ancla = b.fecha_timbrado or b.creation
+	edad_min = time_diff_in_seconds(now_datetime(), ancla) / 60.0
+
+	# COTA DURA anti-bloqueo: pasada la ventana total, se abandona el ciclo automático SIN volver a
+	# llamar al PAC. Queda como error accionable para intervención/alertas.
+	if edad_min > _SUBSTITUTION_CANCEL_MAX_AGE_MIN:
+		_mark_substitution_cancellation_definitive_error(
+			orig_ffm_name,
+			f"Excedió la ventana de reintento automático ({_SUBSTITUTION_CANCEL_MAX_AGE_MIN} min).",
+		)
+		return
+
+	# THROTTLE escalonado (sin contadores): dentro de la ventana rápida inicial, 1 intento por tick
+	# de 1 min. Pasada esa ventana, solo si transcurrieron ≥SLOW_INTERVAL desde el último contacto
+	# con el PAC (fm_last_pac_sync). Cronología: t0→+0.5s→+1s→+1..+5 min→luego ~cada 5 min.
+	if edad_min > _SUBSTITUTION_CANCEL_FAST_WINDOW_MIN and orig.fm_last_pac_sync:
+		desde_ultimo_min = time_diff_in_seconds(now_datetime(), orig.fm_last_pac_sync) / 60.0
+		if desde_ultimo_min < _SUBSTITUTION_CANCEL_SLOW_INTERVAL_MIN:
+			return  # aún en enfriamiento; el próximo tick que cumpla el intervalo reintentará
+
+	with frappe.cache().lock(f"ffm:cascade:{orig_ffm_name}", timeout=30):
+		if (
+			frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "status") or ""
+		).upper() != FiscalStates.PENDIENTE_CANCELACION:
+			return
+		api = TimbradoAPI()
+
+		# Sello de contacto con el PAC para el throttling (marca este tick como intento consumido,
+		# aunque el GET falle). update_modified=False para no alterar el orden del selector.
+		frappe.db.set_value(
+			"Factura Fiscal Mexico",
+			orig_ffm_name,
+			"fm_last_pac_sync",
+			now_datetime(),
+			update_modified=False,
+		)
+
+		# GET-first: estado remoto REAL de A.
+		try:
+			r = api.client.get_invoice(orig.facturapi_id)
+			raw = r.get("raw_response") if isinstance(r, dict) else r
+			remote = (raw.get("status") if isinstance(raw, dict) else "") or ""
+		except Exception as e:
+			# GET transitorio (red/timeout): conservar pending; el próximo ciclo reintenta.
+			frappe.logger().warning(f"Scheduled retry: GET A {orig_ffm_name} falló (transitorio): {e}")
+			return
+
+		if remote == "canceled":
+			# Ya cancelado en el PAC: NO reenviar DELETE. Reconciliar + completar documental.
+			from facturacion_mexico.facturacion_fiscal.cancellation_state import apply_cancellation_state
+
+			apply_cancellation_state(
+				orig_ffm_name, FiscalStates.CANCELADO, sync_status="synced", cancellation_date=now_datetime()
+			)
+			_complete_documental_cancellation(orig_ffm_name, orig.sales_invoice)
+			frappe.db.set_value("Factura Fiscal Mexico", orig_ffm_name, "fm_sync_error", "")
+			frappe.logger().info(
+				f"Scheduled retry: A {orig_ffm_name} ya 'canceled' en PAC -> reconciliado + documental."
+			)
+			return
+
+		if remote == "valid":
+			# A sigue vigente: reenviar UN DELETE motivo 01 + UUID_B. Se pasa el flag interno para que
+			# cancelar_factura acepte reintentar una FFM en PENDIENTE_CANCELACION (el guard manual sigue
+			# exigiendo TIMBRADO). El fallo puede llegar de DOS formas: excepción O retorno
+			# {success: False} — se manejan ambas, sin interpretar un fallo como éxito.
+			try:
+				res = api.cancelar_factura(orig.sales_invoice, "01", b_uuid, _allow_pending_cancellation=True)
+			except Exception as e:
+				if _is_transient_pac_error(e):
+					frappe.logger().warning(f"Scheduled retry: DELETE A {orig_ffm_name} transitorio: {e}")
+					return  # conservar pending -> siguiente ciclo
+				_mark_substitution_cancellation_definitive_error(orig_ffm_name, e)
+				return
+			if isinstance(res, dict) and res.get("success") is False:
+				err = res.get("error") or res.get("message") or "cancelación no exitosa"
+				if _is_transient_pac_error(err):
+					frappe.logger().warning(
+						f"Scheduled retry: DELETE A {orig_ffm_name} success=False transitorio: {err}"
+					)
+					return  # conservar pending -> siguiente ciclo
+				_mark_substitution_cancellation_definitive_error(orig_ffm_name, err)
+				return
+			if (
+				frappe.db.get_value("Factura Fiscal Mexico", orig_ffm_name, "status")
+				== FiscalStates.CANCELADO
+			):
+				_complete_documental_cancellation(orig_ffm_name, orig.sales_invoice)
+				frappe.db.set_value("Factura Fiscal Mexico", orig_ffm_name, "fm_sync_error", "")
+			return  # si quedó pending en PAC, conservar y reintentar en el siguiente ciclo
+
+		# Estado remoto inesperado/incompatible -> intervención (sale del ciclo automático).
+		_mark_substitution_cancellation_definitive_error(orig_ffm_name, f"Estado remoto inesperado: {remote}")
 
 
 def _download_and_attach_cancellation_ack(ffm_name: str, uuid: str, cancel_result: dict):

--- a/facturacion_mexico/hooks.py
+++ b/facturacion_mexico/hooks.py
@@ -453,6 +453,12 @@ scheduler_events = {
 		"facturacion_mexico.facturacion_fiscal.services.ffm_reconciliation.run_auto_reconciliation",
 	],
 	"cron": {
+		# Reintento diferido de cancelaciones motivo 01 (SUSTITUCIÓN) que quedaron PENDIENTE_CANCELACION
+		# tras agotar los reintentos inmediatos de la cascada. Acotado (batch + ventana máx) para no
+		# bloquear la API del PAC. Durable vía estado en BD; NO reenvía cancelaciones no-sustitución.
+		"* * * * *": [
+			"facturacion_mexico.facturacion_fiscal.timbrado_api.retry_pending_substitution_cancellations",
+		],
 		# Validación RFC automática nocturna a las 2:00 AM todos los días
 		"0 2 * * *": [
 			"facturacion_mexico.validaciones.api.run_nightly_rfc_validation",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
       - adr/0034-integridad-correlacion-ffm.md
       - adr/0035-motor-reconciliacion-ffm.md
       - adr/0036-integridad-proyeccion-cancelacion.md
+      - adr/0037-resiliencia-cancelacion-sustitucion-motivo-01.md
   - Referencia:
     - referencia/index.md
     - DocTypes: referencia/doctypes.md


### PR DESCRIPTION
## Objetivo

Corregir un defecto real en el flujo de sustitución motivo 01. Al timbrar el CFDI sustituto (B),
la cascada cancela el original (A) con `TipoRelación 04`. Un `404 invoice_not_found` transitorio e
intermitente del PAC inmediatamente después de timbrar B rompía el flujo y presentaba el timbrado
**exitoso** de B como error. Una prueba de integración real contra FacturAPI TEST reprodujo el 404
de forma natural y destapó tres defectos adicionales.

## Cambios principales

- **Cascada — reintentos inmediatos** ante error transitorio: intento 1 (t0) → espera 0.5 s →
  intento 2 → espera 1.0 s → intento 3 (≈ +1.5 s acumulado). Son 3 intentos, ventana total ≈ 1.5 s.
  Si se agotan, A queda `PENDIENTE_CANCELACION` + `fm_sync_status=pending` + `fm_sync_error`,
  **sin falsear el timbrado de B** (nunca `frappe.throw`).
- **Scheduler dedicado** `retry_pending_substitution_cancellations` (cron **cada minuto**): durante
  los primeros **5 minutos** reintenta con frecuencia (hasta 1 intento por minuto); pasada esa
  ventana aplica un **throttle de ~5 minutos** usando `fm_last_pac_sync`; y **abandona
  automáticamente** el caso tras **~2 horas desde `B.fecha_timbrado`** (queda para intervención).
  GET-first; solo procesa orígenes de sustitución reales; batch 50.
- **Guard acotado:** `cancelar_factura(_allow_pending_cancellation=True)` (keyword-only) para el
  reintento automático; el flujo **manual** sigue exigiendo `TIMBRADO`. El scheduler maneja
  excepción **y** retorno `{success: False}` (nunca interpreta un fallo como éxito).
- **Reconciliación (Gap 2):** `run_auto_reconciliation` sigue **solo-lectura**, pero no revierte
  `PENDIENTE_CANCELACION → TIMBRADO` de una sustitución con B `TIMBRADO` vigente.
- **Convergencia documental** idempotente compartida (cascada / scheduler / reconciliación).
- **UX:** mensaje **amarillo** "cancelación anterior pendiente"; nunca falso error de timbrado.

Decisiones y alternativas descartadas (incluido el diseño durable sobredimensionado) en
**[ADR-0037](docs/adr/0037-resiliencia-cancelacion-sustitucion-motivo-01.md)**.

## Documentación actualizada

- `docs/adr/0037-resiliencia-cancelacion-sustitucion-motivo-01.md` (nuevo)
- `docs/usuario/cancelar-cfdi.md` (estado `PENDIENTE_CANCELACION` + mensaje amarillo)
- `docs/tecnico/arquitectura.md` (scheduler, protección de reconciliación, fail-closed/idempotencia)
- `docs/adr/index.md`, `mkdocs.yml` (nav)

## Validaciones realizadas

- `test_cascade_cancel_01_recovery` — **15/15** ✅
- `test_cancelacion_integridad` — **37/37** ✅
- `test_ffm_reconciliation` (incl. Gap 2) — **50/51** ✅ (ver "Riesgos")
- `ruff check` + `ruff format --check` + `prettier@2.7.1 --check` — limpios ✅
- `mkdocs build --strict` — sin ERROR/WARNING ✅
- **Prueba de integración real** (FacturAPI TEST, par A=`FFMX-2026-00045` / B=`FFMX-2026-00046`):
  404 transitorio reproducido; B `TIMBRADO`; XML del sustituto validado (`TipoRelación 04 → UUID_A`,
  `TFD.UUID = UUID_B`); XML local == PAC (SHA-256 idéntico); recuperación convergió a A `CANCELADO`
  (docstatus=2), B `TIMBRADO`.

## Fuera de alcance

- Duplicación de nodos `cfdi:Traslado` (IVA 0%) — incidente separado.
- Sistema de alertas en tiempo real de facturación.
- "Error visual al timbrar hasta refresh".

## Riesgos / pendientes

- **`test_lote_un_fallo_no_detiene` falla en el site local** por 89+ FFM `pending` acumuladas
  previamente en la BD local de pruebas (`test-facturacion.localhost`). **No es regresión de este
  PR** (no toca `_select_candidates`; los tests Gap 2 pasan). **Se espera verde en CI** (BD fresca
  por corrida → el selector solo ve los 2 FFM del propio test).
- **Sin cambios de esquema** → **no requiere `bench migrate`**. La recuperación diferida requiere
  el scheduler activo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved resilience when canceling replaced CFDIs after transient PAC errors.
  * Added automatic retries for pending substitution cancellations, with throttling and safeguards.
  * Substituto stamping now succeeds even when cancellation of the original CFDI remains pending.
  * Added clear in-app messaging for pending cancellations and automatic recovery.

* **Bug Fixes**
  * Prevented reconciliation from incorrectly reverting pending cancellation states.
  * Ensured cancellations are marked complete only after PAC confirmation.

* **Documentation**
  * Added technical and user guidance for the updated cancellation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->