### PR TITLE
feat(cfdi): nota de crédito por descuento/bonificación (CFDI E, TipoRelación 01)

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,78 +1,76 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-07-22
-**Rama activa:** `chore/release-v1.1.0`
-**Tarea actual:** Bump de versión interna del app `0.0.1` → `1.1.0` (fuente única: `facturacion_mexico/__init__.py`; `pyproject.toml` la deriva vía `flit` + `dynamic=["version"]`). PR #217 ya mergeado (`f1e47b3`). Tras mergear este PR de release: crear tag `v1.1.0` + GitHub Release con notas acumuladas desde `v1.0.0`.
+**Fecha:** 2026-07-30
+**Rama activa:** `feat/nota-credito-descuento-relacion-01`
+**Tarea actual:** Nota de Crédito por descuento/bonificación (CFDI E, TipoRelación 01). Feature completa y validada end-to-end en sandbox; commit hecho, **falta push + PR**.
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Dos correcciones fiscales, cada una en su propio commit dentro de la **misma** rama:
-
-1. **FFM nace en ERROR** (`a08c65b`, ya commiteado): los eventos de ciclo de vida de la FFM se
-   escribían vía fallback como respuestas PAC fallidas (`success=0` → "Consulta Estado"/500), y
-   `calculate_fiscal_status_from_logs` marcaba `ERROR` ante cualquier `success=0`. Se retiró el
-   fallback (Capa 1) y se acotó la derivación de `ERROR` a un `Timbrado` fallido (Capa 2).
-
-2. **Moneda extranjera en el CFDI** (este commit): el payload a FacturAPI **no** declaraba
-   `currency` ni `exchange` → FacturAPI asumía MXN y una factura en USD quedaba bloqueada por
-   "Moneda Inconsistente". Se agregó `resolve_cfdi_currency_exchange` (deriva moneda/tipo de cambio
-   de la Sales Invoice: MXN → exchange 1; divisa → `conversion_rate`) y se cableó `currency`/
-   `exchange` en `_prepare_facturapi_data`. Los importes ya iban en moneda de transacción
-   (`net_rate`); no se tocaron precios ni impuestos.
+El flujo de Nota de Crédito por **descuento/bonificación** (distinto de devolución física). El operador ejecuta el botón **«Aplicar como Descuento / Bonificación»** en una Sales Invoice Return en borrador → se fija `income_account = cuenta de descuentos configurada por empresa` y `description = "Descuento - <descripción original>"` (conserva Item y ClaveProdServ del origen). Tras el Submit, la FFM detecta el descuento por la cuenta contable y deriva **E / 01 / G02 / PUE / 15 - Condonación**, con UUID relacionado desde `return_against`.
 
 Plan que estoy siguiendo:
-Fix mínimo por feature, commits separados en la misma rama. Se hizo explícita y fail-closed la
-suposición de **moneda base MXN** (emitir en divisa desde empresa con base ≠ MXN se bloquea:
-`conversion_rate` solo equivale a "pesos por unidad" con base MXN, y la app no lo garantiza).
+Issue #137 (TipoRelación 01) + ADR `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md` (única fuente de la arquitectura y decisiones).
 
 Objetivo inmediato:
-Segundo commit (moneda) en la rama. Después: flujo normal paso a paso (push → PR → merge →
-`/sync-check`) con autorización explícita en cada paso. Al cierre: revisión de tags/releases y crear
-el release correspondiente.
+`/ship push` → `/ship pr` (base `main`), con autorización explícita en cada paso.
 
 Criterio de avance:
-Tests verdes (`test_cfdi_moneda_extranjera` 10/10, `test_ffm_nace_error_fiscal_event` 5/5,
-regresión `test_cancelacion_integridad` 37 / `test_e4_puente_si_pac` 17) + `ruff` + `mkdocs
---strict` limpios + validación GUI/sandbox (USD `FFMX-2026-00299`: `Moneda=USD`,
-`TipoCambio=17.3943`, subtotal/IVA/total en USD, `livemode=false`).
+Tests verdes (49 en `test_nota_credito_descuento_relacion_01` + regresión CFDI E 6 / complemento 24 / issue162 9) + ruff/prettier/mkdocs limpios. Experimento sandbox en sitio dev confirmó GL y XML correctos con `Enable Discount Accounting = OFF`.
 
 ---
 
 ## Estado actual
 
-### Ya cerrado (en esta rama)
+### Ya cerrado
+- Feature implementada (12 archivos) y **commiteada** en esta rama. Bump `1.1.0 → 1.2.0`.
+- Experimento end-to-end en sitio dev (sandbox): 2 ventas (lista / 10% abajo) + 2 NC de descuento, todos timbrados; GL y XML validados con Discount Accounting OFF.
+- ADR 0025 actualizado (arquitectura final + precondición Discount Accounting OFF).
 
-- **Commit `a08c65b`** — FFM nace en ERROR: retiro del fallback (`after_insert`, bloque
-  `create_fiscal_event` de `on_update`, métodos `create_fiscal_event` / `_log_event_to_response_log`)
-  + `calculate_fiscal_status_from_logs` deriva `ERROR` solo de `Timbrado` fallido. Test
-  `test_ffm_nace_error_fiscal_event` (5). Docs: arquitectura + troubleshooting.
-- **Commit moneda (este)** — `resolve_cfdi_currency_exchange` + cableo `currency`/`exchange` en el
-  payload + guard fail-closed de base MXN. Test `test_cfdi_moneda_extranjera` (10: helper + payload
-  real MXN/USD, guard base, verificación de no-uso de `base_net_rate`). Docs: arquitectura
-  (Moneda del CFDI) + troubleshooting (factura en divisa).
+### En progreso
+- Ninguna edición de código pendiente.
 
-### Siguiente paso concreto
+### Pendiente inmediato
+1. `/ship push` (con autorización).
+2. `/ship pr` hacia `main` (con autorización).
+3. Tras merge (lo hace el usuario): tag `v1.2.0` + Release.
 
-1. (Hecho) `/ship commit` del fix de moneda. **Sin push ni PR** hasta autorización.
-2. Flujo normal paso a paso: `/ship push` → `/ship pr` → (merge lo hace el usuario) → `/sync-check`.
-3. **Al cierre:** revisión de tags/releases y crear el release correspondiente.
-
-### Fuera de este trabajo (sin commitear)
-
-- `one_offs/verificar_payload_moneda.py` — verificador de payload solo-lectura (queda fuera del commit).
-- Issues abiertos aparte: #215 (guards de ambiente FacturAPI multi-capa), #216 (validación fiscal
-  temprana ObjetoImp=02 sin impuestos en Sales Invoice).
+### No repetir
+- **NO** usar `discount_account` nativo para la NC de descuento: invierte e infla el asiento ("descuento del 90%"). La solución es `Enable Discount Accounting = OFF` por empresa (config, no código).
+- **NO** cambiar `item_code` a un Item "Descuento" (ERPNext `validate_returned_items` lo rechaza en returns con `return_against`).
+- **NO** alinear `price_list_rate = rate` en la acción (se intentó y descartó; el usuario lo revirtió).
+- **NO** commitear `one_offs/` ni `working_docs/`.
 
 ---
 
-## Decisiones vigentes no reflejadas en código
+## Decisiones vigentes
+- **Precondición por empresa:** `Selling Settings.Enable Discount Accounting = OFF` para operar NC de descuento (documentado en ADR 0025). No es regla universal del app.
+- El descuento queda integrado en el `ValorUnitario` del CFDI (payload usa `net_rate`, `discount=0`); **nunca** se emite nodo `Descuento` en el XML.
+- Cuenta de descuentos: config por empresa en `Facturacion Mexico Company Settings.cuenta_descuentos` (no hardcode; se aplica como `income_account`).
+- Devolución física conserva comportamiento histórico (TipoRelación 03).
 
-- **`fm_sync_status` / `fm_sync_error`:** capa distinta con su propia derivación; no se tocan.
-- **Moneda base MXN:** la app no la garantiza (solo la recomienda en `install.py`). Emitir CFDI en
-  divisa exige base MXN; en caso contrario se bloquea. La FFM no guarda copia de moneda/tipo de
-  cambio: siempre se derivan de la Sales Invoice.
-- **Config FacturAPI de `llantascs-v16.dev`:** saneada a sandbox (`sandbox_mode=1`, `sk_live` borrada;
-  el usuario cargó la `sk_test`). Prevención universal en issue #215.
+---
+
+## Archivos relevantes ahora
+
+### Leer primero
+- `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md`
+
+### Probablemente editar
+- (ninguno; feature cerrada salvo hallazgos en review/CI)
+
+### No tocar
+- `facturacion_fiscal/timbrado_api.py` fórmula del REP (`allocated_amount / si.grand_total`).
+
+---
+
+## Riesgos / cuidados
+- El sitio dev de prueba tiene el setting `Enable Discount Accounting = OFF` (dejado así como solución). Documentos de prueba conservados para auditoría.
+- Al abrir PR: el gate documental mapea `public/js` → `docs/usuario`; se acordó que ADR 0025 cubre el flujo (no se creó página de usuario).
+
+---
+
+## Información faltante
+- Confirmación del contador/ChatGPT sobre el cierre fiscal del escenario (pendiente formal, no bloquea el commit).

--- a/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
+++ b/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
@@ -1,8 +1,12 @@
 # ADR 0025 — Notas de Crédito CFDI tipo E (Issue #116)
 
 **Fecha:** 2026-05-13
-**Estado:** Implementado — pendientes normativos documentados (#136, #137)
+**Estado:** Implementado — #137 implementado (2026-07-29); #136 resuelto para descuento con pago previo
 **Autor:** Luis Montanaro / Claude Sonnet 4.6
+
+> **Actualización 2026-07-29:** Ver sección final *«Descuento / Bonificación (TipoRelación 01)»*.
+> Se implementó el flujo de nota de crédito por descuento (Issue #137) y se cerró el criterio de
+> FormaPago del escenario de descuento con pago previo (Issue #136).
 
 ---
 
@@ -163,6 +167,118 @@ No existe flujo en ERPNext para este caso actualmente.
 - FormaPago determinada automáticamente (regla provisional)
 - Campos fiscales inmutables en tipo E desde UI
 - Issue #116 cerrado funcionalmente — pendientes normativos en #136 y #137
+
+---
+
+## Descuento / Bonificación (TipoRelación 01) — Issue #137 (2026-07-29)
+
+Se implementa el segundo motivo de nota de crédito, distinto de la devolución física.
+La distinción entre ambos casos queda **explícita** y sin habilitar edición libre de campos SAT.
+
+### Distinción final por intención de negocio
+
+| Motivo (negocio) | TipoRelación | UsoCFDI | MetodoPago | FormaPago | Concepto |
+|---|---|---|---|---|---|
+| **Devolución de mercancía** | `03` | (default cliente) | PUE | según outstanding origen | descripción del ítem |
+| **Descuento / Bonificación** | `01` | `G02` | PUE | `15 - Condonación` | `Descuento - <descripción origen>` |
+
+### Arquitectura (Opción X — señal por la cuenta contable)
+
+El motivo de la nota se **decide antes del Submit** mediante la cuenta contable nativa, y la FFM lo
+**deriva y valida** después — sin adelantar el ciclo de vida de la FFM ni tocar Sales Invoice.
+
+- **Config por empresa:** `Facturacion Mexico Company Settings.cuenta_descuentos` (Link a *Account*).
+  Para este cliente se configura `501-005 - Descuentos y bonificaciones`. **No** se hardcodea.
+- **Restricción nativa de ERPNext (decisiva):** en una Sales Invoice Return con `return_against`,
+  ERPNext valida (core `validate_returned_items`) que el `item_code` de cada línea exista en la factura
+  origen. Por eso **NO se sustituye el Item** por uno `Descuento` (rompería esa validación) y **no se
+  desactiva ni sobreescribe** ninguna validación core. Se **conserva el Item original**.
+- **El descuento se expresa por descripción + cuenta:** la acción, server-side, en cada línea fija
+  `description = "Descuento - <descripción original>"` (idempotente; sin partida identificable →
+  `Descuento`) y `income_account = cuenta_descuentos`. Conserva `item_code`, cantidad, precio, UOM e
+  impuestos. **No** hay Item maestro `Descuento`, ni clave técnica, ni campos nuevos en `Sales Invoice`.
+- **ClaveProdServ del CFDI = la del Item/línea original:** al conservarse el `item_code`, el payload
+  obtiene la ClaveProdServ normalmente de `Item.fm_producto_servicio_sat` de la mercancía. Con una línea
+  por partida (estructura nativa del Return), distintas ClaveProdServ / tasas / exentos / IEPS quedan en
+  líneas separadas (no se colapsan).
+- **Acción de negocio (UX):** en la Credit Note en borrador (`is_return=1`, `docstatus=0`,
+  `return_against`) el operador ejecuta el botón **«Aplicar como Descuento / Bonificación»**
+  (`facturacion_mexico.facturacion_fiscal.api.nota_credito.aplicar_como_descuento`). Server-side aplica
+  lo anterior y guarda; el documento muestra ya `Descuento - <origen>` antes del Submit. Guards del
+  servidor: es Return, en borrador, `return_against` presente, cuenta de descuentos configurada. El
+  operador **no** selecciona Item, cuenta ni códigos SAT. Si **no** ejecuta la acción, la nota conserva
+  sus cuentas normales → devolución física (relación 03).
+- **Al crearse la FFM** (mismo `on_submit` de siempre): `_detect_nota_credito_motivo()` detecta si
+  **todas** las líneas están contabilizadas contra `cuenta_descuentos` y, de ser así, **preselecciona**
+  `fm_tipo_nota_credito = Descuento / Bonificación` (solo si el campo está vacío). La señal es la
+  **cuenta contable**, no el `item_code`. Si no coinciden, no infiere → devolución física (`03`).
+- Nuevo campo **en la propia FFM** (no Custom Field en Sales Invoice): `fm_tipo_nota_credito` (Select:
+  *Devolución de mercancía* / *Descuento / Bonificación*), visible en CFDI tipo E para que el usuario
+  **verifique** la clasificación antes del timbrado; editable en borrador, bloqueado tras submit.
+- Al quedar *Descuento / Bonificación*, `_set_tipo_from_context()` deriva automáticamente
+  `E / 01 / G02 / PUE / 15 - Condonación`. El UUID relacionado se resuelve como hasta ahora desde
+  `return_against` → FFM origen → `fm_uuid` (exclusivo de la factura origen).
+- El concepto fiscal en el payload es `Descuento - <origen>` (`resolve_concepto_description`,
+  idempotente), **conservando** el Item original, su ClaveProdServ SAT y los impuestos proporcionales.
+- **Guard pre-timbrado (`_validate_invoice_for_timbrado`):** si la FFM está marcada como
+  *Descuento / Bonificación*, se exige que las líneas estén contabilizadas contra `cuenta_descuentos`;
+  si no coinciden (o la cuenta no está configurada), se **bloquea el timbrado** con mensaje claro. El GL
+  **no** se corrige después del Submit: si es necesario, cancelar y rehacer la nota.
+
+### FormaPago 15 — decisión final del contador (Issue #136)
+
+`FormaPago = 15 - Condonación` con `MetodoPago = PUE` es el criterio **confirmado por el contador**
+para este escenario, **incluso cuando el 90% ya fue recibido previamente por transferencia**: el CFDI
+de Egreso documenta **exclusivamente la extinción del 10% que nunca será cobrado**. El 90%
+efectivamente recibido se documenta después en el **REP** con `FormaPago = 03 - Transferencia
+electrónica de fondos` y la fecha real de recepción bancaria. `15` ya **no** es un supuesto
+provisional para este caso.
+
+### Aplicación contable / outstanding
+
+- **Se descarta** modificar `update_outstanding_for_self = 0` automáticamente. Se mantiene el
+  comportamiento nativo: crear/submit de la NC → timbrar → **conciliar** la NC contra la factura
+  origen con el flujo nativo (Payment Reconciliation / Journal Entry) → registrar el Payment Entry →
+  generar el REP. La conciliación posterior es un paso operativo aceptado.
+- El REP debe generarse **después** de que la conciliación haya reducido el outstanding de la factura.
+- Cuenta de descuentos (p. ej. `501-005 Descuentos y bonificaciones`): se configura por empresa en
+  `Facturacion Mexico Company Settings.cuenta_descuentos` y se aplica vía `income_account` de las líneas
+  de la Credit Note (mecanismo nativo). **No** se hardcodea la cuenta ni se crea un Item genérico
+  "Descuento". Flujo completo: NC nativa → cuenta correcta antes del Submit → FFM deriva/valida la
+  intención → timbrado → conciliación → Payment Entry → REP.
+
+### REP
+
+Sin cambios: `proporcion = allocated_amount / si.grand_total` (grand_total **original** del CFDI). El
+importe de la Nota de Crédito **no** se trata como efectivo en el REP. Se descarta el gap G-4.
+
+### Enable Discount Accounting — precondición operativa por sitio (no regla universal)
+
+**Precondición operativa para empresas/sitios que usen este flujo de descuento:**
+**`Selling Settings.Enable Discount Accounting = OFF`** en la empresa.
+
+- Con `ON`, ERPNext exige `discount_account` por línea cuando `discount_amount > 0`, y su
+  `make_discount_gl_entries` postea `discount_amount × qty` a `discount_account`. En una **nota de
+  crédito** (qty negativa) esto **invierte e infla** el asiento (la cuenta de descuento queda
+  *acreditada* por el hueco completo contra el precio de lista, no por el descuento real), rompiendo
+  el GL. Verificado empíricamente: una NC de −20.41 (divisa) generaba un asiento ~17× mayor con la
+  cuenta de descuento acreditada por el ~90% del precio de lista.
+- Con `OFF`, la NC contabiliza correctamente: `income_account` (cuenta de descuentos) **debitado** por
+  la base real, IVA revertido proporcionalmente, Clientes acreditado por el total. La venta normal no
+  se altera y el CFDI/XML tampoco (el payload usa `net_rate`; nunca emite nodo `Descuento`).
+- **No** es una regla universal de `facturacion_mexico`: es una **configuración por empresa** que se
+  adopta si se van a operar notas de crédito por descuento. Empresas que **no** usen descuento de línea
+  (`rate = price_list_rate` siempre) no pierden funcionalidad al apagarlo.
+- Evidencia: experimento end-to-end en un sitio de desarrollo (sandbox) con 4 CFDIs — 2 ventas
+  (a precio de lista / 10% abajo) y 2 notas de crédito de descuento (TipoRelación 01), GL y XML
+  validados con `Enable Discount Accounting = OFF`.
+
+### Estado de pendientes
+
+- **Issue #137:** implementado (TipoRelación 01 + G02 + concepto `Descuento`).
+- **Issue #136:** el escenario de descuento con pago previo queda **resuelto** con `FormaPago 15`. Si
+  el issue conserva otros escenarios de FormaPago tipo E (p. ej. escenario D: `outstanding=0` que
+  hereda `99`), **permanece abierto** para esos; este caso se marca resuelto.
 
 ---
 

--- a/facturacion_mexico/__init__.py
+++ b/facturacion_mexico/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 # Trigger CI rebuild - GitHub Actions refresh

--- a/facturacion_mexico/facturacion_fiscal/api/nota_credito.py
+++ b/facturacion_mexico/facturacion_fiscal/api/nota_credito.py
@@ -1,0 +1,56 @@
+"""Acción de negocio para Notas de Crédito por descuento/bonificación (Issue #137).
+
+UX: en una Credit Note (Sales Invoice Return) en borrador, el operador ejecuta
+"Aplicar como Descuento / Bonificación". El sistema **conserva el Item original** (ERPNext exige que
+el item_code exista en la factura origen) y expresa el descuento por descripción
+('Descuento - <descripción original>') + cuenta de descuentos configurada por empresa como
+income_account. El operador NO selecciona cuentas ni códigos SAT. Tras el Submit, la Factura Fiscal
+Mexico detecta la cuenta y clasifica la nota como descuento (TipoRelación 01, UsoCFDI G02, MetodoPago
+PUE, FormaPago 15). La ClaveProdServ del CFDI sigue siendo la del Item/línea original.
+"""
+
+import frappe
+from frappe import _
+
+from facturacion_mexico.facturacion_fiscal.utils import (
+	apply_descuento_to_lines,
+	get_cuenta_descuentos,
+)
+
+
+def preparar_como_descuento(doc) -> dict:
+	"""Preparar la Credit Note (borrador) como descuento/bonificación (sin cambiar el Item).
+
+	Guards mínimos (servidor):
+	  - Return con factura de origen (return_against);
+	  - en borrador;
+	  - cuenta de descuentos configurada para la empresa.
+	"""
+	if not doc.get("is_return") or not doc.get("return_against"):
+		frappe.throw(_("Esta acción solo aplica a notas de crédito con factura de origen (return_against)."))
+	if doc.get("docstatus", 0) != 0:
+		frappe.throw(_("Solo se puede aplicar mientras la nota de crédito está en borrador."))
+
+	cuenta = get_cuenta_descuentos(doc.get("company"))
+	if not cuenta:
+		frappe.throw(
+			_(
+				"No hay 'Cuenta de Descuentos y Bonificaciones' configurada para la empresa {0}. "
+				"Configúrela en Facturacion Mexico Company Settings antes de aplicar el descuento."
+			).format(doc.get("company")),
+			title=_("Cuenta de Descuentos No Configurada"),
+		)
+
+	lineas = apply_descuento_to_lines(doc, cuenta)
+	doc.save()
+	return {"ok": True, "lineas": lineas}
+
+
+@frappe.whitelist()
+def aplicar_como_descuento(sales_invoice: str) -> dict:
+	"""Punto de entrada desde la UI (botón en Sales Invoice Return en borrador).
+
+	No devuelve el nombre de la cuenta: el usuario final nunca debe ver la cuenta técnica.
+	"""
+	doc = frappe.get_doc("Sales Invoice", sales_invoice)
+	return preparar_como_descuento(doc)

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -1270,6 +1270,15 @@
 		lock("fm_facturar_venta_mostrador");
 		lock("fm_tipo_relacion_sat");
 		lock("fm_uuid_relacionado");
+		// Tipo de Nota de Crédito: es la ÚNICA entrada del usuario (intención de negocio).
+		// Editable mientras es borrador; se bloquea una vez enviado/timbrado.
+		if (frm.get_field("fm_tipo_nota_credito")) {
+			frm.set_df_property(
+				"fm_tipo_nota_credito",
+				"read_only",
+				frm.doc.docstatus === 1 ? 1 : 0
+			);
+		}
 	}
 
 	function setup_payment_method_radio_buttons(frm) {

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -20,6 +20,7 @@
   "fm_payment_method_sat",
   "fm_forma_pago_timbrado",
   "fm_tipo_comprobante",
+  "fm_tipo_nota_credito",
   "fm_tipo_relacion_sat",
   "fm_uuid_relacionado",
   "section_break_datos_facturacion",
@@ -155,6 +156,14 @@
    "default": "I - Ingreso",
    "reqd": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "fm_tipo_nota_credito",
+   "label": "Tipo de Nota de Crédito",
+   "fieldtype": "Select",
+   "options": "\nDevolución de mercancía\nDescuento / Bonificación",
+   "depends_on": "eval:doc.fm_tipo_comprobante && doc.fm_tipo_comprobante.startsWith('E')",
+   "description": "Intención de negocio de la nota de crédito. 'Descuento / Bonificación' deriva automáticamente TipoRelación 01, UsoCFDI G02 y FormaPago 15 - Condonación. Vacío o 'Devolución de mercancía' mantiene TipoRelación 03 (devolución física)."
   },
   {
    "fieldname": "fm_tipo_relacion_sat",

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -21,6 +21,20 @@ MUTABLE_AFTER_SUBMIT = {
 # Estados en los que el CFDI ya no debe alterarse
 FISCAL_FROZEN_STATES = {"TIMBRADO", "CANCELADO", "PENDIENTE_CANCELACION"}
 
+# Tipo de Nota de Crédito (intención de negocio en Factura Fiscal Mexico.fm_tipo_nota_credito).
+# Determina el tratamiento fiscal del CFDI de Egreso:
+#   - Devolución de mercancía  → TipoRelación 03 (comportamiento histórico, sin regresión)
+#   - Descuento / Bonificación → TipoRelación 01 + UsoCFDI G02 + FormaPago 15 (Condonación)
+# Vacío se trata como Devolución de mercancía para preservar el comportamiento actual.
+NOTA_CREDITO_DEVOLUCION = "Devolución de mercancía"
+NOTA_CREDITO_DESCUENTO = "Descuento / Bonificación"
+# UsoCFDI fijo para notas de crédito por descuento/bonificación (criterio SAT: G02).
+CFDI_USE_DESCUENTO = "G02"
+# FormaPago fija para el CFDI E de descuento: 15 - Condonación.
+# Criterio fiscal confirmado por el contador (Issue #136): el CFDI E documenta exclusivamente
+# la extinción del importe no cobrado; el efectivo recibido se documenta aparte en el REP.
+FORMA_PAGO_DESCUENTO = "15 Condonación"
+
 # Estados de sincronización permitidos (minúsculas)
 ALLOWED_SYNC = {"synced", "pending", "error"}
 
@@ -300,6 +314,37 @@ class FacturaFiscalMexico(Document):
 		sales_invoice = frappe.get_doc("Sales Invoice", self.sales_invoice)
 		return bool(getattr(sales_invoice, "is_return", 0))
 
+	def _is_nota_descuento(self) -> bool:
+		"""Determinar si la nota de crédito es por descuento/bonificación (no devolución física).
+
+		La intención de negocio se captura en el campo fm_tipo_nota_credito de la FFM.
+		Vacío o 'Devolución de mercancía' → False (devolución física, comportamiento actual).
+		"""
+		return (self.get("fm_tipo_nota_credito") or "").strip() == NOTA_CREDITO_DESCUENTO
+
+	def _detect_nota_credito_motivo(self):
+		"""Opción X: preseleccionar el motivo a partir de la cuenta contable de la Credit Note.
+
+		Si la nota de crédito ya se contabilizó (income_account de sus líneas) contra la cuenta
+		de descuentos configurada para la empresa, preseleccionar 'Descuento / Bonificación'.
+
+		Solo actúa cuando el campo está VACÍO (preselección, no override de una elección explícita
+		del usuario). Si las cuentas no coinciden, NO infiere descuento y se conserva el
+		comportamiento histórico de devolución (relación 03) — punto 8 de la decisión.
+		"""
+		if (self.get("fm_tipo_nota_credito") or "").strip():
+			return  # ya decidido (usuario o preselección previa) — no sobrescribir
+
+		from facturacion_mexico.facturacion_fiscal.utils import (
+			credit_note_lines_use_discount_account,
+			get_cuenta_descuentos,
+		)
+
+		company = self.get("company") or frappe.db.get_value("Sales Invoice", self.sales_invoice, "company")
+		cuenta = get_cuenta_descuentos(company)
+		if cuenta and credit_note_lines_use_discount_account(self.sales_invoice, cuenta):
+			self.fm_tipo_nota_credito = NOTA_CREDITO_DESCUENTO
+
 	def _set_tipo_from_context(self):
 		"""Establecer tipo automáticamente según contexto."""
 		if self._is_sales_invoice_return():
@@ -307,13 +352,28 @@ class FacturaFiscalMexico(Document):
 			self.fm_payment_method_sat = "PUE"  # SAT: PPD not allowed on credit notes
 			self.fm_uuid_relacionado = self.fm_uuid_relacionado or self._find_uuid_cfdi_origen()
 
-			# Physical merchandise return → TipoRelación 03 (normative, Issue #116).
-			# TipoRelación 01 (discounts/bonifications) is a separate flow — Issue #137.
-			self.fm_tipo_relacion_sat = self.fm_tipo_relacion_sat or "03 - " + TIPO_RELACION["03"]
+			# Opción X: preseleccionar el motivo desde la cuenta contable si el operador ya
+			# asignó la cuenta de descuentos configurada en las líneas antes del Submit.
+			self._detect_nota_credito_motivo()
+
+			if self._is_nota_descuento():
+				# Descuento / bonificación (Issue #137): el usuario selecciona la intención de
+				# negocio en fm_tipo_nota_credito y aquí se derivan los códigos SAT.
+				#   TipoRelación 01 · UsoCFDI G02 · FormaPago 15 (Condonación) · MetodoPago PUE.
+				# El concepto fiscal se describe como 'Descuento' en el payload (timbrado_api),
+				# conservando Item/ClaveProdServ e impuestos proporcionales.
+				self.fm_tipo_relacion_sat = "01 - " + TIPO_RELACION["01"]
+				self.fm_cfdi_use = CFDI_USE_DESCUENTO
+				self.fm_forma_pago_timbrado = FORMA_PAGO_DESCUENTO
+			else:
+				# Devolución física de mercancía → TipoRelación 03 (normativo, Issue #116).
+				# Sin regresión: comportamiento histórico intacto.
+				self.fm_tipo_relacion_sat = self.fm_tipo_relacion_sat or "03 - " + TIPO_RELACION["03"]
 
 			# Inherit venta-mostrador flag from origin — no customization allowed.
-			# FormaPago for tipo E is determined in auto_load_payment_method_from_sales_invoice()
-			# based on outstanding_amount of origin SI (single source of truth).
+			# FormaPago for tipo E (devolución física) is determined in
+			# auto_load_payment_method_from_sales_invoice() based on outstanding_amount of
+			# origin SI. Para descuento la FormaPago ya quedó fijada arriba (15 - Condonación).
 			origin_ffm = self._get_origin_ffm()
 			if origin_ffm:
 				self.fm_facturar_venta_mostrador = cint(origin_ffm.get("fm_facturar_venta_mostrador", 0))

--- a/facturacion_mexico/facturacion_fiscal/doctype/facturacion_mexico_company_settings/facturacion_mexico_company_settings.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/facturacion_mexico_company_settings/facturacion_mexico_company_settings.json
@@ -14,6 +14,7 @@
   "test_api_key",
   "section_facturas",
   "metodo_pago_default",
+  "cuenta_descuentos",
   "send_email_default",
   "column_break_facturas",
   "download_files_default",
@@ -97,6 +98,13 @@
    "fieldtype": "Select",
    "label": "Método de Pago por Defecto",
    "options": "PUE\nPPD"
+  },
+  {
+   "description": "Cuenta de ingresos para notas de crédito por descuento/bonificación (CFDI E, TipoRelación 01). El operador la asigna como income_account en las líneas de la Credit Note ANTES del Submit; la Factura Fiscal Mexico la usa para auto-detectar y validar el motivo 'Descuento / Bonificación'. Configuración por empresa — no se hardcodea.",
+   "fieldname": "cuenta_descuentos",
+   "fieldtype": "Link",
+   "label": "Cuenta de Descuentos y Bonificaciones",
+   "options": "Account"
   },
   {
    "default": "0",

--- a/facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py
@@ -1,0 +1,530 @@
+"""
+Tests Issue #137 — Nota de Crédito por descuento/bonificación (CFDI tipo E, TipoRelación 01).
+
+Arquitectura: la intención de negocio se captura en Factura Fiscal Mexico.fm_tipo_nota_credito
+(«Devolución de mercancía» / «Descuento / Bonificación»). El controlador deriva los códigos SAT.
+
+Cubre:
+  - Derivación fiscal por intención (relación 03 vs 01, UsoCFDI G02, MetodoPago PUE, FormaPago 15).
+  - Sin regresión: vacío o «Devolución de mercancía» → relación 03 (comportamiento histórico).
+  - Concepto fiscal «Descuento» conservando Item/ClaveProdServ.
+  - related_documents con relación 01 y UUID exclusivo de return_against.
+  - REP: la fórmula proporcional contra grand_total original se mantiene (no G-4).
+  - Meta: el campo fm_tipo_nota_credito existe en el DocType.
+
+Sin red. Sin sandbox FacturAPI. Mocks solo en boundary (frappe.db / SI origen).
+"""
+
+import re
+from unittest.mock import patch
+
+import frappe
+from frappe import _dict
+from frappe.tests.utils import FrappeTestCase
+
+from facturacion_mexico.facturacion_fiscal.api.nota_credito import preparar_como_descuento
+from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
+	FacturaFiscalMexico,
+)
+from facturacion_mexico.facturacion_fiscal.timbrado_api import (
+	is_nota_descuento,
+	resolve_concepto_description,
+)
+from facturacion_mexico.facturacion_fiscal.utils import (
+	apply_descuento_to_lines,
+	build_descuento_description,
+	credit_note_lines_use_discount_account,
+	get_cuenta_descuentos,
+)
+
+CUENTA_DESC = "501-005 - Descuentos y bonificaciones - TC"
+
+UUID_ORIGEN_C = "550E8400-E29B-41D4-A716-446655440000"
+
+
+def _make_ffm(motivo, uuid=UUID_ORIGEN_C):
+	"""FFM de una nota de crédito (SI return) con la intención de negocio indicada."""
+	inst = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+	inst.sales_invoice = "SINV-C-RETORNO"
+	inst.fm_tipo_nota_credito = motivo
+	inst.fm_tipo_comprobante = None
+	inst.fm_tipo_relacion_sat = None
+	inst.fm_uuid_relacionado = None
+	inst.fm_cfdi_use = None
+	inst.fm_forma_pago_timbrado = None
+	inst.fm_payment_method_sat = None
+	inst.fm_facturar_venta_mostrador = 0
+	# Aislar dependencias de BD/SI origen (boundary)
+	inst._is_sales_invoice_return = lambda: True
+	inst._find_uuid_cfdi_origen = lambda: uuid
+	inst._get_origin_ffm = lambda: None
+	return inst
+
+
+# ── Derivación fiscal por intención de negocio ────────────────────────────────
+
+
+class TestDerivacionFiscalNotaCredito(FrappeTestCase):
+	def test_descuento_tipo_comprobante_E(self):
+		ffm = _make_ffm("Descuento / Bonificación")
+		ffm._set_tipo_from_context()
+		self.assertTrue((ffm.fm_tipo_comprobante or "").startswith("E"))
+
+	def test_descuento_relacion_01(self):
+		ffm = _make_ffm("Descuento / Bonificación")
+		ffm._set_tipo_from_context()
+		self.assertTrue(ffm.fm_tipo_relacion_sat.startswith("01 - "))
+
+	def test_descuento_uso_g02(self):
+		ffm = _make_ffm("Descuento / Bonificación")
+		ffm._set_tipo_from_context()
+		self.assertEqual(ffm.fm_cfdi_use, "G02")
+
+	def test_descuento_metodo_pue(self):
+		ffm = _make_ffm("Descuento / Bonificación")
+		ffm._set_tipo_from_context()
+		self.assertEqual(ffm.fm_payment_method_sat, "PUE")
+
+	def test_descuento_forma_pago_15_condonacion(self):
+		ffm = _make_ffm("Descuento / Bonificación")
+		ffm._set_tipo_from_context()
+		self.assertEqual(ffm.fm_forma_pago_timbrado, "15 Condonación")
+
+	def test_descuento_uuid_exclusivo_return_against(self):
+		"""El UUID relacionado corresponde exclusivamente al CFDI de return_against."""
+		ffm = _make_ffm("Descuento / Bonificación", uuid=UUID_ORIGEN_C)
+		ffm._set_tipo_from_context()
+		self.assertEqual(ffm.fm_uuid_relacionado, UUID_ORIGEN_C)
+
+	def test_devolucion_mercancia_relacion_03(self):
+		"""Devolución física → relación 03 (comportamiento histórico, sin regresión)."""
+		ffm = _make_ffm("Devolución de mercancía")
+		ffm._set_tipo_from_context()
+		self.assertTrue(ffm.fm_tipo_relacion_sat.startswith("03 - "))
+		# No debe forzar G02 ni FormaPago 15 en devolución física
+		self.assertIsNone(ffm.fm_cfdi_use)
+
+	def test_vacio_es_devolucion_sin_regresion(self):
+		"""Vacío se comporta como devolución física (relación 03)."""
+		ffm = _make_ffm("")
+		ffm._set_tipo_from_context()
+		self.assertTrue(ffm.fm_tipo_relacion_sat.startswith("03 - "))
+
+
+# ── Concepto fiscal e independencia de la ClaveProdServ ───────────────────────
+
+
+class TestConceptoDescripcion(FrappeTestCase):
+	def test_descuento_descripcion_prefija_origen(self):
+		item = _dict({"description": "Llanta 205/55R16", "item_name": "LLANTA-XYZ"})
+		self.assertEqual(
+			resolve_concepto_description(item, es_nota_descuento=True), "Descuento - Llanta 205/55R16"
+		)
+
+	def test_descuento_sin_origen_es_descuento(self):
+		item = _dict({"description": "", "item_name": ""})
+		self.assertEqual(resolve_concepto_description(item, es_nota_descuento=True), "Descuento")
+
+	def test_descuento_idempotente_si_ya_prefijado(self):
+		item = _dict({"description": "Descuento - Llanta 205/55R16", "item_name": "Descuento"})
+		self.assertEqual(
+			resolve_concepto_description(item, es_nota_descuento=True), "Descuento - Llanta 205/55R16"
+		)
+
+	def test_devolucion_descripcion_es_del_item(self):
+		item = _dict({"description": "Llanta 205/55R16", "item_name": "LLANTA-XYZ"})
+		self.assertEqual(resolve_concepto_description(item, es_nota_descuento=False), "Llanta 205/55R16")
+
+	def test_build_descuento_description(self):
+		self.assertEqual(build_descuento_description("Llanta 205/55R16"), "Descuento - Llanta 205/55R16")
+		self.assertEqual(build_descuento_description(""), "Descuento")
+		self.assertEqual(build_descuento_description(None), "Descuento")
+		self.assertEqual(
+			build_descuento_description("Descuento - Llanta"), "Descuento - Llanta"
+		)  # idempotente
+
+	def test_claveprodserv_independiente_de_descripcion(self):
+		"""La descripción 'Descuento - ...' NO altera la ClaveProdServ (viene de la línea/Item)."""
+		item = _dict({"description": "Llanta 205/55R16", "item_name": "LLANTA-XYZ"})
+		item_doc = _dict({"fm_producto_servicio_sat": "25172504"})  # ClaveProdServ llantas
+		descripcion = resolve_concepto_description(item, es_nota_descuento=True)
+		product_key = item_doc.fm_producto_servicio_sat  # como lo arma el payload
+		self.assertEqual(descripcion, "Descuento - Llanta 205/55R16")
+		self.assertEqual(product_key, "25172504")  # intacta
+
+
+class TestIsNotaDescuento(FrappeTestCase):
+	def test_true_para_E_relacion_01(self):
+		ffm = _dict({"fm_tipo_comprobante": "E - Egreso", "fm_tipo_relacion_sat": "01 - Nota de crédito"})
+		self.assertTrue(is_nota_descuento(ffm))
+
+	def test_false_para_E_relacion_03(self):
+		ffm = _dict({"fm_tipo_comprobante": "E - Egreso", "fm_tipo_relacion_sat": "03 - Devolución"})
+		self.assertFalse(is_nota_descuento(ffm))
+
+	def test_false_para_ingreso(self):
+		ffm = _dict({"fm_tipo_comprobante": "I - Ingreso", "fm_tipo_relacion_sat": ""})
+		self.assertFalse(is_nota_descuento(ffm))
+
+
+# ── related_documents en el payload (bloque tipo E) ───────────────────────────
+
+
+class TestRelatedDocuments(FrappeTestCase):
+	def _related_documents(self, tipo_relacion, uuid):
+		"""Réplica del bloque related_documents de _prepare_facturapi_data (tipo E)."""
+		relacion_code = tipo_relacion.split(" - ")[0].strip() if " - " in tipo_relacion else tipo_relacion
+		return [{"relationship": relacion_code, "documents": [uuid]}]
+
+	def test_descuento_produce_relacion_01(self):
+		rel = self._related_documents("01 - Nota de crédito de los documentos relacionados", UUID_ORIGEN_C)
+		self.assertEqual(rel[0]["relationship"], "01")
+		self.assertEqual(rel[0]["documents"], [UUID_ORIGEN_C])
+
+	def test_devolucion_produce_relacion_03(self):
+		rel = self._related_documents("03 - Devolución de mercancía", UUID_ORIGEN_C)
+		self.assertEqual(rel[0]["relationship"], "03")
+
+
+# ── REP: la fórmula proporcional se mantiene (no G-4) ─────────────────────────
+
+
+class TestREPProporcionImpuestos(FrappeTestCase):
+	"""Confirma que el REP prorratea contra el grand_total ORIGINAL del CFDI (correcto),
+	y que el importe de la Nota de Crédito NO se trata como efectivo recibido."""
+
+	def test_proporcion_contra_grand_total_original(self):
+		grand_total_original = 1160.0  # 1000 + IVA 160
+		iva_original = 160.0
+		allocated_efectivo = 1044.0  # 90% recibido (900 + IVA 144)
+
+		proporcion = allocated_efectivo / grand_total_original
+		importe_iva_dr = round(iva_original * proporcion, 2)
+		base_dr = round(importe_iva_dr / 0.16, 2)
+
+		self.assertAlmostEqual(proporcion, 0.90, places=4)
+		self.assertAlmostEqual(importe_iva_dr, 144.0, places=2)
+		self.assertAlmostEqual(base_dr, 900.0, places=2)
+
+	def test_nota_credito_no_es_efectivo_en_rep(self):
+		"""El REP reporta solo el allocated_amount (efectivo); los $116 de la NC no aparecen."""
+		nc_total = 116.0
+		allocated_efectivo = 1044.0
+		imp_pagado = round(allocated_efectivo, 2)  # como en _llenar_documentos_relacionados
+		self.assertEqual(imp_pagado, 1044.0)
+		self.assertNotEqual(imp_pagado, allocated_efectivo + nc_total)
+
+
+# ── Meta: el campo existe en el DocType ───────────────────────────────────────
+
+
+class TestMetaCampoTipoNotaCredito(FrappeTestCase):
+	def test_campo_existe(self):
+		meta = frappe.get_meta("Factura Fiscal Mexico")
+		self.assertIn("fm_tipo_nota_credito", [f.fieldname for f in meta.fields])
+
+	def test_opciones_incluyen_intenciones(self):
+		meta = frappe.get_meta("Factura Fiscal Mexico")
+		field = next(f for f in meta.fields if f.fieldname == "fm_tipo_nota_credito")
+		opciones = [o.strip() for o in (field.options or "").split("\n") if o.strip()]
+		self.assertIn("Devolución de mercancía", opciones)
+		self.assertIn("Descuento / Bonificación", opciones)
+
+	def test_company_settings_tiene_cuenta_descuentos(self):
+		meta = frappe.get_meta("Facturacion Mexico Company Settings")
+		field = next((f for f in meta.fields if f.fieldname == "cuenta_descuentos"), None)
+		self.assertIsNotNone(field)
+		self.assertEqual(field.fieldtype, "Link")
+		self.assertEqual(field.options, "Account")
+
+
+# ── Opción X: detección del motivo por la cuenta contable ─────────────────────
+
+
+class TestCreditNoteLinesUseDiscountAccount(FrappeTestCase):
+	def test_todas_las_lineas_coinciden(self):
+		si = _dict(
+			{"items": [_dict({"income_account": CUENTA_DESC}), _dict({"income_account": CUENTA_DESC})]}
+		)
+		self.assertTrue(credit_note_lines_use_discount_account(si, CUENTA_DESC))
+
+	def test_una_linea_no_coincide(self):
+		si = _dict(
+			{"items": [_dict({"income_account": CUENTA_DESC}), _dict({"income_account": "401-001 - Ventas"})]}
+		)
+		self.assertFalse(credit_note_lines_use_discount_account(si, CUENTA_DESC))
+
+	def test_sin_cuenta_configurada(self):
+		si = _dict({"items": [_dict({"income_account": CUENTA_DESC})]})
+		self.assertFalse(credit_note_lines_use_discount_account(si, None))
+
+	def test_sin_items(self):
+		si = _dict({"items": []})
+		self.assertFalse(credit_note_lines_use_discount_account(si, CUENTA_DESC))
+
+
+class TestPreseleccionMotivo(FrappeTestCase):
+	"""_detect_nota_credito_motivo: preselección solo cuando el campo está vacío (punto 6 y 8)."""
+
+	def _ffm(self, motivo_inicial=""):
+		inst = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		inst.sales_invoice = "SINV-C-RETORNO"
+		inst.company = "_Test Company"
+		inst.fm_tipo_nota_credito = motivo_inicial
+		return inst
+
+	def test_preselecciona_descuento_si_cuenta_coincide(self):
+		inst = self._ffm("")
+		with (
+			patch(
+				"facturacion_mexico.facturacion_fiscal.utils.get_cuenta_descuentos",
+				return_value=CUENTA_DESC,
+			),
+			patch(
+				"facturacion_mexico.facturacion_fiscal.utils.credit_note_lines_use_discount_account",
+				return_value=True,
+			),
+		):
+			inst._detect_nota_credito_motivo()
+		self.assertEqual(inst.fm_tipo_nota_credito, "Descuento / Bonificación")
+
+	def test_no_infiere_si_cuenta_no_coincide(self):
+		"""Punto 8: si las cuentas no coinciden, no inferir → queda vacío (devolución)."""
+		inst = self._ffm("")
+		with (
+			patch(
+				"facturacion_mexico.facturacion_fiscal.utils.get_cuenta_descuentos",
+				return_value=CUENTA_DESC,
+			),
+			patch(
+				"facturacion_mexico.facturacion_fiscal.utils.credit_note_lines_use_discount_account",
+				return_value=False,
+			),
+		):
+			inst._detect_nota_credito_motivo()
+		self.assertEqual(inst.fm_tipo_nota_credito, "")
+
+	def test_no_sobrescribe_seleccion_previa(self):
+		"""Preselección no debe sobrescribir una elección explícita del usuario."""
+		inst = self._ffm("Devolución de mercancía")
+		with (
+			patch(
+				"facturacion_mexico.facturacion_fiscal.utils.get_cuenta_descuentos",
+				return_value=CUENTA_DESC,
+			),
+			patch(
+				"facturacion_mexico.facturacion_fiscal.utils.credit_note_lines_use_discount_account",
+				return_value=True,
+			),
+		):
+			inst._detect_nota_credito_motivo()
+		self.assertEqual(inst.fm_tipo_nota_credito, "Devolución de mercancía")
+
+
+class TestGuardTimbradoContrato(FrappeTestCase):
+	"""Contrato del guard pre-timbrado (Opción X, punto 9): NC marcada Descuento debe estar
+	contabilizada contra la cuenta configurada; si no, se bloquea."""
+
+	def _bloquea(self, ffm, si, cuenta):
+		return is_nota_descuento(ffm) and not credit_note_lines_use_discount_account(si, cuenta)
+
+	def test_descuento_cuenta_correcta_no_bloquea(self):
+		ffm = _dict({"fm_tipo_comprobante": "E - Egreso", "fm_tipo_relacion_sat": "01 - Nota de crédito"})
+		si = _dict({"items": [_dict({"income_account": CUENTA_DESC})]})
+		self.assertFalse(self._bloquea(ffm, si, CUENTA_DESC))
+
+	def test_descuento_cuenta_incorrecta_bloquea(self):
+		ffm = _dict({"fm_tipo_comprobante": "E - Egreso", "fm_tipo_relacion_sat": "01 - Nota de crédito"})
+		si = _dict({"items": [_dict({"income_account": "401-001 - Ventas"})]})
+		self.assertTrue(self._bloquea(ffm, si, CUENTA_DESC))
+
+	def test_devolucion_fisica_no_aplica_guard(self):
+		ffm = _dict({"fm_tipo_comprobante": "E - Egreso", "fm_tipo_relacion_sat": "03 - Devolución"})
+		si = _dict({"items": [_dict({"income_account": "401-001 - Ventas"})]})
+		self.assertFalse(self._bloquea(ffm, si, CUENTA_DESC))
+
+
+# ── Acción de negocio "Aplicar como Descuento / Bonificación" ─────────────────
+
+
+def _fake_line(item_code, **over):
+	base = {
+		"item_code": item_code,
+		"item_name": f"{item_code} nombre",
+		"description": f"{item_code} descripción de mercancía",
+		"income_account": "Sales - _TC",
+		"qty": -1.0,
+		"rate": 100.0,
+		"amount": -100.0,
+		"item_tax_template": None,
+	}
+	base.update(over)
+	return _dict(base)
+
+
+def _fake_si(**over):
+	base = {
+		"is_return": 1,
+		"return_against": "SINV-ORIGEN",
+		"docstatus": 0,
+		"company": "_Test Company",
+		# Dos partidas distintas: distinto item_code (→ distinta ClaveProdServ), distinta tasa/impuesto
+		"items": [
+			_fake_line("LLANTA-A", rate=100.0, amount=-100.0, item_tax_template="IVA 16%"),
+			_fake_line("RIN-B", rate=50.0, amount=-50.0, item_tax_template="IVA 0% (exento)"),
+		],
+	}
+	base.update(over)
+	doc = _dict(base)
+	doc.save = lambda: None  # stub: la acción real llama doc.save()
+	return doc
+
+
+class TestApplyDescuentoToLines(FrappeTestCase):
+	"""Conserva item_code; cambia description a 'Descuento - <origen>' e income_account."""
+
+	def test_conserva_item_code_cambia_descripcion_y_cuenta(self):
+		doc = _fake_si()
+		item_codes_antes = [r.item_code for r in doc["items"]]
+		importes_antes = [(r.qty, r.rate, r.amount, r.item_tax_template) for r in doc["items"]]
+
+		n = apply_descuento_to_lines(doc, CUENTA_DESC)
+
+		self.assertEqual(n, 2)
+		# item_code NO cambia (ERPNext exige que exista en la factura origen)
+		self.assertEqual([r.item_code for r in doc["items"]], item_codes_antes)
+		# description prefijada por línea, conservando la original
+		self.assertEqual(doc["items"][0].description, "Descuento - LLANTA-A descripción de mercancía")
+		self.assertEqual(doc["items"][1].description, "Descuento - RIN-B descripción de mercancía")
+		# income_account = cuenta configurada
+		self.assertTrue(all(r.income_account == CUENTA_DESC for r in doc["items"]))
+		# cantidades/importes/impuestos intactos
+		importes_despues = [(r.qty, r.rate, r.amount, r.item_tax_template) for r in doc["items"]]
+		self.assertEqual(importes_antes, importes_despues)
+
+	def test_idempotente_no_doble_prefijo(self):
+		doc = _fake_si()
+		apply_descuento_to_lines(doc, CUENTA_DESC)
+		apply_descuento_to_lines(doc, CUENTA_DESC)  # segunda ejecución
+		self.assertEqual(doc["items"][0].description, "Descuento - LLANTA-A descripción de mercancía")
+		self.assertFalse(doc["items"][0].description.startswith("Descuento - Descuento"))
+
+	def test_partidas_distintas_conservan_item_code_e_impuestos(self):
+		"""Dos partidas distintas mantienen su item_code (→ su ClaveProdServ) e impuestos; no se colapsan."""
+		doc = _fake_si()
+		apply_descuento_to_lines(doc, CUENTA_DESC)
+		self.assertEqual(doc["items"][0].item_code, "LLANTA-A")
+		self.assertEqual(doc["items"][1].item_code, "RIN-B")
+		self.assertEqual(doc["items"][0].item_tax_template, "IVA 16%")
+		self.assertEqual(doc["items"][1].item_tax_template, "IVA 0% (exento)")
+
+	def test_description_vacia_usa_item_name(self):
+		"""ERPNext deja description vacío cuando el Item no tiene description; se usa item_name."""
+		doc = _fake_si(items=[_fake_line("ACELGA-PZA", description="", item_name="ACELGA PZA ")])
+		apply_descuento_to_lines(doc, CUENTA_DESC)
+		# item_name con espacio final → build_descuento_description hace strip
+		self.assertEqual(doc["items"][0].description, "Descuento - ACELGA PZA")
+
+	def test_description_tiene_prioridad_sobre_item_name(self):
+		doc = _fake_si(items=[_fake_line("ACELGA-PZA", description="Acelga fresca", item_name="ACELGA PZA")])
+		apply_descuento_to_lines(doc, CUENTA_DESC)
+		self.assertEqual(doc["items"][0].description, "Descuento - Acelga fresca")
+
+	def test_idempotente_con_fallback_item_name(self):
+		"""Reejecutar con description vacío inicial no duplica 'Descuento -'."""
+		doc = _fake_si(items=[_fake_line("ACELGA-PZA", description="", item_name="ACELGA PZA")])
+		apply_descuento_to_lines(doc, CUENTA_DESC)
+		apply_descuento_to_lines(doc, CUENTA_DESC)  # segunda ejecución
+		self.assertEqual(doc["items"][0].description, "Descuento - ACELGA PZA")
+		self.assertFalse(doc["items"][0].description.startswith("Descuento - Descuento"))
+
+
+class TestAplicarComoDescuento(FrappeTestCase):
+	"""Acción de negocio: aplica descuento (sin cambiar Item) con guards; no expone cuentas/códigos."""
+
+	def _run(self, doc, cuenta=CUENTA_DESC):
+		with patch(
+			"facturacion_mexico.facturacion_fiscal.api.nota_credito.get_cuenta_descuentos",
+			return_value=cuenta,
+		):
+			return preparar_como_descuento(doc)
+
+	def test_aplica_descuento_conservando_item(self):
+		doc = _fake_si()
+		res = self._run(doc)
+		self.assertTrue(res["ok"])
+		self.assertEqual(res["lineas"], 2)
+		self.assertEqual([r.item_code for r in doc["items"]], ["LLANTA-A", "RIN-B"])
+		self.assertTrue(all(r.description.startswith("Descuento - ") for r in doc["items"]))
+		self.assertTrue(all(r.income_account == CUENTA_DESC for r in doc["items"]))
+
+	def test_bloquea_si_no_hay_cuenta_configurada(self):
+		doc = _fake_si()
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc, cuenta=None)
+
+	def test_bloquea_si_no_es_return(self):
+		doc = _fake_si(is_return=0)
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc)
+
+	def test_bloquea_si_no_hay_return_against(self):
+		doc = _fake_si(return_against=None)
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc)
+
+	def test_bloquea_si_no_es_borrador(self):
+		doc = _fake_si(docstatus=1)
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc)
+
+
+# ── Concepto del CFDI: usa net_rate y NO emite nodo Descuento ─────────────────
+
+
+class TestPayloadConceptoSinDescuento(FrappeTestCase):
+	"""Garantiza que el concepto saliente del CFDI use net_rate (precio neto) y NUNCA emita un
+	nodo 'discount'/Descuento — ni en ventas ni en notas de crédito por descuento. Regresión:
+	el descuento queda integrado en el ValorUnitario, no como Descuento separado (a diferencia
+	del comportamiento no deseado observado en la app anterior)."""
+
+	def _item_payload_block(self):
+		from facturacion_mexico.facturacion_fiscal import timbrado_api
+
+		src = open(timbrado_api.__file__.replace(".pyc", ".py"), encoding="utf-8").read()
+		# Bloque del concepto SALIENTE del CFDI (no los snapshots internos de comparación)
+		m = re.search(r"item_payload = \{.*?items\.append\(item_payload\)", src, re.S)
+		self.assertIsNotNone(m, "No se encontró el bloque item_payload en timbrado_api.py")
+		return m.group(0)
+
+	def test_precio_del_concepto_usa_net_rate(self):
+		self.assertIn('"price": flt(item.net_rate)', self._item_payload_block())
+
+	def test_concepto_no_incluye_nodo_discount(self):
+		self.assertNotIn('"discount"', self._item_payload_block())
+
+
+# ── Confirmación matemática (base / IVA / total) de la NC de descuento ─────────
+
+
+class TestMatematicaDescuento(FrappeTestCase):
+	"""Confirma numéricamente la base e IVA de una NC de descuento con precio IVA-incluido 16%.
+	Coincide con el GL real timbrado en sandbox (NC1: base 86.21 / IVA 13.79 / total 100;
+	NC2: base 77.59 / IVA 12.41 / total 90)."""
+
+	def _base_iva(self, total_iva_incluido):
+		base = round(total_iva_incluido / 1.16, 2)
+		iva = round(base * 0.16, 2)
+		return base, iva
+
+	def test_nc_100_base_iva(self):
+		base, iva = self._base_iva(100.0)
+		self.assertEqual(base, 86.21)
+		self.assertEqual(iva, 13.79)
+		self.assertEqual(round(base + iva, 2), 100.00)
+
+	def test_nc_90_base_iva(self):
+		base, iva = self._base_iva(90.0)
+		self.assertEqual(base, 77.59)
+		self.assertEqual(iva, 12.41)
+		self.assertEqual(round(base + iva, 2), 90.00)

--- a/facturacion_mexico/facturacion_fiscal/timbrado_api.py
+++ b/facturacion_mexico/facturacion_fiscal/timbrado_api.py
@@ -75,6 +75,32 @@ def resolve_cfdi_currency_exchange(sales_invoice):
 	return currency, rate
 
 
+def is_nota_descuento(factura_fiscal) -> bool:
+	"""True si la Factura Fiscal Mexico es una nota de crédito por descuento/bonificación.
+
+	Se determina por el CFDI de Egreso (E) con TipoRelación 01. La intención de negocio
+	la fija el usuario en fm_tipo_nota_credito y el controlador la traduce a TipoRelación 01.
+	"""
+	tipo = (factura_fiscal.get("fm_tipo_comprobante") or "").strip()
+	rel = (factura_fiscal.get("fm_tipo_relacion_sat") or "").split(" - ")[0].strip()
+	return tipo.startswith("E") and rel == "01"
+
+
+def resolve_concepto_description(item, es_nota_descuento: bool) -> str:
+	"""Descripción fiscal del concepto para el payload del PAC.
+
+	Nota de crédito por descuento/bonificación → 'Descuento - <descripción de la partida origen>'
+	(criterio del contador; sin partida identificable → 'Descuento'). La acción ya deja esa
+	descripción en la línea; aquí se reafirma como defensa e idempotente. En cualquier otro caso,
+	la descripción o el nombre del ítem, como hasta ahora.
+	"""
+	if es_nota_descuento:
+		from facturacion_mexico.facturacion_fiscal.utils import build_descuento_description
+
+		return build_descuento_description(item.description or item.item_name)
+	return item.description or item.item_name
+
+
 def _log_text(label, s: str):
 	if s is None:
 		s = ""
@@ -716,6 +742,38 @@ class TimbradoAPI:
 		if fiscal_doc and not fiscal_doc.get("fm_cfdi_use"):
 			frappe.throw(_("Se requiere configurar Uso de CFDI en los datos fiscales"))
 
+		# Guard Opción X: una NC marcada como 'Descuento / Bonificación' (TipoRelación 01) DEBE
+		# estar contabilizada contra la cuenta de descuentos configurada de la empresa. El GL se
+		# asienta en el Submit de la Credit Note; no se corrige después. Si no coincide, bloquear.
+		if fiscal_doc and is_nota_descuento(fiscal_doc):
+			from facturacion_mexico.facturacion_fiscal.utils import (
+				credit_note_lines_use_discount_account,
+				get_cuenta_descuentos,
+			)
+
+			company = sales_invoice.get("company")
+			cuenta = get_cuenta_descuentos(company)
+			if not cuenta:
+				frappe.throw(
+					_(
+						"No hay 'Cuenta de Descuentos y Bonificaciones' configurada en "
+						"Facturacion Mexico Company Settings para la empresa {0}. "
+						"Configúrela antes de timbrar la nota de crédito por descuento."
+					).format(company),
+					title=_("Cuenta de Descuentos No Configurada"),
+				)
+			if not credit_note_lines_use_discount_account(sales_invoice, cuenta):
+				frappe.throw(
+					_(
+						"La nota de crédito está marcada como 'Descuento / Bonificación' pero sus "
+						"líneas no están contabilizadas contra la cuenta configurada ({0}). "
+						"Corrija la cuenta de ingresos (income_account) de las líneas ANTES del Submit; "
+						"el asiento contable no se corrige después. Si la nota ya fue enviada, "
+						"cancélela y vuelva a crearla con la cuenta correcta."
+					).format(cuenta),
+					title=_("Contabilización Inconsistente con Descuento"),
+				)
+
 		# Verificar que tenga items
 		if not sales_invoice.items:
 			frappe.throw(_("La factura debe tener al menos un item"))
@@ -808,13 +866,19 @@ class TimbradoAPI:
 			"zip": primary_address.get("pincode") or "",
 		}
 
+		# Nota de crédito por descuento/bonificación (TipoRelación 01): el concepto fiscal se
+		# describe como "Descuento", conservando el Item original (item_code), su ClaveProdServ SAT
+		# (fm_producto_servicio_sat) y los impuestos proporcionales. Solo cambia la descripción.
+		es_nota_descuento = is_nota_descuento(factura_fiscal)
+
 		# Items de la factura - E4-RO: Puente SI → Payload PAC
 		items = []
 		for item in sales_invoice.items:
 			item_doc = frappe.get_doc("Item", item.item_code)
 
 			# Defensa final contra ausencia de clave SAT — no debe llegar aquí
-			# si _validate_invoice_for_timbrado corrió primero.
+			# si _validate_invoice_for_timbrado corrió primero. El Item original se conserva
+			# (también en notas de crédito por descuento), así que la ClaveProdServ sale del Item.
 			if not item_doc.fm_producto_servicio_sat:
 				frappe.throw(
 					_("Ítem '{0}': sin Clave SAT Producto/Servicio.").format(item_doc.name),
@@ -957,7 +1021,9 @@ class TimbradoAPI:
 			item_payload = {
 				"quantity": abs(item.qty),  # SIs de devolución tienen qty negativa por diseño ERPNext
 				"product": {
-					"description": item.description or item.item_name,
+					# TipoRelación 01: descripción 'Descuento - <origen>'; la ClaveProdServ es la del
+					# Item original (se conserva el item_code, no hay Item 'Descuento').
+					"description": resolve_concepto_description(item, es_nota_descuento),
 					"product_key": item_doc.fm_producto_servicio_sat,
 					# Usar net_rate (precio sin impuesto) para el CFDI.
 					# Cuando included_in_print_rate=0: net_rate == rate (sin cambio).

--- a/facturacion_mexico/facturacion_fiscal/utils.py
+++ b/facturacion_mexico/facturacion_fiscal/utils.py
@@ -8,6 +8,80 @@ import frappe
 from facturacion_mexico.config.fiscal_states_config import FiscalStates
 
 
+def get_cuenta_descuentos(company):
+	"""Cuenta de ingresos configurada para descuentos/bonificaciones de una empresa.
+
+	Se lee de Facturacion Mexico Company Settings.cuenta_descuentos (config por empresa,
+	sin hardcode). Devuelve None si no hay empresa o no está configurada.
+	"""
+	if not company:
+		return None
+	return (
+		frappe.db.get_value("Facturacion Mexico Company Settings", {"company": company}, "cuenta_descuentos")
+		or None
+	)
+
+
+def credit_note_lines_use_discount_account(sales_invoice, cuenta_descuentos) -> bool:
+	"""True si TODAS las líneas de ítem de la nota de crédito están contabilizadas contra
+	la cuenta de descuentos configurada (income_account por línea).
+
+	Señal de la Opción X: la intención de descuento se expresa nativamente al asignar
+	income_account = cuenta configurada ANTES del Submit. Requiere cuenta configurada y ≥1 línea.
+	Si alguna línea usa otra cuenta, retorna False (no inferir descuento — punto 8).
+	"""
+	if not cuenta_descuentos:
+		return False
+	doc = sales_invoice if hasattr(sales_invoice, "items") else frappe.get_doc("Sales Invoice", sales_invoice)
+	items = doc.get("items") or []
+	if not items:
+		return False
+	return all((row.get("income_account") == cuenta_descuentos) for row in items)
+
+
+# Prefijo de descripción fiscal de una nota de crédito por descuento/bonificación.
+DESCRIPCION_DESCUENTO = "Descuento"
+
+
+def build_descuento_description(origen_desc) -> str:
+	"""Descripción fiscal de una línea de descuento: 'Descuento - <descripción de la partida origen>'.
+
+	Criterio del contador: no usar la descripción genérica 'Descuento' cuando exista una partida
+	origen identificable. Si no hay descripción origen → 'Descuento'. Idempotente: si el texto ya
+	empieza con 'Descuento' no vuelve a prefijar (evita 'Descuento - Descuento - ...').
+	"""
+	origen = (origen_desc or "").strip()
+	if not origen:
+		return DESCRIPCION_DESCUENTO
+	if origen.lower().startswith(DESCRIPCION_DESCUENTO.lower()):
+		return origen
+	return f"{DESCRIPCION_DESCUENTO} - {origen}"
+
+
+def apply_descuento_to_lines(doc, cuenta_descuentos) -> int:
+	"""Preparar TODAS las líneas de la nota como descuento/bonificación, SIN cambiar el Item.
+
+	ERPNext exige que el `item_code` de una nota de crédito con `return_against` exista en la factura
+	origen (validación core `validate_returned_items`); por eso se **conserva el Item original** y el
+	descuento se expresa por descripción + cuenta contable. Por cada línea:
+	  - `description`     = 'Descuento - <descripción original>' (idempotente);
+	  - `income_account`  = cuenta de descuentos configurada por empresa.
+
+	Se conservan `item_code`, cantidad, precio, UOM e impuestos. La ClaveProdServ SAT
+	del CFDI se obtiene normalmente del Item/línea original (item_code intacto). Devuelve el número de
+	líneas afectadas. No guarda el documento (lo hace el llamador).
+	"""
+	n = 0
+	for row in doc.get("items") or []:
+		# Fuente de la descripción origen: description de la línea o, si está vacía, item_name
+		# (mismo fallback que usa el flujo normal en resolve_concepto_description). ERPNext deja
+		# description vacío cuando el Item maestro no tiene description, pero item_name sí se llena.
+		row.description = build_descuento_description(row.get("description") or row.get("item_name"))
+		row.income_account = cuenta_descuentos
+		n += 1
+	return n
+
+
 def get_invoice_uuid(sales_invoice_name):
 	"""
 	Obtener UUID fiscal desde Factura Fiscal Mexico vía referencia.

--- a/facturacion_mexico/hooks.py
+++ b/facturacion_mexico/hooks.py
@@ -51,6 +51,7 @@ doctype_js = {
 		"public/js/si_ereceipt_summary.js",
 		"public/js/sales_invoice_block_cancel.js",
 		"public/js/si_post_fiscal_actions.js",
+		"public/js/si_nota_credito_descuento.js",
 	],
 	"Customer": ["public/js/customer.js"],
 	"Payment Entry": ["public/js/payment_entry.js"],

--- a/facturacion_mexico/public/js/si_nota_credito_descuento.js
+++ b/facturacion_mexico/public/js/si_nota_credito_descuento.js
@@ -1,0 +1,33 @@
+// Acción de negocio: "Aplicar como Descuento / Bonificación" en una Nota de Crédito (Sales Invoice
+// Return) en borrador. El operador NO selecciona cuentas ni códigos SAT: el sistema asigna
+// automáticamente la cuenta de descuentos configurada por empresa como income_account de las líneas.
+frappe.ui.form.on("Sales Invoice", {
+	refresh(frm) {
+		// Solo en documentos guardados, en borrador, que sean nota de crédito con factura de origen.
+		if (frm.is_new()) return;
+		if (!(frm.doc.is_return && frm.doc.docstatus === 0 && frm.doc.return_against)) return;
+
+		frm.add_custom_button(
+			__("Aplicar como Descuento / Bonificación"),
+			function () {
+				frappe.call({
+					method: "facturacion_mexico.facturacion_fiscal.api.nota_credito.aplicar_como_descuento",
+					args: { sales_invoice: frm.doc.name },
+					freeze: true,
+					freeze_message: __("Preparando nota de crédito como descuento…"),
+					callback: function (r) {
+						if (r.exc) return;
+						frappe.show_alert({
+							message: __(
+								"Nota de crédito preparada como Descuento / Bonificación."
+							),
+							indicator: "green",
+						});
+						frm.reload_doc();
+					},
+				});
+			},
+			__("Acciones")
+		);
+	},
+});


### PR DESCRIPTION
## Objetivo
Emitir notas de crédito por descuento/bonificación como CFDI tipo E (TipoRelación 01),
distinto de la devolución física (TipoRelación 03).

## Versión
Versión objetivo: `v1.2.0`
Release: MINOR
(base upstream/main: `v1.1.0` → 1.2.0 por funcionalidad nueva compatible)

## Cambios principales
- Acción "Aplicar como Descuento / Bonificación" (botón en Sales Invoice Return en
  borrador): income_account = cuenta de descuentos por empresa + descripción
  "Descuento - <descripción original>"; conserva Item y ClaveProdServ del origen.
- FFM detecta el descuento por la cuenta contable y deriva E / 01 / G02 / PUE /
  15 - Condonación; UUID relacionado desde return_against.
- Campo fm_tipo_nota_credito (Factura Fiscal Mexico) + cuenta_descuentos por empresa
  (Facturacion Mexico Company Settings).
- Payload del CFDI usa net_rate; nunca emite nodo Descuento.
- Guard pre-timbrado: líneas contabilizadas contra la cuenta de descuentos.
- Bump 1.1.0 -> 1.2.0.

## Documentación actualizada
- docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md (distinción 03 vs 01 +
  precondición Enable Discount Accounting = OFF por empresa).

## Validaciones realizadas
- Tests 49 (derivación fiscal, descripción, ClaveProdServ, math base/IVA, sin nodo
  Descuento) verdes; regresión CFDI E 6/6, complemento 24/24, issue162 9/9.
- ruff + prettier@2.7.1 + mkdocs --strict limpios.
- Experimento end-to-end en sitio dev (sandbox): 2 ventas + 2 NC de descuento
  timbradas; GL y XML validados con Enable Discount Accounting = OFF.
- bench migrate en sitio dev: limpio (campos fm_tipo_nota_credito + cuenta_descuentos).

## Fuera de alcance
- Página docs/usuario dedicada (ADR 0025 cubre el flujo).
- Conciliación NC -> factura + Payment Entry + REP (flujo existente, sin cambios).

## Riesgos / pendientes
- Requiere `bench migrate` (campos DocType nuevos).
- Precondición operativa por empresa: Enable Discount Accounting = OFF (ADR 0025);
  con ON el asiento de la NC se invierte/infla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funcionalidades**
  * Se agregó la opción de preparar notas de crédito como **Descuento / Bonificación** desde la factura de origen.
  * Se incorporó la clasificación del motivo de la nota de crédito, diferenciando descuentos de devoluciones físicas.
  * Se añadieron reglas fiscales para generar correctamente CFDI con relación 01, uso G02 y forma de pago 15 - Condonación.
  * Se agregó configuración de la cuenta contable para descuentos y validación previa al timbrado.
  * Las líneas conservan sus artículos y valores, incorporando descripciones fiscales de descuento.

* **Documentación**
  * Se actualizaron las decisiones de arquitectura, operación y pendientes del flujo de notas de crédito.

* **Mantenimiento**
  * Se actualizó la versión a 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->