### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,8 +1,8 @@
 # CONTINUITY.md — facturacion_mexico
 
 **Fecha:** 2026-07-22
-**Rama activa:** `fix/ffm-nace-error-fiscal-event-fallback` (PR #217)
-**Tarea actual:** PR #217 con dos fixes: (1) FFM ya no nace en `ERROR` (`a08c65b`); (2) soporte de moneda extranjera en el CFDI (`caf893a`, `001557a` formato). Follow-ups: reorder `on_update` (CodeRabbit) + determinismo de CI en `test_cfdi_moneda_extranjera` (Address Template, Company USD para el guard, y Company MXN ligada al Año Fiscal vigente). Pendiente: re-CI del PR.
+**Rama activa:** `chore/release-v1.1.0`
+**Tarea actual:** Bump de versión interna del app `0.0.1` → `1.1.0` (fuente única: `facturacion_mexico/__init__.py`; `pyproject.toml` la deriva vía `flit` + `dynamic=["version"]`). PR #217 ya mergeado (`f1e47b3`). Tras mergear este PR de release: crear tag `v1.1.0` + GitHub Release con notas acumuladas desde `v1.0.0`.
 
 ---
 

--- a/facturacion_mexico/__init__.py
+++ b/facturacion_mexico/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.1"
+__version__ = "1.1.0"
 
 # Trigger CI rebuild - GitHub Actions refresh


### PR DESCRIPTION
## Objetivo

Alinear la versión interna de `facturacion_mexico` con la próxima versión oficial `v1.1.0`.

## Cambio

- Actualiza la versión interna del app de `0.0.1` a `1.1.0` (fuente única: `facturacion_mexico/__init__.py`; `pyproject.toml` la deriva vía `flit` con `dynamic = ["version"]`).
- No incluye cambios funcionales ni de schema.

## Contexto

El tag `v1.0.0` ya existía, pero la versión interna del paquete nunca fue actualizada y permaneció en `0.0.1`. Este PR restablece la sincronización entre la versión del código y el esquema de releases antes de publicar `v1.1.0`.

## Documentación actualizada

No aplica — cambio exclusivo de metadata de versión (sin comportamiento observable nuevo).

## Validaciones realizadas

- Versión importable: `facturacion_mexico.__version__ == "1.1.0"`.
- `ruff check` + `ruff format --check` limpios; `mkdocs build --strict` exit 0.
- Suites fiscales completas: **No ejecutado** — cambio exclusivo de metadata de versión, sin impacto en lógica ni tests.

## Fuera de alcance

- Cualquier cambio funcional, de schema o de dependencias.
- Creación del tag `v1.1.0` y del GitHub Release (se harán **después** del merge).

## Riesgos / pendientes

- No requiere `bench migrate` ni `bench build`.
- Post-merge: crear tag `v1.1.0` sobre `main` + GitHub Release `v1.1.0` con notas acumuladas desde `v1.0.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to **1.1.0**.
* **Documentation**
  * Updated release tracking information for the 1.1.0 release, including tagging and publication steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->