### PR TITLE
fix(fiscal): FFM no nace en ERROR + soporte de moneda extranjera (CFDI currency/exchange)

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,8 +1,8 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-07-21
-**Rama activa:** `fix/ffm-nace-error-fiscal-event-fallback`
-**Tarea actual:** Dos fixes en una sola rama: (1) FFM ya no nace en `ERROR` (commit `a08c65b`); (2) soporte de moneda extranjera en el CFDI (este segundo commit). Ambos validados en GUI/sandbox.
+**Fecha:** 2026-07-22
+**Rama activa:** `fix/ffm-nace-error-fiscal-event-fallback` (PR #217)
+**Tarea actual:** PR #217 con dos fixes: (1) FFM ya no nace en `ERROR` (`a08c65b`); (2) soporte de moneda extranjera en el CFDI (`caf893a`, `001557a` formato). Follow-up: fix de CI (test determinista) + hallazgo CodeRabbit (orden de `on_update`). Pendiente: push del follow-up y re-CI.
 
 ---
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,76 +1,76 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-07-17
-**Rama activa:** `fix/cascade-cancel-01-transient-404-and-doc-reconcile`
-**Tarea actual:** Fix — resiliencia de la cancelación de sustitución (motivo 01) ante fallos transitorios del PAC. **PR #214 abierto**; aplicando fixes post-review de CodeRabbit antes del merge.
+**Fecha:** 2026-07-21
+**Rama activa:** `fix/ffm-nace-error-fiscal-event-fallback`
+**Tarea actual:** Fix — la Factura Fiscal Mexico (FFM) nacía en estado `ERROR` al crearse, sin ninguna llamada al PAC. Commit en la rama (flujo `/ship commit`). Validación GUI ya confirmada por el usuario.
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Corrección de un defecto real en el flujo de sustitución motivo 01. Al timbrar el CFDI sustituto (B),
-la cascada cancela el original (A) con `TipoRelación = 04`; un `404 invoice_not_found` transitorio del
-PAC (consistencia eventual justo tras timbrar B) rompía el flujo y presentaba el timbrado exitoso de B
-como error. La prueba de integración real (par A=`FFMX-2026-00045` / B=`FFMX-2026-00046`, FacturAPI TEST)
-reprodujo el 404 de forma natural y destapó **tres defectos**: (1) B mostrado como error; (2) la
-recuperación diferida no cancelaba nunca porque `cancelar_factura` exige `TIMBRADO` y devolvía
-`{success: False}` sin excepción; (3) `run_auto_reconciliation` revertía `PENDIENTE_CANCELACION → TIMBRADO`
-(valid/none) destruyendo la cancelación en curso.
+Corrección del bug "FFM nace en ERROR". Al crear una FFM (flujo normal desde Sales Invoice), la FFM
+quedaba de inmediato en `ERROR` con todas sus implicaciones (botón "Reintentar Timbrado", badge de sync
+rojo), **sin contactar a FacturAPI**. Causa raíz: los eventos de ciclo de vida de la FFM
+(`create`/`status_change`) se escribían, vía un fallback (`_log_event_to_response_log`), como
+respuestas PAC fallidas en `FacturAPI Response Log` (`success=0`, `operation_type` mapeado por defecto a
+`"Consulta Estado"`, HTTP 500), porque el DocType `Fiscal Event MX` fue deprecado/eliminado. Luego
+`calculate_fiscal_status_from_logs` marcaba `ERROR` ante **cualquier** log `success=0`.
 
 Plan que estoy siguiendo:
-Fix mínimo y proporcionado (sin campos nuevos, sin contadores, un solo scheduler): reintentos inmediatos
-(0.5s/1s) → `PENDIENTE_CANCELACION` sin falsear el timbrado → scheduler cada minuto con throttle escalonado
-y corte 2h → guard interno `_allow_pending_cancellation` (manual sigue exigiendo TIMBRADO) + manejo de
-`{success: False}` → protección Gap 2 en reconciliación (no revertir sustitución vigente) → convergencia
-documental idempotente. UX: mensaje amarillo, nunca falso error. Detalle en ADR-0037.
+Fix mínimo en dos capas (aprobado en revisión con ChatGPT):
+- **Capa 1 (origen):** retirar por completo el fallback y su código muerto — `after_insert`, el bloque
+  `create_fiscal_event` de `on_update`, y los métodos `create_fiscal_event` / `_log_event_to_response_log`.
+  Los guards `fiscal_event_*` de `api/__init__.py` se conservan (defensivos y cubiertos por tests).
+- **Capa 2 (blindaje):** `calculate_fiscal_status_from_logs` deriva `ERROR` fiscal **solo** de un
+  `Timbrado` fallido, consistente con la regla canónica por operación de `api/__init__.py:790-816`.
+  Consulta/reconciliación/cancelación fallidas pertenecen a `fm_sync_status`, no al estado fiscal.
 
 Objetivo inmediato:
-Commit en la rama (flujo `/ship commit`), con código + tests + documentación exigida por el gate.
-Sin push, sin PR (pendientes de autorización separada).
+Commit en la rama (código + test + docs mínimos del gate; sin ADR). Sin push, sin PR (pendientes de
+autorización separada). Después: investigar y registrar con `/ship issue` un problema DISTINTO (validación
+fiscal temprana en Sales Invoice — `ObjetoImp=02` sin impuestos), sin mezclar código.
 
 Criterio de avance:
-Tests específicos verdes (`test_cascade_cancel_01_recovery` 15/15, `test_cancelacion_integridad` 37/37,
-Gap 2 en `test_ffm_reconciliation`) + linters limpios + `mkdocs build --strict` limpio + validación real
-en sandbox (A convergió a CANCELADO/docstatus=2, B TIMBRADO, XML `04 → UUID_A` PASS, local==PAC).
+Tests verdes (`test_ffm_nace_error_fiscal_event` 5/5, más sin regresión en `test_sync_status_semantics`
+17, `test_cancelacion_integridad` 37, `test_cascade_cancel_01_recovery` 15) + `ruff` limpio +
+`mkdocs build --strict` exit 0 + validación GUI del usuario OK (FFM nueva queda en `BORRADOR`).
 
 ---
 
 ## Estado actual
 
-### Ya cerrado
+### Ya cerrado (en esta rama)
 
-- **Cascada:** reintentos inmediatos transitorios (0.5s/1s); si se agotan, A → `PENDIENTE_CANCELACION`
-  + `fm_sync_status=pending` + `fm_sync_error`, sin `frappe.throw` (B queda TIMBRADO).
-- **Scheduler** `retry_pending_substitution_cancellations` (cron `* * * * *` en `hooks.py`): GET-first,
-  throttle escalonado anclado en `B.fecha_timbrado` + `fm_last_pac_sync` (rápido 5 min → ~5 min → corte 2h),
-  batch 50. Solo procesa orígenes de sustitución reales.
-- **Guard acotado:** `cancelar_factura(..., _allow_pending_cancellation=True)` (keyword-only) para el
-  reintento automático; manual intacto. Scheduler maneja excepción **y** `{success: False}`.
-- **Gap 2:** `_es_origen_sustitucion_vigente` en `ffm_reconciliation`; la reconciliación (solo-lectura)
-  no revierte `PENDIENTE_CANCELACION → TIMBRADO` de una sustitución con B TIMBRADO vigente.
-- **Gap 3 / documental:** `_complete_documental_cancellation` única e idempotente (cascada/scheduler/reconcile).
-- **UX:** `base_result.cancelacion_previa_pendiente` → mensaje amarillo en `factura_fiscal_mexico.js`.
-- **Tests:** nuevo `test_cascade_cancel_01_recovery.py` (15) + Gap 2 en `test_ffm_reconciliation.py` (2)
-  + adaptación de `test_cancelacion_integridad` al nuevo contrato.
-- **Docs (gate):** ADR-0037, `docs/usuario/cancelar-cfdi.md`, `docs/tecnico/arquitectura.md`,
-  `mkdocs.yml`, `docs/adr/index.md`.
-- **Validación real (sandbox FacturAPI TEST):** flujo completo verificado end-to-end.
-- **Fix CI (commit `039a18f`):** `si.currency` en el test de recuperación (mismatch MXN/INR en `_Test Company`).
-- **Post-review CodeRabbit (PR #214):** aplicados 12 de 17 — company en cliente PAC (cascada y scheduler),
-  `{success: False}` en reintentos inmediatos, reconcile exige B TIMBRADO, lock `ffm:cascade` compartido en
-  reconciliación, pre-filtro de sustituciones antes del batch (anti-inanición), retorno documental veraz
-  (`completed`/`incomplete`), `canceled_at` real, rename a inglés, IDs únicos en test, docs (docstatus=2 en
-  usuario, MD040 en ADR).
+- **Capa 1:** eliminado el fallback a `FacturAPI Response Log` en `factura_fiscal_mexico.py`
+  (`after_insert`, bloque `create_fiscal_event` de `on_update`, métodos `create_fiscal_event` y
+  `_log_event_to_response_log`). `Factura Global MX` tiene su propio `create_fiscal_event` — no se tocó.
+- **Capa 2:** `calculate_fiscal_status_from_logs` — `ERROR` solo si el último `Timbrado` falló y no hay
+  timbrado/cancelación exitoso posterior. Se retiró la heurística de "cualquier `success=0` en 24h".
+- **Tests:** `test_ffm_nace_error_fiscal_event.py` (5): nace BORRADOR sin logs sintéticos; timbrado
+  fallido → ERROR; fallido→éxito → TIMBRADO; consulta fallida → NO ERROR; PENDIENTE_CANCELACION intacto.
+- **Docs (gate):** `docs/tecnico/arquitectura.md` (derivación de estado fiscal) y
+  `docs/usuario/troubleshooting.md` (FFM en ERROR sin timbrar). Sin ADR (corrige comportamiento contra
+  el diseño existente, no es decisión nueva).
 
-### Pendiente / siguiente paso
+### Siguiente paso concreto
 
-- **Push** de estos fixes a la rama del PR #214 → luego **re-correr la prueba GUI** para confirmar que los
-  cambios de CodeRabbit no rompieron el flujo.
-- **Fuera de alcance / posible issue separado (CodeRabbit):** #6 clasificación estructural de errores PAC;
-  #8 defensa ante fallo de persistencia; #11 limpieza exhaustiva de fixtures de tests; #12 aislamiento de
-  tests con selector global.
-- Otros incidentes separados: duplicación `cfdi:Traslado` (IVA 0%); alertas en tiempo real; error visual al
-  timbrar hasta refresh.
-- Artefactos locales sin commitear (correcto): `one_offs/`, `poc-playwright-demo/val01/`.
-- Servidor dev `facturacion-v16.dev:8888` levantado en tmux `serve_facturacion-v16_dev`.
+1. (Este commit) `/ship commit` en la rama. **Sin push ni PR** hasta autorización.
+2. Investigar + `/ship issue` del problema de **validación fiscal temprana en Sales Invoice**
+   (`ObjetoImp=02` sin impuestos por configuración fiscal de sucursal incompleta; se detecta tarde, en
+   la FFM antes del timbrado). Solo issue, sin código, sin rama nueva.
+3. **Remediación de datos (separada, futura, con autorización):** las FFM históricas ya pegadas en
+   `ERROR` deben recalcularse (one-off idempotente por sitio) tras desplegar y validar el fix.
+
+---
+
+## Decisiones vigentes no reflejadas en código
+
+- **RCA cronología (cerrada):** el bug estaba latente desde agosto 2025 (commits #37/#51/#60). El
+  disparador operativo fue la eliminación efectiva del DocType `Fiscal Event MX` de la BD de producción
+  entre el 15 y el 18 de junio de 2026 (no se conserva evidencia del deploy/migración específico). Antes
+  del 15-jun el `frappe.db.exists` daba True y el fallback no corría; desde el 18-jun las FFM nacen en ERROR.
+- **`fm_sync_status` / `fm_sync_error`:** NO se tocan en este fix (capa distinta con su propia derivación).
+- **Config FacturAPI de `llantascs-v16.dev`** (aparte de este fix): ya saneada a sandbox (sk_live borrada,
+  `sandbox_mode=1`); el usuario carga la `sk_test` real. Prevención universal en issue #215 (guards
+  multi-capa + indicador de ambiente).

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-07-22
 **Rama activa:** `fix/ffm-nace-error-fiscal-event-fallback` (PR #217)
-**Tarea actual:** PR #217 con dos fixes: (1) FFM ya no nace en `ERROR` (`a08c65b`); (2) soporte de moneda extranjera en el CFDI (`caf893a`, `001557a` formato). Follow-up: fix de CI (test determinista) + hallazgo CodeRabbit (orden de `on_update`). Pendiente: push del follow-up y re-CI.
+**Tarea actual:** PR #217 con dos fixes: (1) FFM ya no nace en `ERROR` (`a08c65b`); (2) soporte de moneda extranjera en el CFDI (`caf893a`, `001557a` formato). Follow-ups: reorder `on_update` (CodeRabbit) + determinismo de CI en `test_cfdi_moneda_extranjera` (Address Template, Company USD para el guard, y Company MXN ligada al Año Fiscal vigente). Pendiente: re-CI del PR.
 
 ---
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,39 +2,42 @@
 
 **Fecha:** 2026-07-21
 **Rama activa:** `fix/ffm-nace-error-fiscal-event-fallback`
-**Tarea actual:** Fix — la Factura Fiscal Mexico (FFM) nacía en estado `ERROR` al crearse, sin ninguna llamada al PAC. Commit en la rama (flujo `/ship commit`). Validación GUI ya confirmada por el usuario.
+**Tarea actual:** Dos fixes en una sola rama: (1) FFM ya no nace en `ERROR` (commit `a08c65b`); (2) soporte de moneda extranjera en el CFDI (este segundo commit). Ambos validados en GUI/sandbox.
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Corrección del bug "FFM nace en ERROR". Al crear una FFM (flujo normal desde Sales Invoice), la FFM
-quedaba de inmediato en `ERROR` con todas sus implicaciones (botón "Reintentar Timbrado", badge de sync
-rojo), **sin contactar a FacturAPI**. Causa raíz: los eventos de ciclo de vida de la FFM
-(`create`/`status_change`) se escribían, vía un fallback (`_log_event_to_response_log`), como
-respuestas PAC fallidas en `FacturAPI Response Log` (`success=0`, `operation_type` mapeado por defecto a
-`"Consulta Estado"`, HTTP 500), porque el DocType `Fiscal Event MX` fue deprecado/eliminado. Luego
-`calculate_fiscal_status_from_logs` marcaba `ERROR` ante **cualquier** log `success=0`.
+Dos correcciones fiscales, cada una en su propio commit dentro de la **misma** rama:
+
+1. **FFM nace en ERROR** (`a08c65b`, ya commiteado): los eventos de ciclo de vida de la FFM se
+   escribían vía fallback como respuestas PAC fallidas (`success=0` → "Consulta Estado"/500), y
+   `calculate_fiscal_status_from_logs` marcaba `ERROR` ante cualquier `success=0`. Se retiró el
+   fallback (Capa 1) y se acotó la derivación de `ERROR` a un `Timbrado` fallido (Capa 2).
+
+2. **Moneda extranjera en el CFDI** (este commit): el payload a FacturAPI **no** declaraba
+   `currency` ni `exchange` → FacturAPI asumía MXN y una factura en USD quedaba bloqueada por
+   "Moneda Inconsistente". Se agregó `resolve_cfdi_currency_exchange` (deriva moneda/tipo de cambio
+   de la Sales Invoice: MXN → exchange 1; divisa → `conversion_rate`) y se cableó `currency`/
+   `exchange` en `_prepare_facturapi_data`. Los importes ya iban en moneda de transacción
+   (`net_rate`); no se tocaron precios ni impuestos.
 
 Plan que estoy siguiendo:
-Fix mínimo en dos capas (aprobado en revisión con ChatGPT):
-- **Capa 1 (origen):** retirar por completo el fallback y su código muerto — `after_insert`, el bloque
-  `create_fiscal_event` de `on_update`, y los métodos `create_fiscal_event` / `_log_event_to_response_log`.
-  Los guards `fiscal_event_*` de `api/__init__.py` se conservan (defensivos y cubiertos por tests).
-- **Capa 2 (blindaje):** `calculate_fiscal_status_from_logs` deriva `ERROR` fiscal **solo** de un
-  `Timbrado` fallido, consistente con la regla canónica por operación de `api/__init__.py:790-816`.
-  Consulta/reconciliación/cancelación fallidas pertenecen a `fm_sync_status`, no al estado fiscal.
+Fix mínimo por feature, commits separados en la misma rama. Se hizo explícita y fail-closed la
+suposición de **moneda base MXN** (emitir en divisa desde empresa con base ≠ MXN se bloquea:
+`conversion_rate` solo equivale a "pesos por unidad" con base MXN, y la app no lo garantiza).
 
 Objetivo inmediato:
-Commit en la rama (código + test + docs mínimos del gate; sin ADR). Sin push, sin PR (pendientes de
-autorización separada). Después: investigar y registrar con `/ship issue` un problema DISTINTO (validación
-fiscal temprana en Sales Invoice — `ObjetoImp=02` sin impuestos), sin mezclar código.
+Segundo commit (moneda) en la rama. Después: flujo normal paso a paso (push → PR → merge →
+`/sync-check`) con autorización explícita en cada paso. Al cierre: revisión de tags/releases y crear
+el release correspondiente.
 
 Criterio de avance:
-Tests verdes (`test_ffm_nace_error_fiscal_event` 5/5, más sin regresión en `test_sync_status_semantics`
-17, `test_cancelacion_integridad` 37, `test_cascade_cancel_01_recovery` 15) + `ruff` limpio +
-`mkdocs build --strict` exit 0 + validación GUI del usuario OK (FFM nueva queda en `BORRADOR`).
+Tests verdes (`test_cfdi_moneda_extranjera` 10/10, `test_ffm_nace_error_fiscal_event` 5/5,
+regresión `test_cancelacion_integridad` 37 / `test_e4_puente_si_pac` 17) + `ruff` + `mkdocs
+--strict` limpios + validación GUI/sandbox (USD `FFMX-2026-00299`: `Moneda=USD`,
+`TipoCambio=17.3943`, subtotal/IVA/total en USD, `livemode=false`).
 
 ---
 
@@ -42,35 +45,34 @@ Tests verdes (`test_ffm_nace_error_fiscal_event` 5/5, más sin regresión en `te
 
 ### Ya cerrado (en esta rama)
 
-- **Capa 1:** eliminado el fallback a `FacturAPI Response Log` en `factura_fiscal_mexico.py`
-  (`after_insert`, bloque `create_fiscal_event` de `on_update`, métodos `create_fiscal_event` y
-  `_log_event_to_response_log`). `Factura Global MX` tiene su propio `create_fiscal_event` — no se tocó.
-- **Capa 2:** `calculate_fiscal_status_from_logs` — `ERROR` solo si el último `Timbrado` falló y no hay
-  timbrado/cancelación exitoso posterior. Se retiró la heurística de "cualquier `success=0` en 24h".
-- **Tests:** `test_ffm_nace_error_fiscal_event.py` (5): nace BORRADOR sin logs sintéticos; timbrado
-  fallido → ERROR; fallido→éxito → TIMBRADO; consulta fallida → NO ERROR; PENDIENTE_CANCELACION intacto.
-- **Docs (gate):** `docs/tecnico/arquitectura.md` (derivación de estado fiscal) y
-  `docs/usuario/troubleshooting.md` (FFM en ERROR sin timbrar). Sin ADR (corrige comportamiento contra
-  el diseño existente, no es decisión nueva).
+- **Commit `a08c65b`** — FFM nace en ERROR: retiro del fallback (`after_insert`, bloque
+  `create_fiscal_event` de `on_update`, métodos `create_fiscal_event` / `_log_event_to_response_log`)
+  + `calculate_fiscal_status_from_logs` deriva `ERROR` solo de `Timbrado` fallido. Test
+  `test_ffm_nace_error_fiscal_event` (5). Docs: arquitectura + troubleshooting.
+- **Commit moneda (este)** — `resolve_cfdi_currency_exchange` + cableo `currency`/`exchange` en el
+  payload + guard fail-closed de base MXN. Test `test_cfdi_moneda_extranjera` (10: helper + payload
+  real MXN/USD, guard base, verificación de no-uso de `base_net_rate`). Docs: arquitectura
+  (Moneda del CFDI) + troubleshooting (factura en divisa).
 
 ### Siguiente paso concreto
 
-1. (Este commit) `/ship commit` en la rama. **Sin push ni PR** hasta autorización.
-2. Investigar + `/ship issue` del problema de **validación fiscal temprana en Sales Invoice**
-   (`ObjetoImp=02` sin impuestos por configuración fiscal de sucursal incompleta; se detecta tarde, en
-   la FFM antes del timbrado). Solo issue, sin código, sin rama nueva.
-3. **Remediación de datos (separada, futura, con autorización):** las FFM históricas ya pegadas en
-   `ERROR` deben recalcularse (one-off idempotente por sitio) tras desplegar y validar el fix.
+1. (Hecho) `/ship commit` del fix de moneda. **Sin push ni PR** hasta autorización.
+2. Flujo normal paso a paso: `/ship push` → `/ship pr` → (merge lo hace el usuario) → `/sync-check`.
+3. **Al cierre:** revisión de tags/releases y crear el release correspondiente.
+
+### Fuera de este trabajo (sin commitear)
+
+- `one_offs/verificar_payload_moneda.py` — verificador de payload solo-lectura (queda fuera del commit).
+- Issues abiertos aparte: #215 (guards de ambiente FacturAPI multi-capa), #216 (validación fiscal
+  temprana ObjetoImp=02 sin impuestos en Sales Invoice).
 
 ---
 
 ## Decisiones vigentes no reflejadas en código
 
-- **RCA cronología (cerrada):** el bug estaba latente desde agosto 2025 (commits #37/#51/#60). El
-  disparador operativo fue la eliminación efectiva del DocType `Fiscal Event MX` de la BD de producción
-  entre el 15 y el 18 de junio de 2026 (no se conserva evidencia del deploy/migración específico). Antes
-  del 15-jun el `frappe.db.exists` daba True y el fallback no corría; desde el 18-jun las FFM nacen en ERROR.
-- **`fm_sync_status` / `fm_sync_error`:** NO se tocan en este fix (capa distinta con su propia derivación).
-- **Config FacturAPI de `llantascs-v16.dev`** (aparte de este fix): ya saneada a sandbox (sk_live borrada,
-  `sandbox_mode=1`); el usuario carga la `sk_test` real. Prevención universal en issue #215 (guards
-  multi-capa + indicador de ambiente).
+- **`fm_sync_status` / `fm_sync_error`:** capa distinta con su propia derivación; no se tocan.
+- **Moneda base MXN:** la app no la garantiza (solo la recomienda en `install.py`). Emitir CFDI en
+  divisa exige base MXN; en caso contrario se bloquea. La FFM no guarda copia de moneda/tipo de
+  cambio: siempre se derivan de la Sales Invoice.
+- **Config FacturAPI de `llantascs-v16.dev`:** saneada a sandbox (`sandbox_mode=1`, `sk_live` borrada;
+  el usuario cargó la `sk_test`). Prevención universal en issue #215.

--- a/docs/tecnico/arquitectura.md
+++ b/docs/tecnico/arquitectura.md
@@ -40,6 +40,22 @@ El `status` de la Factura Fiscal Mexico se calcula desde los `FacturAPI Response
   canónica por operación de `api/__init__.py`. Consulta, reconciliación y cancelación fallidas
   pertenecen a `fm_sync_status`, no al estado fiscal.
 
+### Moneda del CFDI (`currency` / `exchange`)
+
+El payload a FacturAPI declara la moneda y el tipo de cambio derivados de la Sales Invoice, que es
+la **fuente de verdad** (`resolve_cfdi_currency_exchange` en `timbrado_api.py`):
+
+- `SI.currency = MXN` → `currency = "MXN"`, `exchange = 1` (por definición del CFDI, sin importar la
+  moneda base contable).
+- `SI.currency = <divisa>` → `currency = <divisa>`, `exchange = SI.conversion_rate`.
+
+Los importes de los conceptos van en la **moneda de la transacción** (`item.net_rate`, base de IVA
+sobre `net_rate`); **nunca** en campos `base_*` convertidos a la moneda base. `FacturAPI.exchange`
+(pesos por unidad de la divisa) equivale a `ERPNext.conversion_rate` **solo si la moneda base de la
+empresa es MXN**; la app no lo garantiza (solo lo recomienda en el setup), por lo que emitir en
+divisa desde una empresa con base ≠ MXN se **bloquea** explícitamente (fail-closed). La FFM **no**
+guarda copia propia de moneda/tipo de cambio: siempre se derivan de la Sales Invoice.
+
 ## Flujo E-Receipt / Autofactura
 
 ```text

--- a/docs/tecnico/arquitectura.md
+++ b/docs/tecnico/arquitectura.md
@@ -29,6 +29,17 @@ Sales Invoice (submit)
   → timbrado_api.py → FacturAPI.io → SAT
 ```
 
+### Derivación del estado fiscal de la FFM
+
+El `status` de la Factura Fiscal Mexico se calcula desde los `FacturAPI Response Log`
+(`calculate_fiscal_status_from_logs`). Reglas vigentes:
+
+- Una FFM recién creada queda en `BORRADOR`; su creación **no** contacta al PAC ni escribe logs.
+- `TIMBRADO` / `CANCELADO` / `PENDIENTE_CANCELACION` derivan de logs PAC exitosos.
+- `ERROR` fiscal deriva **exclusivamente de un `Timbrado` fallido**, consistente con la regla
+  canónica por operación de `api/__init__.py`. Consulta, reconciliación y cancelación fallidas
+  pertenecen a `fm_sync_status`, no al estado fiscal.
+
 ## Flujo E-Receipt / Autofactura
 
 ```text

--- a/docs/usuario/troubleshooting.md
+++ b/docs/usuario/troubleshooting.md
@@ -14,6 +14,19 @@ o de consulta se reflejan en `fm_sync_status`, no en el estado fiscal.
 
 ---
 
+## Factura en moneda extranjera (USD u otra)
+
+El CFDI hereda la **moneda** y el **tipo de cambio** de la Sales Invoice:
+
+- La SI debe tener su moneda (ej. `USD`) y un tipo de cambio (`conversion_rate`) válido (> 0).
+- La empresa emisora debe tener **moneda base MXN**. Si no, el timbrado se bloquea con
+  **"Moneda base no soportada"**: el tipo de cambio del CFDI (pesos por unidad de la divisa) solo se
+  deriva automáticamente desde `conversion_rate` cuando la base de la empresa es MXN.
+- Los importes del CFDI (subtotal, IVA, total) quedan **en la moneda de la factura**, no convertidos
+  a pesos. El CFDI incluye `Moneda` y `TipoCambio` conforme al CFDI 4.0.
+
+---
+
 ## Timbrado falla al hacer Submit
 
 **Verificar en orden:**

--- a/docs/usuario/troubleshooting.md
+++ b/docs/usuario/troubleshooting.md
@@ -4,6 +4,16 @@ Solución a los problemas más comunes.
 
 ---
 
+## La Factura Fiscal aparece en ERROR sin haberla timbrado
+
+Una Factura Fiscal Mexico recién creada debe quedar en **BORRADOR**. El estado **ERROR** solo
+aparece cuando un intento real de **Timbrado** fue rechazado por el PAC. Si ves una FFM en
+`ERROR` que nunca se envió a timbrar, es un estado incorrecto: revisa el `FacturAPI Response Log`
+de esa factura; solo un `Timbrado` fallido debe producir `ERROR`. Los problemas de sincronización
+o de consulta se reflejan en `fm_sync_status`, no en el estado fiscal.
+
+---
+
 ## Timbrado falla al hacer Submit
 
 **Verificar en orden:**

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -634,86 +634,13 @@ class FacturaFiscalMexico(Document):
 		# NO actualizar campo status - es manejado por Frappe
 		# self.calculate_status_from_fiscal_status() # DEPRECADO - no usar campo status estándar
 
-	def after_insert(self):
-		"""Ejecutar después de insertar."""
-		# Crear evento fiscal
-		self.create_fiscal_event(
-			"create",
-			{"sales_invoice": self.sales_invoice, "company": self.company, "status": self.status},
-		)
-
 	def on_update(self):
 		"""Ejecutar después de actualizar."""
-		# Si el estado cambió, crear evento fiscal
-		if self.has_value_changed("status"):
-			self.create_fiscal_event(
-				"status_change",
-				{
-					"old_status": self.get_doc_before_save().status
-					if self.get_doc_before_save()
-					else "BORRADOR",
-					"new_status": self.status,
-					"uuid": self.fm_uuid,
-					"facturapi_id": getattr(self, "facturapi_id", None),
-				},
-			)
-
 		# Actualizar Sales Invoice con información fiscal
 		self.update_sales_invoice_fiscal_info()
 
 		# Recalcular estado fiscal basado en logs
 		self.calculate_fiscal_status_from_logs()
-
-	def create_fiscal_event(self, event_type, event_data):
-		"""Crear evento fiscal - ELIMINACIÓN EN PROGRESO (FASE 0)."""
-		try:
-			# GUARD INMEDIATO: Verificar existencia DocType
-			if not frappe.db.exists("DocType", "Fiscal Event MX"):
-				# FALLBACK: Usar Response Log como única fuente verdad
-				self._log_event_to_response_log(event_type, event_data)
-				return None
-
-			# Código original (si DocType existe - transición suave)
-			fiscal_event = frappe.new_doc("Fiscal Event MX")
-			fiscal_event.event_type = event_type
-			fiscal_event.reference_doctype = self.doctype
-			fiscal_event.reference_name = self.name
-			fiscal_event.event_data = frappe.as_json(event_data)
-			fiscal_event.status = "success"
-			fiscal_event.user_role = (
-				frappe.get_roles(frappe.session.user)[0] if frappe.get_roles(frappe.session.user) else "Guest"
-			)
-			fiscal_event.save(ignore_permissions=True)
-
-		except Exception as e:
-			# ERROR: También loggear en Response Log
-			self._log_event_to_response_log(
-				f"error_{event_type}", {"error": str(e), "original_data": event_data}
-			)
-			frappe.log_error(f"Error creating fiscal event: {e!s}", "Fiscal Event Creation Error")
-
-	def _log_event_to_response_log(self, event_type, event_data):
-		"""Fallback: usar Response Log para eventos fiscales."""
-		try:
-			import json
-
-			from facturacion_mexico.facturacion_fiscal.api import write_pac_response
-
-			write_pac_response(
-				self.sales_invoice or self.name,
-				json.dumps({"event_type": event_type, "source": "fiscal_event_fallback"}),
-				json.dumps(event_data),
-				f"fiscal_event_{event_type}",
-				factura_fiscal_name=self.name,
-			)
-
-			frappe.logger().info(f"Fiscal event logged to Response Log: {event_type} for {self.name}")
-
-		except Exception as fallback_error:
-			frappe.log_error(
-				f"Error in fiscal event fallback: {fallback_error!s}\nOriginal event: {event_type}\nData: {event_data}",
-				"Fiscal Event Fallback Error",
-			)
 
 	def update_sales_invoice_fiscal_info(self):
 		"""Actualizar información fiscal en Sales Invoice."""
@@ -1035,23 +962,25 @@ class FacturaFiscalMexico(Document):
 				if not confirmation_exists:
 					new_status = "PENDIENTE_CANCELACION"
 
-			# Verificar si hay errores recientes
-			recent_error = frappe.db.get_value(
+			# ERROR fiscal SOLO desde un Timbrado realmente fallido. Es la misma regla canónica
+			# por operación que ya aplica api/__init__.py (solo "Timbrado" deriva ERROR fiscal;
+			# consulta, reconciliación y cancelación NO). Cualquier otro log success=0 —incluidos
+			# los eventos sintéticos "fiscal_event_*" y las consultas de estado— pertenece a
+			# fm_sync_status, no al estado fiscal, y NO debe marcar la FFM como ERROR.
+			failed_timbrado = frappe.db.get_value(
 				"FacturAPI Response Log",
 				{
 					"factura_fiscal_mexico": self.name,
+					"operation_type": "Timbrado",
 					"success": 0,
-					"timestamp": (
-						">",
-						frappe.utils.add_days(frappe.utils.now_datetime(), -1),
-					),  # Últimas 24 horas
 				},
-				["operation_type", "timestamp"],
+				"timestamp",
 				order_by="timestamp desc",
 			)
 
-			# Si hay error reciente y no hay éxito posterior, marcar como Error
-			if recent_error and not latest_log:
+			# Marcar ERROR solo si el último Timbrado falló y no hay timbrado/cancelación exitoso
+			# posterior (latest_log). Así un éxito posterior siempre prevalece sobre el ERROR.
+			if failed_timbrado and not latest_log:
 				new_status = "ERROR"
 
 			# Actualizar estado solo si cambió usando db_set (reconocido por semgrep)

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -636,11 +636,12 @@ class FacturaFiscalMexico(Document):
 
 	def on_update(self):
 		"""Ejecutar después de actualizar."""
+		# Recalcular el estado fiscal desde los logs ANTES de sincronizar la Sales Invoice, para que
+		# la SI reciba el estado fiscal ya recalculado (no el previo) en el mismo update.
+		self.calculate_fiscal_status_from_logs()
+
 		# Actualizar Sales Invoice con información fiscal
 		self.update_sales_invoice_fiscal_info()
-
-		# Recalcular estado fiscal basado en logs
-		self.calculate_fiscal_status_from_logs()
 
 	def update_sales_invoice_fiscal_info(self):
 		"""Actualizar información fiscal en Sales Invoice."""

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cfdi_moneda_extranjera.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cfdi_moneda_extranjera.py
@@ -62,9 +62,7 @@ class TestResolveCurrencyExchange(FrappeTestCase):
 	def test_usd_sin_tipo_cambio_falla(self):
 		for bad in (0, -3):
 			with self.assertRaises(frappe.ValidationError):
-				resolve_cfdi_currency_exchange(
-					frappe._dict(name="SI-Z", currency="USD", conversion_rate=bad)
-				)
+				resolve_cfdi_currency_exchange(frappe._dict(name="SI-Z", currency="USD", conversion_rate=bad))
 
 	def test_guard_empresa_base_no_mxn(self):
 		# `_Test Company` es base INR → emitir en divisa se bloquea (suposición explícita).
@@ -143,17 +141,21 @@ class TestPayloadMoneda(FrappeTestCase):
 		)
 		if not self.debit_to_usd:
 			parent = frappe.db.get_value("Account", self.debit_to, "parent_account")
-			self.debit_to_usd = frappe.get_doc(
-				{
-					"doctype": "Account",
-					"account_name": "Debtors USD",
-					"parent_account": parent,
-					"company": self.company,
-					"account_type": "Receivable",
-					"account_currency": "USD",
-					"is_group": 0,
-				}
-			).insert(ignore_permissions=True).name
+			self.debit_to_usd = (
+				frappe.get_doc(
+					{
+						"doctype": "Account",
+						"account_name": "Debtors USD",
+						"parent_account": parent,
+						"company": self.company,
+						"account_type": "Receivable",
+						"account_currency": "USD",
+						"is_group": 0,
+					}
+				)
+				.insert(ignore_permissions=True)
+				.name
+			)
 		self.income_acc = frappe.db.get_value(
 			"Account", {"company": self.company, "root_type": "Income", "is_group": 0}, "name"
 		)
@@ -201,9 +203,9 @@ class TestPayloadMoneda(FrappeTestCase):
 			"Uso CFDI SAT", {}, "name"
 		)
 		# fm_forma_pago_timbrado debe empezar con el código SAT de 2 dígitos (ej. "01 Efectivo").
-		self.forma_pago = frappe.db.get_value("Mode of Payment", "01 Efectivo", "name") or frappe.db.get_value(
-			"Mode of Payment", {"name": ["like", "0%"]}, "name"
-		)
+		self.forma_pago = frappe.db.get_value(
+			"Mode of Payment", "01 Efectivo", "name"
+		) or frappe.db.get_value("Mode of Payment", {"name": ["like", "0%"]}, "name")
 
 		self.customer = frappe.get_doc(
 			{
@@ -217,7 +219,12 @@ class TestPayloadMoneda(FrappeTestCase):
 		frappe.db.set_value(
 			"Customer",
 			self.customer.name,
-			{"tax_id": "XAXX010101000", "fm_rfc_validated": 1, "fm_uso_cfdi_default": "G03", "fm_tax_regime": "601"},
+			{
+				"tax_id": "XAXX010101000",
+				"fm_rfc_validated": 1,
+				"fm_uso_cfdi_default": "G03",
+				"fm_tax_regime": "601",
+			},
 		)
 		# Dirección primaria (el builder exige CP del receptor).
 		frappe.get_doc(

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cfdi_moneda_extranjera.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cfdi_moneda_extranjera.py
@@ -114,6 +114,22 @@ class TestPayloadMoneda(FrappeTestCase):
 			roc = frappe.db.get_value("Cost Center", {"company": co, "is_group": 0}, "name")
 			frappe.db.set_value("Company", co, {"round_off_account": roa, "round_off_cost_center": roc})
 
+			# Ligar la empresa al Año Fiscal vigente si éste está restringido por empresa (en CI lo
+			# está; en un site fresco la Company nueva no queda cubierta y falla FiscalYearError).
+			from frappe.utils import getdate, today
+
+			d = getdate(today())
+			for fy in frappe.get_all(
+				"Fiscal Year",
+				filters={"year_start_date": ["<=", d], "year_end_date": [">=", d]},
+				pluck="name",
+			):
+				fydoc = frappe.get_doc("Fiscal Year", fy)
+				companies = [c.company for c in (fydoc.get("companies") or [])]
+				if companies and co not in companies:
+					fydoc.append("companies", {"company": co})
+					fydoc.save(ignore_permissions=True)
+
 		# Empresa base USD para probar el guard fail-closed (independiente del entorno).
 		if not frappe.db.exists("Company", cls.USD_COMPANY):
 			frappe.get_doc(
@@ -135,6 +151,7 @@ class TestPayloadMoneda(FrappeTestCase):
 		# usa DELETE directo → sin problemas de jerarquía de cuentas.
 		try:
 			for co in (cls.MXN_COMPANY, cls.USD_COMPANY):
+				frappe.db.delete("Fiscal Year Company", {"company": co})
 				for dt in ("Account", "Cost Center", "Warehouse"):
 					frappe.db.delete(dt, {"company": co})
 				frappe.db.delete("Company", {"name": co})

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cfdi_moneda_extranjera.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cfdi_moneda_extranjera.py
@@ -1,0 +1,325 @@
+"""Moneda del CFDI (currency/exchange) en el payload FacturAPI.
+
+Cambio bajo prueba: el payload declara `currency` y `exchange` derivados de la Sales Invoice, y los
+importes de los conceptos van en la moneda de la transacción (`net_rate`), nunca en `base_*`.
+
+Dos niveles:
+  1. `resolve_cfdi_currency_exchange` (la regla, sin DB).
+  2. Payload real construido por `_prepare_facturapi_data` (MXN y USD sobre una empresa base MXN),
+     que falla si alguien deja de poner `currency`/`exchange` o usa `base_net_rate`.
+
+`get_facturapi_client` se parchea; no hay llamadas de red.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.facturacion_fiscal.timbrado_api import (
+	TimbradoAPI,
+	resolve_cfdi_currency_exchange,
+)
+
+
+class TestResolveCurrencyExchange(FrappeTestCase):
+	"""La regla currency/exchange, aislada (sin empresa → sin guard de base)."""
+
+	def test_mxn_exchange_1(self):
+		self.assertEqual(
+			resolve_cfdi_currency_exchange(frappe._dict(currency="MXN", conversion_rate=1.0)), ("MXN", 1.0)
+		)
+
+	def test_mxn_ignora_conversion_rate(self):
+		self.assertEqual(
+			resolve_cfdi_currency_exchange(frappe._dict(currency="MXN", conversion_rate=17.5)), ("MXN", 1.0)
+		)
+
+	def test_sin_currency_default_mxn(self):
+		self.assertEqual(
+			resolve_cfdi_currency_exchange(frappe._dict(currency=None, conversion_rate=1.0)), ("MXN", 1.0)
+		)
+
+	def test_usd_usa_conversion_rate(self):
+		self.assertEqual(
+			resolve_cfdi_currency_exchange(frappe._dict(name="SI-X", currency="USD", conversion_rate=17.5)),
+			("USD", 17.5),
+		)
+
+	def test_currency_se_normaliza_mayusculas(self):
+		self.assertEqual(
+			resolve_cfdi_currency_exchange(frappe._dict(name="SI-Y", currency="usd", conversion_rate=18.0)),
+			("USD", 18.0),
+		)
+
+	def test_usd_exchange_1_es_valido(self):
+		# No se infiere que 1 sea imposible para una divisa: se acepta si es un tipo de cambio real.
+		self.assertEqual(
+			resolve_cfdi_currency_exchange(frappe._dict(name="SI-P", currency="USD", conversion_rate=1.0)),
+			("USD", 1.0),
+		)
+
+	def test_usd_sin_tipo_cambio_falla(self):
+		for bad in (0, -3):
+			with self.assertRaises(frappe.ValidationError):
+				resolve_cfdi_currency_exchange(
+					frappe._dict(name="SI-Z", currency="USD", conversion_rate=bad)
+				)
+
+	def test_guard_empresa_base_no_mxn(self):
+		# `_Test Company` es base INR → emitir en divisa se bloquea (suposición explícita).
+		base = frappe.db.get_value("Company", "_Test Company", "default_currency")
+		self.assertNotEqual(base, "MXN")  # sanity del entorno de test
+		with self.assertRaises(frappe.ValidationError):
+			resolve_cfdi_currency_exchange(
+				frappe._dict(name="SI-Q", currency="USD", conversion_rate=17.5, company="_Test Company")
+			)
+
+
+class TestPayloadMoneda(FrappeTestCase):
+	"""Payload real de `_prepare_facturapi_data` sobre una empresa base MXN."""
+
+	MXN_COMPANY = "_Test FM MXN"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls._patcher = patch(
+			"facturacion_mexico.facturacion_fiscal.timbrado_api.get_facturapi_client",
+			return_value=MagicMock(),
+		)
+		cls._patcher.start()
+		if not frappe.db.exists("Company", cls.MXN_COMPANY):
+			frappe.get_doc(
+				{
+					"doctype": "Company",
+					"company_name": cls.MXN_COMPANY,
+					"abbr": "TFMMXN",
+					"default_currency": "MXN",
+					"country": "Mexico",
+				}
+			).insert(ignore_permissions=True)
+			# La empresa recién creada necesita Round Off configurado para poder submitear SIs.
+			co = cls.MXN_COMPANY
+			roa = frappe.db.get_value(
+				"Account", {"company": co, "account_name": ["like", "Round Off%"], "is_group": 0}, "name"
+			) or frappe.db.get_value(
+				"Account", {"company": co, "root_type": "Expense", "is_group": 0}, "name"
+			)
+			roc = frappe.db.get_value("Cost Center", {"company": co, "is_group": 0}, "name")
+			frappe.db.set_value("Company", co, {"round_off_account": roa, "round_off_cost_center": roc})
+			frappe.db.commit()  # nosemgrep: frappe-manual-commit
+
+	@classmethod
+	def tearDownClass(cls):
+		cls._patcher.stop()
+		# Limpieza dura de la empresa de prueba y TODO lo que cuelga de ella (evita cuentas huérfanas
+		# que contaminarían otras suites que buscan "la primera cuenta Receivable"). frappe.db.delete
+		# usa DELETE directo → sin problemas de jerarquía de cuentas.
+		try:
+			for dt in ("Account", "Cost Center", "Warehouse"):
+				frappe.db.delete(dt, {"company": cls.MXN_COMPANY})
+			frappe.db.delete("Company", {"name": cls.MXN_COMPANY})
+			frappe.db.commit()  # nosemgrep: frappe-manual-commit
+		except Exception:
+			frappe.db.rollback()
+		super().tearDownClass()
+
+	def setUp(self):
+		self.h = frappe.generate_hash()[:6]
+		self.company = self.MXN_COMPANY
+		self.debit_to = frappe.db.get_value(
+			"Account",
+			{"company": self.company, "account_type": "Receivable", "account_currency": "MXN", "is_group": 0},
+			"name",
+		) or frappe.db.get_value(
+			"Account", {"company": self.company, "account_type": "Receivable", "is_group": 0}, "name"
+		)
+		# ERPNext exige que la moneda del debit_to coincida con la del documento → cuenta Receivable USD.
+		self.debit_to_usd = frappe.db.get_value(
+			"Account",
+			{"company": self.company, "account_type": "Receivable", "account_currency": "USD", "is_group": 0},
+			"name",
+		)
+		if not self.debit_to_usd:
+			parent = frappe.db.get_value("Account", self.debit_to, "parent_account")
+			self.debit_to_usd = frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Debtors USD",
+					"parent_account": parent,
+					"company": self.company,
+					"account_type": "Receivable",
+					"account_currency": "USD",
+					"is_group": 0,
+				}
+			).insert(ignore_permissions=True).name
+		self.income_acc = frappe.db.get_value(
+			"Account", {"company": self.company, "root_type": "Income", "is_group": 0}, "name"
+		)
+		self.cc = frappe.db.get_value("Cost Center", {"is_group": 0, "company": self.company}, "name")
+		self.cg = frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+		self.terr = frappe.db.get_value("Territory", {"is_group": 0}, "name")
+
+		# Clave SAT ObjetoImp=01 (no objeto de impuesto) → payload sin impuestos, mínimo para el builder.
+		# `codigo` debe ser numérico.
+		self.clave_sat = str(int(self.h, 16))[-8:].zfill(8)
+		if not frappe.db.exists("SAT Producto Servicio", {"codigo": self.clave_sat}):
+			frappe.get_doc(
+				{
+					"doctype": "SAT Producto Servicio",
+					"codigo": self.clave_sat,
+					"descripcion": f"Test 01 {self.h}",
+					"incluye_objeto_impuesto": "01",
+				}
+			).insert(ignore_permissions=True)
+		self.sat_name = frappe.db.get_value("SAT Producto Servicio", {"codigo": self.clave_sat}, "name")
+
+		# UOM con clave SAT válida (c_ClaveUnidad H87 = Pieza), exigida por el builder del CFDI.
+		if not frappe.db.exists("UOM", "H87"):
+			frappe.get_doc({"doctype": "UOM", "uom_name": "H87"}).insert(ignore_permissions=True)
+
+		self.item = f"FM-CUR-{self.h}"
+		if not frappe.db.exists("Item", self.item):
+			ig = frappe.db.get_value("Item Group", "Products", "name") or frappe.db.get_value(
+				"Item Group", {"is_group": 0}, "name"
+			)
+			frappe.get_doc(
+				{
+					"doctype": "Item",
+					"item_code": self.item,
+					"item_name": self.item,
+					"item_group": ig,
+					"stock_uom": "H87",
+					"is_stock_item": 0,
+					"is_sales_item": 1,
+					"fm_producto_servicio_sat": self.sat_name,
+				}
+			).insert(ignore_permissions=True)
+
+		self.uso_cfdi = frappe.db.get_value("Uso CFDI SAT", "G03", "name") or frappe.db.get_value(
+			"Uso CFDI SAT", {}, "name"
+		)
+		# fm_forma_pago_timbrado debe empezar con el código SAT de 2 dígitos (ej. "01 Efectivo").
+		self.forma_pago = frappe.db.get_value("Mode of Payment", "01 Efectivo", "name") or frappe.db.get_value(
+			"Mode of Payment", {"name": ["like", "0%"]}, "name"
+		)
+
+		self.customer = frappe.get_doc(
+			{
+				"doctype": "Customer",
+				"customer_name": f"CLI-{self.h}",
+				"customer_type": "Company",
+				"customer_group": self.cg,
+				"territory": self.terr,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value(
+			"Customer",
+			self.customer.name,
+			{"tax_id": "XAXX010101000", "fm_rfc_validated": 1, "fm_uso_cfdi_default": "G03", "fm_tax_regime": "601"},
+		)
+		# Dirección primaria (el builder exige CP del receptor).
+		frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": f"CLI-{self.h}",
+				"address_type": "Billing",
+				"address_line1": "Calle Falsa 123",
+				"city": "CDMX",
+				"pincode": "01000",
+				"country": "Mexico",
+				"is_primary_address": 1,
+				"links": [{"link_doctype": "Customer", "link_name": self.customer.name}],
+			}
+		).insert(ignore_permissions=True)
+		self._sis = []
+		self._ffms = []
+
+	def tearDown(self):
+		super().tearDown()
+		for ffm in self._ffms:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self._sis:
+			frappe.db.delete("Sales Invoice Item", {"parent": si})
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
+
+	def _mk_si(self, currency, conversion_rate, company=None):
+		debit_to = self.debit_to if currency == "MXN" else self.debit_to_usd
+		si = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"company": company or self.company,
+				"customer": self.customer.name,
+				"currency": currency,
+				"conversion_rate": conversion_rate,
+				"cost_center": self.cc,
+				"debit_to": debit_to,
+				"items": [
+					{
+						"item_code": self.item,
+						"qty": 1,
+						"rate": 100,
+						"cost_center": self.cc,
+						"income_account": self.income_acc,
+					}
+				],
+			}
+		)
+		si.insert(ignore_permissions=True)
+		si.submit()
+		self._sis.append(si.name)
+		return si.name
+
+	def _mk_ffm(self, si_name):
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			get_or_create_active_ffm,
+		)
+
+		ffm_name = get_or_create_active_ffm(si_name)
+		ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
+		if not ffm.get("fm_cfdi_use") and self.uso_cfdi:
+			ffm.fm_cfdi_use = self.uso_cfdi
+		if not ffm.get("fm_tax_system"):
+			ffm.fm_tax_system = "601"
+		if self.forma_pago:
+			ffm.fm_forma_pago_timbrado = self.forma_pago
+		ffm.fm_payment_method_sat = "PUE"
+		ffm.save(ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
+		self._ffms.append(ffm_name)
+		return ffm_name
+
+	def _build_payload(self, si_name):
+		si = frappe.get_doc("Sales Invoice", si_name)
+		ffm = frappe.get_doc("Factura Fiscal Mexico", self._ffms[-1])
+		api = TimbradoAPI(company=si.company)  # get_facturapi_client parcheado (sin red)
+		return api._prepare_facturapi_data(si, ffm), si
+
+	# ---------------- MXN ----------------
+
+	def test_payload_mxn(self):
+		si_name = self._mk_si("MXN", 1.0)
+		self._mk_ffm(si_name)
+		payload, si = self._build_payload(si_name)
+		self.assertEqual(payload["currency"], "MXN")
+		self.assertEqual(payload["exchange"], 1.0)
+		price = payload["items"][0]["product"]["price"]
+		self.assertEqual(price, si.items[0].net_rate)
+
+	# ---------------- USD (empresa base MXN) ----------------
+
+	def test_payload_usd_no_usa_base(self):
+		rate = 17.5
+		si_name = self._mk_si("USD", rate)
+		self._mk_ffm(si_name)
+		payload, si = self._build_payload(si_name)
+		self.assertEqual(payload["currency"], "USD")
+		self.assertEqual(payload["exchange"], rate)
+		price = payload["items"][0]["product"]["price"]
+		# El precio permanece en USD (net_rate), NO en base_net_rate (MXN).
+		self.assertEqual(price, si.items[0].net_rate)
+		self.assertNotEqual(price, si.items[0].base_net_rate)
+		self.assertEqual(si.items[0].base_net_rate, si.items[0].net_rate * rate)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_cfdi_moneda_extranjera.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_cfdi_moneda_extranjera.py
@@ -64,20 +64,12 @@ class TestResolveCurrencyExchange(FrappeTestCase):
 			with self.assertRaises(frappe.ValidationError):
 				resolve_cfdi_currency_exchange(frappe._dict(name="SI-Z", currency="USD", conversion_rate=bad))
 
-	def test_guard_empresa_base_no_mxn(self):
-		# `_Test Company` es base INR → emitir en divisa se bloquea (suposición explícita).
-		base = frappe.db.get_value("Company", "_Test Company", "default_currency")
-		self.assertNotEqual(base, "MXN")  # sanity del entorno de test
-		with self.assertRaises(frappe.ValidationError):
-			resolve_cfdi_currency_exchange(
-				frappe._dict(name="SI-Q", currency="USD", conversion_rate=17.5, company="_Test Company")
-			)
-
 
 class TestPayloadMoneda(FrappeTestCase):
 	"""Payload real de `_prepare_facturapi_data` sobre una empresa base MXN."""
 
 	MXN_COMPANY = "_Test FM MXN"
+	USD_COMPANY = "_Test FM USD"  # empresa base != MXN para el guard (determinista en cualquier entorno)
 
 	@classmethod
 	def setUpClass(cls):
@@ -87,6 +79,21 @@ class TestPayloadMoneda(FrappeTestCase):
 			return_value=MagicMock(),
 		)
 		cls._patcher.start()
+
+		# Address Template por defecto: el site fresco de CI no lo trae y Address.on_update lo exige.
+		if not frappe.db.exists("Address Template", {"is_default": 1}):
+			if frappe.db.exists("Address Template", "Mexico"):
+				frappe.db.set_value("Address Template", "Mexico", "is_default", 1)
+			else:
+				frappe.get_doc(
+					{
+						"doctype": "Address Template",
+						"country": "Mexico",
+						"is_default": 1,
+						"template": "{{ address_line1 or '' }}",
+					}
+				).insert(ignore_permissions=True)
+
 		if not frappe.db.exists("Company", cls.MXN_COMPANY):
 			frappe.get_doc(
 				{
@@ -106,22 +113,42 @@ class TestPayloadMoneda(FrappeTestCase):
 			)
 			roc = frappe.db.get_value("Cost Center", {"company": co, "is_group": 0}, "name")
 			frappe.db.set_value("Company", co, {"round_off_account": roa, "round_off_cost_center": roc})
-			frappe.db.commit()  # nosemgrep: frappe-manual-commit
+
+		# Empresa base USD para probar el guard fail-closed (independiente del entorno).
+		if not frappe.db.exists("Company", cls.USD_COMPANY):
+			frappe.get_doc(
+				{
+					"doctype": "Company",
+					"company_name": cls.USD_COMPANY,
+					"abbr": "TFMUSD",
+					"default_currency": "USD",
+					"country": "United States",
+				}
+			).insert(ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
 
 	@classmethod
 	def tearDownClass(cls):
 		cls._patcher.stop()
-		# Limpieza dura de la empresa de prueba y TODO lo que cuelga de ella (evita cuentas huérfanas
+		# Limpieza dura de las empresas de prueba y TODO lo que cuelga de ellas (evita cuentas huérfanas
 		# que contaminarían otras suites que buscan "la primera cuenta Receivable"). frappe.db.delete
 		# usa DELETE directo → sin problemas de jerarquía de cuentas.
 		try:
-			for dt in ("Account", "Cost Center", "Warehouse"):
-				frappe.db.delete(dt, {"company": cls.MXN_COMPANY})
-			frappe.db.delete("Company", {"name": cls.MXN_COMPANY})
+			for co in (cls.MXN_COMPANY, cls.USD_COMPANY):
+				for dt in ("Account", "Cost Center", "Warehouse"):
+					frappe.db.delete(dt, {"company": co})
+				frappe.db.delete("Company", {"name": co})
 			frappe.db.commit()  # nosemgrep: frappe-manual-commit
 		except Exception:
 			frappe.db.rollback()
 		super().tearDownClass()
+
+	def test_guard_empresa_base_no_mxn(self):
+		# Empresa base USD → emitir en divisa se bloquea (suposición explícita fail-closed).
+		with self.assertRaises(frappe.ValidationError):
+			resolve_cfdi_currency_exchange(
+				frappe._dict(name="SI-Q", currency="USD", conversion_rate=17.5, company=self.USD_COMPANY)
+			)
 
 	def setUp(self):
 		self.h = frappe.generate_hash()[:6]

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_nace_error_fiscal_event.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_nace_error_fiscal_event.py
@@ -1,0 +1,213 @@
+"""Regresión del fix "FFM nace en estado ERROR".
+
+Bug: los eventos de ciclo de vida de la FFM (create/status_change) se escribían, vía fallback,
+como respuestas PAC fallidas (success=0, operation_type mapeado a "Consulta Estado"), y
+`calculate_fiscal_status_from_logs` marcaba ERROR ante CUALQUIER success=0. Resultado: toda FFM
+nueva nacía en ERROR sin ninguna llamada a FacturAPI.
+
+Fix:
+  Capa 1 — se retiró el fallback (create_fiscal_event / _log_event_to_response_log); una FFM
+           nueva ya no genera logs sintéticos success=0.
+  Capa 2 — `calculate_fiscal_status_from_logs` deriva ERROR fiscal SOLO de un "Timbrado" fallido
+           (consistente con la regla canónica por operación de api/__init__.py). Consulta,
+           reconciliación y eventos sintéticos NO marcan ERROR.
+
+No se mockea el PAC: no hay ninguna llamada externa en estos flujos (esa es la tesis del fix).
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.config.fiscal_states_config import FiscalStates
+
+
+class TestFFMNaceErrorFiscalEvent(FrappeTestCase):
+	def setUp(self):
+		self.h = frappe.generate_hash()[:6]
+		self.debit_to = frappe.db.get_value(
+			"Account", {"account_type": "Receivable", "is_group": 0}, ["name", "company"], as_dict=True
+		)
+		self.company = self.debit_to.company
+		self.debit_to = self.debit_to.name
+		self.si_currency = frappe.db.get_value(
+			"Account", self.debit_to, "account_currency"
+		) or frappe.db.get_value("Company", self.company, "default_currency")
+		self.income_acc = frappe.db.get_value(
+			"Account", {"company": self.company, "root_type": "Income", "is_group": 0}, "name"
+		)
+		self.cg = frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+		self.terr = frappe.db.get_value("Territory", {"is_group": 0}, "name")
+		self.cc = frappe.db.get_value("Cost Center", {"is_group": 0, "company": self.company}, "name")
+
+		self.item = f"FM-NACEERR-{self.h}"
+		if not frappe.db.exists("Item", self.item):
+			ig = frappe.db.get_value("Item Group", "Products", "name") or frappe.db.get_value(
+				"Item Group", {"is_group": 0}, "name"
+			)
+			frappe.get_doc(
+				{
+					"doctype": "Item",
+					"item_code": self.item,
+					"item_name": self.item,
+					"item_group": ig,
+					"stock_uom": "Nos",
+					"is_stock_item": 0,
+					"is_sales_item": 1,
+					"fm_producto_servicio_sat": "84111506",
+				}
+			).insert(ignore_permissions=True)
+
+		self.uso_cfdi = frappe.db.get_value("Uso CFDI SAT", "G03", "name") or frappe.db.get_value(
+			"Uso CFDI SAT", {}, "name"
+		)
+		self.forma_pago = frappe.db.get_value("Mode of Payment", {}, "name")
+
+		self.customer = frappe.get_doc(
+			{
+				"doctype": "Customer",
+				"customer_name": f"CLI-{self.h}",
+				"customer_type": "Company",
+				"customer_group": self.cg,
+				"territory": self.terr,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value(
+			"Customer",
+			self.customer.name,
+			{
+				"tax_id": "XAXX010101000",
+				"fm_rfc_validated": 1,
+				"fm_uso_cfdi_default": "G03",
+				"fm_tax_regime": "601",
+			},
+		)
+		self._sis = []
+		self._ffms = []
+
+	def tearDown(self):
+		super().tearDown()
+		for ffm in self._ffms:
+			frappe.db.delete("FacturAPI Response Log", {"factura_fiscal_mexico": ffm})
+			frappe.db.delete("Factura Fiscal Mexico", {"name": ffm})
+		for si in self._sis:
+			frappe.db.delete("Sales Invoice Item", {"parent": si})
+			frappe.db.delete("Sales Invoice", {"name": si})
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
+
+	# ---------------- helpers ----------------
+
+	def _mk_si(self):
+		si = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"company": self.company,
+				"customer": self.customer.name,
+				"currency": self.si_currency,
+				"cost_center": self.cc,
+				"debit_to": self.debit_to,
+				"items": [
+					{
+						"item_code": self.item,
+						"qty": 1,
+						"rate": 100,
+						"cost_center": self.cc,
+						"income_account": self.income_acc,
+					}
+				],
+			}
+		)
+		si.insert(ignore_permissions=True)
+		si.submit()
+		self._sis.append(si.name)
+		return si.name
+
+	def _mk_ffm(self, si_name):
+		"""Crea la FFM por el flujo real (mismo path que la app)."""
+		from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+			get_or_create_active_ffm,
+		)
+
+		ffm_name = get_or_create_active_ffm(si_name)
+		self._ffms.append(ffm_name)
+		return ffm_name
+
+	def _seed_log(self, ffm_name, operation_type, success, offset_secs=0):
+		ts = frappe.utils.add_to_date(frappe.utils.now_datetime(), seconds=offset_secs)
+		frappe.get_doc(
+			{
+				"doctype": "FacturAPI Response Log",
+				"factura_fiscal_mexico": ffm_name,
+				"operation_type": operation_type,
+				"success": 1 if success else 0,
+				"status_code": 200 if success else 400,
+				"timestamp": ts,
+				"facturapi_response": "{}",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
+
+	def _recalc(self, ffm_name):
+		ffm = frappe.get_doc("Factura Fiscal Mexico", ffm_name)
+		ffm.calculate_fiscal_status_from_logs()
+		return frappe.db.get_value("Factura Fiscal Mexico", ffm_name, "status")
+
+	# ---------------- Capa 1 ----------------
+
+	def test_01_ffm_nueva_nace_borrador_sin_llamada_pac(self):
+		"""FFM nueva → BORRADOR (no ERROR) y SIN logs sintéticos success=0."""
+		si = self._mk_si()
+		ffm = self._mk_ffm(si)
+
+		status = frappe.db.get_value("Factura Fiscal Mexico", ffm, "status")
+		self.assertEqual(status, FiscalStates.BORRADOR, "La FFM nueva debe nacer en BORRADOR, no en ERROR")
+
+		# Capa 1: no se escribió ningún log sintético (fallback) ni respuesta PAC fallida.
+		logs = frappe.get_all(
+			"FacturAPI Response Log",
+			filters={"factura_fiscal_mexico": ffm},
+			fields=["operation_type", "success", "request_payload"],
+		)
+		self.assertFalse(
+			[r for r in logs if not r.success],
+			f"No debe existir ningún Response Log success=0 al crear la FFM; encontrados: {logs}",
+		)
+		self.assertFalse(
+			[r for r in logs if "fiscal_event" in (r.request_payload or "")],
+			"No debe existir ningún log 'fiscal_event_*' (fallback eliminado)",
+		)
+
+	# ---------------- Capa 2 ----------------
+
+	def test_02_timbrado_fallido_marca_error(self):
+		"""Un Timbrado realmente fallido SÍ deriva ERROR fiscal."""
+		si = self._mk_si()
+		ffm = self._mk_ffm(si)
+		self._seed_log(ffm, "Timbrado", success=False)
+		self.assertEqual(self._recalc(ffm), FiscalStates.ERROR)
+
+	def test_03_timbrado_fallido_luego_exitoso_es_timbrado(self):
+		"""Un éxito posterior prevalece sobre el ERROR."""
+		si = self._mk_si()
+		ffm = self._mk_ffm(si)
+		self._seed_log(ffm, "Timbrado", success=False, offset_secs=0)
+		self._seed_log(ffm, "Timbrado", success=True, offset_secs=5)
+		self.assertEqual(self._recalc(ffm), FiscalStates.TIMBRADO)
+
+	def test_04_consulta_estado_fallida_no_marca_error(self):
+		"""Una 'Consulta Estado' success=0 (o evento sintético) NO debe marcar ERROR fiscal."""
+		si = self._mk_si()
+		ffm = self._mk_ffm(si)
+		self._seed_log(ffm, "Consulta Estado", success=False)
+		self.assertEqual(
+			self._recalc(ffm),
+			FiscalStates.BORRADOR,
+			"Consulta/reconciliación fallida pertenece a fm_sync_status, no al estado fiscal",
+		)
+
+	def test_05_pendiente_cancelacion_intacto(self):
+		"""Regresión: Timbrado OK + Solicitud Cancelación OK sin Confirmación → PENDIENTE_CANCELACION."""
+		si = self._mk_si()
+		ffm = self._mk_ffm(si)
+		self._seed_log(ffm, "Timbrado", success=True, offset_secs=0)
+		self._seed_log(ffm, "Solicitud Cancelación", success=True, offset_secs=5)
+		self.assertEqual(self._recalc(ffm), FiscalStates.PENDIENTE_CANCELACION)

--- a/facturacion_mexico/facturacion_fiscal/tests/test_ffm_nace_error_fiscal_event.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_ffm_nace_error_fiscal_event.py
@@ -211,3 +211,41 @@ class TestFFMNaceErrorFiscalEvent(FrappeTestCase):
 		self._seed_log(ffm, "Timbrado", success=True, offset_secs=0)
 		self._seed_log(ffm, "Solicitud Cancelación", success=True, offset_secs=5)
 		self.assertEqual(self._recalc(ffm), FiscalStates.PENDIENTE_CANCELACION)
+
+	# ---------------- Orden de on_update (sincronización inmediata SI) ----------------
+
+	def test_06_si_recibe_estado_recalculado_en_un_solo_save(self):
+		"""on_update recalcula ANTES de sincronizar: la SI recibe el estado FINAL en un solo save.
+
+		Con el orden anterior (sync → recalcular), la SI quedaba con el estado previo hasta un save
+		posterior. Este test falla con el orden anterior y pasa con el nuevo.
+		"""
+		si = self._mk_si()
+		ffm = self._mk_ffm(si)  # BORRADOR
+		# Datos fiscales mínimos para que save() pase validate (vía db.set_value, sin disparar on_update).
+		frappe.db.set_value(
+			"Factura Fiscal Mexico",
+			ffm,
+			{
+				"fm_cfdi_use": self.uso_cfdi,
+				"fm_tax_system": "601",
+				"fm_forma_pago_timbrado": self.forma_pago,
+				"fm_payment_method_sat": "PUE",
+			},
+		)
+		# calculate determinará TIMBRADO (estado distinto al previo).
+		self._seed_log(ffm, "Timbrado", success=True)
+		# Estado previo distinto en la SI, para evidenciar la sincronización.
+		frappe.db.set_value("Sales Invoice", si, "fm_fiscal_status", FiscalStates.BORRADOR)
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit
+
+		# Un solo save dispara on_update (calculate → update_sales_invoice_fiscal_info).
+		frappe.get_doc("Factura Fiscal Mexico", ffm).save(ignore_permissions=True)
+
+		# Sin un segundo save: tanto la FFM como la SI quedan en el estado recalculado.
+		self.assertEqual(frappe.db.get_value("Factura Fiscal Mexico", ffm, "status"), FiscalStates.TIMBRADO)
+		self.assertEqual(
+			frappe.db.get_value("Sales Invoice", si, "fm_fiscal_status"),
+			FiscalStates.TIMBRADO,
+			"La SI debe recibir el estado recalculado en el mismo on_update (calculate antes de sync)",
+		)

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -20,6 +20,61 @@ except ImportError:
 	get_conversion_factor = None
 
 
+def resolve_cfdi_currency_exchange(sales_invoice):
+	"""Deriva (currency, exchange) del CFDI desde la Sales Invoice, que es la fuente de verdad.
+
+	Regla SAT/FacturAPI:
+	- MXN: el tipo de cambio es 1 por definición (el CFDI se expresa en pesos), sin importar la
+	  moneda base contable de la empresa.
+	- Divisa extranjera (p. ej. USD): `exchange` = pesos mexicanos por unidad de esa divisa.
+
+	`FacturAPI.exchange` = pesos por unidad de la moneda; `ERPNext.conversion_rate` = moneda de la
+	transacción → moneda **base de la empresa**. Ambos coinciden **solo si la moneda base es MXN**.
+	La app NO lo garantiza (solo lo recomienda en el setup, `install.py`), así que aquí se valida de
+	forma explícita y fail-closed: si la empresa no es base MXN, no se deriva un tipo de cambio
+	incorrecto — se bloquea.
+
+	Los importes del payload ya van en la moneda de la transacción (`item.net_rate`, base IVA sobre
+	`net_rate`, IVA por tasa). NO se usan campos `base_*` (convertidos a la moneda base).
+
+	Returns:
+		tuple(currency: str, exchange: float)
+
+	Raises:
+		frappe.ValidationError: si la empresa no es base MXN al emitir en divisa, o si la SI está en
+		divisa sin un tipo de cambio válido (> 0).
+	"""
+	currency = (sales_invoice.get("currency") or "MXN").upper()
+	if currency == "MXN":
+		return currency, 1.0
+
+	# Suposición explícita: `conversion_rate` == pesos por unidad SOLO si la base de la empresa es MXN.
+	company = sales_invoice.get("company")
+	base_currency = frappe.db.get_value("Company", company, "default_currency") if company else None
+	if base_currency and base_currency != "MXN":
+		frappe.throw(
+			_(
+				"No se puede emitir un CFDI en {0}: la empresa {1} tiene moneda base {2}. "
+				"El tipo de cambio del CFDI (pesos por unidad) solo se puede derivar automáticamente "
+				"si la moneda base de la empresa es MXN."
+			).format(currency, company, base_currency),
+			title=_("Moneda base no soportada"),
+		)
+
+	# Debe existir un tipo de cambio válido (> 0). No se infiere que 1 sea imposible para una divisa:
+	# solo se rechaza ausente / cero / negativo.
+	rate = flt(sales_invoice.get("conversion_rate"))
+	if rate <= 0:
+		frappe.throw(
+			_(
+				"La Sales Invoice {0} está en {1} pero no tiene un tipo de cambio válido "
+				"(conversion_rate = {2}). Configure el tipo de cambio de la factura antes de timbrar."
+			).format(sales_invoice.get("name") or "", currency, rate),
+			title=_("Tipo de cambio requerido"),
+		)
+	return currency, rate
+
+
 def _log_text(label, s: str):
 	if s is None:
 		s = ""
@@ -948,6 +1003,11 @@ class TimbradoAPI:
 				# Extraer solo la parte alfabética del patrón para enviar al PAC
 				serie_for_pac = self._extract_series_from_pattern(branch_doc.fm_serie_pattern)
 
+		# Moneda y tipo de cambio del CFDI: derivados de la Sales Invoice (fuente de verdad).
+		# Los importes de los conceptos ya van en la moneda de la transacción (net_rate); aquí solo
+		# se declara la moneda y el tipo de cambio. MXN → exchange 1; divisa extranjera → conversion_rate.
+		cfdi_currency, cfdi_exchange = resolve_cfdi_currency_exchange(sales_invoice)
+
 		# Datos de la factura
 		invoice_data = {
 			"customer": customer_data,
@@ -957,6 +1017,8 @@ class TimbradoAPI:
 			# MILESTONE 1: NO enviar folio_number - deja autoincremento del PAC
 			"series": serie_for_pac,  # Serie resuelta por Branch o default
 			"use": cfdi_use,
+			"currency": cfdi_currency,
+			"exchange": cfdi_exchange,
 		}
 
 		# TIPO DE COMPROBANTE: Obtener desde Factura Fiscal Mexico


### PR DESCRIPTION
## Objetivo

Dos correcciones fiscales independientes, cada una en su propio commit:

1. **FFM ya no nace en ERROR** (`a08c65b`): una Factura Fiscal Mexico recién creada quedaba de
   inmediato en `ERROR` sin ninguna llamada al PAC.
2. **Soporte de moneda extranjera en el CFDI** (`caf893a`): una factura en USD quedaba bloqueada al
   timbrar ("Moneda Inconsistente"); el payload no declaraba `currency` ni `exchange`.

## Cambios principales

### FFM nace en ERROR (a08c65b)
- Se retira el fallback que registraba los eventos de ciclo de vida de la FFM (`create`/`status_change`)
  como respuestas PAC fallidas (`success=0` → "Consulta Estado"/HTTP 500): eliminados `after_insert`,
  el bloque `create_fiscal_event` de `on_update` y los métodos `create_fiscal_event` /
  `_log_event_to_response_log` (el DocType `Fiscal Event MX` está deprecado; ningún consumidor usa
  esos logs).
- `calculate_fiscal_status_from_logs` deriva `ERROR` fiscal **solo** de un `Timbrado` fallido,
  consistente con la regla canónica por operación de `api/__init__.py`.

### Moneda extranjera (caf893a)
- Nuevo helper `resolve_cfdi_currency_exchange`: deriva `currency`/`exchange` desde la Sales Invoice
  (MXN → exchange 1; divisa → `conversion_rate`). Se cablea en `_prepare_facturapi_data`.
- Los importes ya iban en la moneda de la transacción (`net_rate`); no se tocan precios ni impuestos.
- La suposición de **moneda base MXN** queda explícita y fail-closed: emitir en divisa desde una
  empresa con base ≠ MXN se bloquea.

## Documentación actualizada
- `docs/tecnico/arquitectura.md` — derivación del estado fiscal de la FFM + Moneda del CFDI.
- `docs/usuario/troubleshooting.md` — FFM en ERROR sin timbrar + factura en moneda extranjera.

## Validaciones realizadas
- Tests (lightmode) — 86 OK: `test_ffm_nace_error_fiscal_event` (5), `test_cfdi_moneda_extranjera`
  (10: helper + payload real MXN/USD, guard de base, verificación de no-uso de `base_net_rate`);
  regresión `test_cancelacion_integridad` (37), `test_sync_status_semantics` (17),
  `test_e4_puente_si_pac` (17).
- `ruff check` + `ruff format` limpios; `mkdocs build --strict` exit 0.
- Validación GUI/end-to-end en ambiente sandbox:
  - FFM nueva queda en `BORRADOR` (no `ERROR`).
  - CFDI en USD generado correctamente con `Moneda=USD`, `TipoCambio=17.3943`, subtotal/IVA/total en
    USD y `livemode=false`.

## Fuera de alcance
- Remediación de FFM históricas ya pegadas en `ERROR` (paso separado, one-off idempotente por sitio).
- `fm_sync_status` / `fm_sync_error` (capa distinta con su propia derivación).
- Guards de ambiente FacturAPI multi-capa (issue #215) y validación fiscal temprana ObjetoImp=02 (#216).

## Riesgos / pendientes
- No requiere `bench migrate` ni `export-fixtures` (sin cambios de schema/fixtures).
- Moneda extranjera soportada solo con empresa base MXN (se bloquea explícitamente en otro caso).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nuevas funciones**
  - Las Facturas Fiscales se mantienen en **Borrador** y pasan a **Error** únicamente cuando el **timbrado** es rechazado.
  - Se habilita el **CFDI en moneda extranjera**, derivando **moneda** y **tipo de cambio** desde la factura de origen e incluyendo importes calculados en la divisa.
  - Emisión en divisas con **validación estricta**: la moneda base de la empresa debe ser **MXN**.
- **Documentación**
  - Actualizadas guías de troubleshooting para **ERROR sin timbrado** y para **facturas en moneda extranjera**.
- **Pruebas**
  - Nuevos casos para validar reglas de estado fiscal y payload en MXN y divisas, incluyendo regresión.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->