### PR TITLE
feat(cfdi): robustez NC descuento en SI Return — inventario, guard y reversión

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,76 +1,77 @@
 # CONTINUITY.md — facturacion_mexico
 
 **Fecha:** 2026-07-30
-**Rama activa:** `feat/nota-credito-descuento-relacion-01`
-**Tarea actual:** Nota de Crédito por descuento/bonificación (CFDI E, TipoRelación 01). Feature completa y validada end-to-end en sandbox; commit hecho, **falta push + PR**.
+**Rama activa:** `feat/nc-descuento-inventario-reversion`
+**Tarea actual:** Robustez de la Nota de Crédito por descuento en la Sales Invoice Return (puntos 1-3). Listo para commit; falta autorización de commit + push + PR.
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-El flujo de Nota de Crédito por **descuento/bonificación** (distinto de devolución física). El operador ejecuta el botón **«Aplicar como Descuento / Bonificación»** en una Sales Invoice Return en borrador → se fija `income_account = cuenta de descuentos configurada por empresa` y `description = "Descuento - <descripción original>"` (conserva Item y ClaveProdServ del origen). Tras el Submit, la FFM detecta el descuento por la cuenta contable y deriva **E / 01 / G02 / PUE / 15 - Condonación**, con UUID relacionado desde `return_against`.
+Endurecimiento del flujo de **Nota de Crédito por descuento/bonificación**, acotado a la **Sales Invoice Return en borrador** (la FFM no participa). Tres cambios: (1) al «Aplicar como Descuento» se fuerza `update_stock = 0` (reversible desde `return_against.update_stock`); (2) guard que bloquea la conversión si `Enable Discount Accounting = ON`, sin apagar el setting global; (3) acción inversa «Revertir a Devolución de mercancía» que restaura `income_account`/`description`/`update_stock` **exactos desde el origen** (vía `sales_invoice_item`), fail-closed si una línea no mapea, y solo en borrador.
 
 Plan que estoy siguiendo:
-Issue #137 (TipoRelación 01) + ADR `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md` (única fuente de la arquitectura y decisiones).
+Puntos 1-3 de la revisión GUI post-#220. ADR `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md`, sección «Robustez operativa descuento ⇄ devolución en SI Return».
 
 Objetivo inmediato:
-`/ship push` → `/ship pr` (base `main`), con autorización explícita en cada paso.
+`/ship commit` → `/ship push` → `/ship pr` (base `main`), con autorización explícita en cada paso.
 
 Criterio de avance:
-Tests verdes (49 en `test_nota_credito_descuento_relacion_01` + regresión CFDI E 6 / complemento 24 / issue162 9) + ruff/prettier/mkdocs limpios. Experimento sandbox en sitio dev confirmó GL y XML correctos con `Enable Discount Accounting = OFF`.
+Tests focalizados verdes (13 nuevos + acción/reversión) + ruff/prettier/mkdocs `--strict` limpios + diff contra `upstream/main` solo con archivos en alcance + bump `1.3.0`.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- Feature implementada (12 archivos) y **commiteada** en esta rama. Bump `1.1.0 → 1.2.0`.
-- Experimento end-to-end en sitio dev (sandbox): 2 ventas (lista / 10% abajo) + 2 NC de descuento, todos timbrados; GL y XML validados con Discount Accounting OFF.
-- ADR 0025 actualizado (arquitectura final + precondición Discount Accounting OFF).
+- Puntos 1-3 implementados (4 archivos: `api/nota_credito.py`, JS del botón, tests, ADR 0025).
+- Bump `__version__` `1.2.0 → 1.3.0` (MINOR: nueva acción de reversión + endpoints).
+- Rama `feat/nc-descuento-inventario-reversion` creada **desde `upstream/main`** (PR #220 ya mergeado; la rama vieja quedó obsoleta).
 
 ### En progreso
-- Ninguna edición de código pendiente.
+- Ninguna edición de código pendiente. Falta autorización de commit.
 
 ### Pendiente inmediato
-1. `/ship push` (con autorización).
-2. `/ship pr` hacia `main` (con autorización).
-3. Tras merge (lo hace el usuario): tag `v1.2.0` + Release.
+1. `/ship commit` (con autorización).
+2. `/ship push` → `/ship pr` hacia `main` (con autorización).
 
 ### No repetir
-- **NO** usar `discount_account` nativo para la NC de descuento: invierte e infla el asiento ("descuento del 90%"). La solución es `Enable Discount Accounting = OFF` por empresa (config, no código).
-- **NO** cambiar `item_code` a un Item "Descuento" (ERPNext `validate_returned_items` lo rechaza en returns con `return_against`).
-- **NO** alinear `price_list_rate = rate` en la acción (se intentó y descartó; el usuario lo revirtió).
+- **NO** reutilizar la rama vieja `feat/nota-credito-descuento-relacion-01` (PR #220 ya mergeado por squash; PR desde ahí saldría sucio).
+- **NO** tocar FFM en este PR: `fm_tipo_nota_credito`, derivación fiscal, visibilidad/textos → PR independiente de puntos 4-5.
+- **NO** usar `discount_account` para la NC de descuento (invierte/infla el asiento).
 - **NO** commitear `one_offs/` ni `working_docs/`.
 
 ---
 
 ## Decisiones vigentes
-- **Precondición por empresa:** `Selling Settings.Enable Discount Accounting = OFF` para operar NC de descuento (documentado en ADR 0025). No es regla universal del app.
-- El descuento queda integrado en el `ValorUnitario` del CFDI (payload usa `net_rate`, `discount=0`); **nunca** se emite nodo `Descuento` en el XML.
-- Cuenta de descuentos: config por empresa en `Facturacion Mexico Company Settings.cuenta_descuentos` (no hardcode; se aplica como `income_account`).
-- Devolución física conserva comportamiento histórico (TipoRelación 03).
+- La reversión descuento ⇄ devolución vive **solo en la SI Return en borrador**; la FFM no participa.
+- El estado de la nota (qué botón mostrar) se decide por el **estado contable real** (`income_account == cuenta_descuentos`), no por la descripción.
+- Reversión **fail-closed**: sin vínculo `sales_invoice_item` exacto → bloquea sin modificar.
+- Precondición `Enable Discount Accounting = OFF` ahora **protegida por guard** en la acción (antes solo documentada).
+- **FormaPago `15 - Condonación` (PUE)** para la NC de descuento está **confirmada por el contador** (ADR 0025). No es un pendiente. Lo que permanece abierto en #136 son otros escenarios tipo E (p. ej. `outstanding=0` que hereda `99`), no el de descuento.
 
 ---
 
 ## Archivos relevantes ahora
 
 ### Leer primero
-- `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md`
+- `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md` (sección «Robustez operativa descuento ⇄ devolución»).
 
 ### Probablemente editar
-- (ninguno; feature cerrada salvo hallazgos en review/CI)
+- (ninguno; puntos 1-3 cerrados salvo hallazgos en review/CI).
 
 ### No tocar
-- `facturacion_fiscal/timbrado_api.py` fórmula del REP (`allocated_amount / si.grand_total`).
+- `facturacion_fiscal/timbrado_api.py`, `factura_fiscal_mexico.py`/`.js` (pertenecen al PR de puntos 4-5).
 
 ---
 
 ## Riesgos / cuidados
-- El sitio dev de prueba tiene el setting `Enable Discount Accounting = OFF` (dejado así como solución). Documentos de prueba conservados para auditoría.
-- Al abrir PR: el gate documental mapea `public/js` → `docs/usuario`; se acordó que ADR 0025 cubre el flujo (no se creó página de usuario).
+- CodeRabbit #4 (ADR vs CONTINUITY sobre FormaPago 15) queda alineado en este archivo.
+- Pendientes CodeRabbit para el PR de puntos 4-5: #2 (forzar TipoRelación 03 en `_set_tipo_from_context`), #5 (JS `fm_tipo_nota_credito` editable en `docstatus==2`), #8 (`-> None` en `_set_tipo_from_context`).
+- Fuera por bajo valor/alcance: #1 (rename RG-001), #3 (test integración del guard), #6 (IDs de mocks in-memory).
 
 ---
 
 ## Información faltante
-- Confirmación del contador/ChatGPT sobre el cierre fiscal del escenario (pendiente formal, no bloquea el commit).
+- Confirmación normativa de otros escenarios FormaPago tipo E del Issue #136 (escenario `outstanding=0 → 99`). No aplica al flujo de descuento (ya confirmado) ni bloquea este PR.

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -28,13 +28,15 @@ Tests focalizados verdes (13 nuevos + acción/reversión) + ruff/prettier/mkdocs
 - Puntos 1-3 implementados (4 archivos: `api/nota_credito.py`, JS del botón, tests, ADR 0025).
 - Bump `__version__` `1.2.0 → 1.3.0` (MINOR: nueva acción de reversión + endpoints).
 - Rama `feat/nc-descuento-inventario-reversion` creada **desde `upstream/main`** (PR #220 ya mergeado; la rama vieja quedó obsoleta).
+- PR #221 abierto (base `main`), CI verde.
+- **CodeRabbit #221 #1/#2/#4 atendidos**: #1 ADR lista el guard Enable Discount Accounting; #2 `check_permission` en endpoints whitelisted (write en aplicar/revertir, read en estado y sobre el origen); #4 JS quita ambos botones antes de agregar el actual. + tests de permisos.
 
 ### En progreso
-- Ninguna edición de código pendiente. Falta autorización de commit.
+- Ninguna edición de código pendiente en este PR.
 
 ### Pendiente inmediato
-1. `/ship commit` (con autorización).
-2. `/ship push` → `/ship pr` hacia `main` (con autorización).
+1. Merge de PR #221 (lo hace el usuario) — tag `v1.3.0` + Release tras merge (con autorización).
+2. PR independiente de puntos 4-5 (FFM).
 
 ### No repetir
 - **NO** reutilizar la rama vieja `feat/nota-credito-descuento-relacion-01` (PR #220 ya mergeado por squash; PR desde ahí saldría sucio).
@@ -67,8 +69,8 @@ Tests focalizados verdes (13 nuevos + acción/reversión) + ruff/prettier/mkdocs
 ---
 
 ## Riesgos / cuidados
-- CodeRabbit #4 (ADR vs CONTINUITY sobre FormaPago 15) queda alineado en este archivo.
-- Pendientes CodeRabbit para el PR de puntos 4-5: #2 (forzar TipoRelación 03 en `_set_tipo_from_context`), #5 (JS `fm_tipo_nota_credito` editable en `docstatus==2`), #8 (`-> None` en `_set_tipo_from_context`).
+- **CodeRabbit #221 pendientes deliberados:** #3 (no mockear `frappe.get_doc` en tests — deuda RG-003; no se cambian firmas de código productivo solo por el mock) y #5 (helper DRY de botones JS — bajo valor).
+- Pendientes para el PR independiente de puntos 4-5 (del review de #220): forzar TipoRelación 03 en `_set_tipo_from_context`, JS `fm_tipo_nota_credito` editable en `docstatus==2`, y `-> None` en `_set_tipo_from_context`.
 - Fuera por bajo valor/alcance: #1 (rename RG-001), #3 (test integración del guard), #6 (IDs de mocks in-memory).
 
 ---

--- a/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
+++ b/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
@@ -258,8 +258,9 @@ importe de la Nota de Crédito **no** se trata como efectivo en el REP. Se desca
 
 ### Enable Discount Accounting — precondición operativa por sitio (no regla universal)
 
-**Precondición operativa para empresas/sitios que usen este flujo de descuento:**
-**`Selling Settings.Enable Discount Accounting = OFF`** en la empresa.
+**Precondición operativa para los sitios que usen este flujo de descuento:**
+**`Selling Settings.Enable Discount Accounting = OFF`** — es un setting **a nivel de sitio**
+(*Selling Settings* es un Single global de ERPNext), **no** una configuración por empresa.
 
 - Con `ON`, ERPNext exige `discount_account` por línea cuando `discount_amount > 0`, y su
   `make_discount_gl_entries` postea `discount_amount × qty` a `discount_account`. En una **nota de
@@ -270,9 +271,10 @@ importe de la Nota de Crédito **no** se trata como efectivo en el REP. Se desca
 - Con `OFF`, la NC contabiliza correctamente: `income_account` (cuenta de descuentos) **debitado** por
   la base real, IVA revertido proporcionalmente, Clientes acreditado por el total. La venta normal no
   se altera y el CFDI/XML tampoco (el payload usa `net_rate`; nunca emite nodo `Descuento`).
-- **No** es una regla universal de `facturacion_mexico`: es una **configuración por empresa** que se
-  adopta si se van a operar notas de crédito por descuento. Empresas que **no** usen descuento de línea
-  (`rate = price_list_rate` siempre) no pierden funcionalidad al apagarlo.
+- **No** es una regla universal de `facturacion_mexico`: es una **configuración a nivel de sitio**
+  (*Selling Settings*, un Single global) que se adopta si en ese sitio se van a operar notas de crédito
+  por descuento. Los sitios donde **no** se usa descuento de línea (`rate = price_list_rate` siempre)
+  no pierden funcionalidad al apagarlo.
 - Evidencia: experimento end-to-end en un sitio de desarrollo (sandbox) con 4 CFDIs — 2 ventas
   (a precio de lista / 10% abajo) y 2 notas de crédito de descuento (TipoRelación 01), GL y XML
   validados con `Enable Discount Accounting = OFF`.

--- a/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
+++ b/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
@@ -4,9 +4,13 @@
 **Estado:** Implementado — #137 implementado (2026-07-29); #136 resuelto para descuento con pago previo
 **Autor:** Luis Montanaro / Claude Sonnet 4.6
 
-> **Actualización 2026-07-29:** Ver sección final *«Descuento / Bonificación (TipoRelación 01)»*.
+> **Actualización 2026-07-29:** Ver sección *«Descuento / Bonificación (TipoRelación 01)»*.
 > Se implementó el flujo de nota de crédito por descuento (Issue #137) y se cerró el criterio de
 > FormaPago del escenario de descuento con pago previo (Issue #136).
+>
+> **Actualización 2026-07-30:** Ver sección *«Robustez operativa descuento ⇄ devolución en SI
+> Return»*: inventario, guard de Discount Accounting y reversión determinista (puntos 1–3). Los
+> puntos 4–5 (FFM: `fm_tipo_nota_credito` derivado, visibilidad/textos) quedan para rama/PR aparte.
 
 ---
 
@@ -279,6 +283,66 @@ importe de la Nota de Crédito **no** se trata como efectivo en el REP. Se desca
 - **Issue #136:** el escenario de descuento con pago previo queda **resuelto** con `FormaPago 15`. Si
   el issue conserva otros escenarios de FormaPago tipo E (p. ej. escenario D: `outstanding=0` que
   hereda `99`), **permanece abierto** para esos; este caso se marca resuelto.
+
+---
+
+## Robustez operativa descuento ⇄ devolución en SI Return (2026-07-30)
+
+Endurecimiento del flujo tras validación GUI en producción. Los cambios se acotan a la **Sales
+Invoice Return en borrador** y a la acción de negocio; **no** se toca la derivación de códigos SAT ni
+el timbrado.
+
+### Implementado (puntos 1–3)
+
+1. **Inventario en descuento.** Al «Aplicar como Descuento / Bonificación», la acción fuerza
+   `update_stock = 0` (un descuento no es devolución física → no mueve inventario). Es **reversible**:
+   el valor correcto de una devolución es `return_against.update_stock`, y la acción inversa lo
+   restaura desde el origen (determinista, 0 o 1). Antes la NC podía heredar `update_stock = 1` del
+   origen y afectar inventario.
+
+2. **Guard de Enable Discount Accounting.** La conversión a descuento **se bloquea antes de modificar
+   la nota** si `Selling Settings.Enable Discount Accounting = ON`, con mensaje claro. **No** se apaga
+   el setting global automáticamente (afectaría otros procesos): la precondición documentada arriba
+   pasa de "manual" a **protegida por guard** en la acción (`preparar_como_descuento`). El mecanismo
+   sigue usando `cuenta_descuentos` como `income_account`; nunca `discount_account`.
+
+3. **Reversión determinista descuento ⇄ devolución (solo SI Return en Draft).**
+   - Botón **«Revertir a Devolución de mercancía»**, simétrico a «Aplicar como Descuento».
+   - Restaura **exacto desde el origen**: por cada línea usa el vínculo nativo `sales_invoice_item`
+     (poblado por `make_return_doc`) para leer su renglón en `return_against` y restaurar
+     `income_account` y `description`; restaura `update_stock` desde `return_against.update_stock`.
+   - **Fail-closed:** si alguna línea no tiene vínculo con su renglón de origen (o no se encuentra),
+     **bloquea sin modificar** la nota y lista las líneas afectadas — no adivina cuentas contables.
+   - **Ninguna acción disponible tras el Submit** (ambas exigen `docstatus = 0`).
+   - La UX elige qué botón mostrar según el **estado contable real** (`income_account ==
+     cuenta_descuentos`), no según la descripción (editable).
+
+**La reversión vive exclusivamente en la SI Return en borrador. La FFM no participa en la reversión.**
+
+### Pendiente — rama/PR independiente (puntos 4–5)
+
+No se implementan en esta rama:
+
+- **`fm_tipo_nota_credito` como dato derivado/no editable en FFM.** Hoy es editable en borrador pero su
+  cambio manual no re-deriva de forma simétrica los códigos SAT (la rama devolución conserva valores
+  del descuento por el `or` y por no resetear `fm_cfdi_use`/`fm_forma_pago_timbrado`) → «parece
+  editable pero no hace nada». Propuesta: derivarlo autoritativamente desde el estado contable y
+  volverlo read-only permanente. **No** hay caso legítimo de cambio manual en FFM (la intención se
+  decide y revierte en la SI Return).
+- **Visibilidad / textos de campos FFM** (`fm_tipo_nota_credito`, `fm_tipo_relacion_sat`,
+  `fm_uuid_relacionado`): sin bug de visibilidad activo (solo aparecen en tipo E); pendiente acortar el
+  `description` largo de `fm_tipo_nota_credito` (UX) y evaluar gating por existencia real de UUID.
+- **UsoCFDI en devolución:** hoy no se fuerza a `G02` (queda al default del cliente); confirmar con el
+  contador si debe ser `G02` como en descuento.
+
+### Propuesta futura — bandera explícita en la SI Return como fuente de verdad
+
+Sustituir la **inferencia por cuenta contable** (`income_account == cuenta_descuentos`) por una
+**bandera explícita en la Sales Invoice Return** (p. ej. un campo booleano/estado «modo descuento»)
+que registre la intención de forma inequívoca. Motivos: (a) evita falsos positivos si una devolución
+legítima usara la misma cuenta; (b) define comportamiento claro si unas líneas están en la cuenta de
+descuentos y otras no; (c) da a la FFM una fuente de verdad estable en lugar de inferir. **No se
+implementa aquí** — queda para la rama/PR de los puntos 4–5.
 
 ---
 

--- a/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
+++ b/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
@@ -209,9 +209,10 @@ El motivo de la nota se **decide antes del Submit** mediante la cuenta contable 
   `return_against`) el operador ejecuta el botón **«Aplicar como Descuento / Bonificación»**
   (`facturacion_mexico.facturacion_fiscal.api.nota_credito.aplicar_como_descuento`). Server-side aplica
   lo anterior y guarda; el documento muestra ya `Descuento - <origen>` antes del Submit. Guards del
-  servidor: es Return, en borrador, `return_against` presente, cuenta de descuentos configurada. El
-  operador **no** selecciona Item, cuenta ni códigos SAT. Si **no** ejecuta la acción, la nota conserva
-  sus cuentas normales → devolución física (relación 03).
+  servidor: es Return, en borrador, `return_against` presente, `Enable Discount Accounting = OFF` en
+  Selling Settings, y cuenta de descuentos configurada. El operador **no** selecciona Item, cuenta ni
+  códigos SAT. Si **no** ejecuta la acción, la nota conserva sus cuentas normales → devolución física
+  (relación 03).
 - **Al crearse la FFM** (mismo `on_submit` de siempre): `_detect_nota_credito_motivo()` detecta si
   **todas** las líneas están contabilizadas contra `cuenta_descuentos` y, de ser así, **preselecciona**
   `fm_tipo_nota_credito = Descuento / Bonificación` (solo si el campo está vacío). La señal es la

--- a/facturacion_mexico/__init__.py
+++ b/facturacion_mexico/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 # Trigger CI rebuild - GitHub Actions refresh

--- a/facturacion_mexico/facturacion_fiscal/api/nota_credito.py
+++ b/facturacion_mexico/facturacion_fiscal/api/nota_credito.py
@@ -82,6 +82,8 @@ def aplicar_como_descuento(sales_invoice: str) -> dict:
 	No devuelve el nombre de la cuenta: el usuario final nunca debe ver la cuenta técnica.
 	"""
 	doc = frappe.get_doc("Sales Invoice", sales_invoice)
+	# Modifica la nota de crédito → exigir permiso de escritura sobre ella antes de operar.
+	doc.check_permission("write")
 	return preparar_como_descuento(doc)
 
 
@@ -105,6 +107,8 @@ def preparar_reversion_a_devolucion(doc) -> dict:
 		frappe.throw(_("Solo se puede revertir mientras la nota de crédito está en borrador."))
 
 	origen = frappe.get_doc("Sales Invoice", doc.get("return_against"))
+	# Se leen datos contables de la factura de origen → exigir permiso de lectura sobre ella.
+	origen.check_permission("read")
 	origen_rows = {r.name: r for r in (origen.get("items") or [])}
 
 	# Validación previa (sin mutación): cada línea debe mapearse EXACTAMENTE a su renglón de origen.
@@ -145,6 +149,8 @@ def preparar_reversion_a_devolucion(doc) -> dict:
 def revertir_a_devolucion(sales_invoice: str) -> dict:
 	"""Punto de entrada desde la UI (botón inverso en Sales Invoice Return en borrador)."""
 	doc = frappe.get_doc("Sales Invoice", sales_invoice)
+	# Modifica la nota de crédito → exigir permiso de escritura sobre ella antes de operar.
+	doc.check_permission("write")
 	return preparar_reversion_a_devolucion(doc)
 
 
@@ -158,6 +164,8 @@ def estado_nota_descuento(sales_invoice: str) -> dict:
 	  - es_descuento: la nota ya está preparada como descuento.
 	"""
 	doc = frappe.get_doc("Sales Invoice", sales_invoice)
+	# Solo lectura de estado → exigir permiso de lectura sobre la nota.
+	doc.check_permission("read")
 	cuenta = get_cuenta_descuentos(doc.get("company"))
 	return {
 		"cuenta_configurada": bool(cuenta),

--- a/facturacion_mexico/facturacion_fiscal/api/nota_credito.py
+++ b/facturacion_mexico/facturacion_fiscal/api/nota_credito.py
@@ -14,8 +14,14 @@ from frappe import _
 
 from facturacion_mexico.facturacion_fiscal.utils import (
 	apply_descuento_to_lines,
+	credit_note_lines_use_discount_account,
 	get_cuenta_descuentos,
 )
+
+
+def _discount_accounting_enabled() -> bool:
+	"""True si ERPNext tiene activa la contabilidad de descuentos (Selling Settings)."""
+	return bool(frappe.db.get_single_value("Selling Settings", "enable_discount_accounting"))
 
 
 def preparar_como_descuento(doc) -> dict:
@@ -24,12 +30,28 @@ def preparar_como_descuento(doc) -> dict:
 	Guards mínimos (servidor):
 	  - Return con factura de origen (return_against);
 	  - en borrador;
+	  - contabilidad de descuentos de ERPNext DESHABILITADA (ver nota abajo);
 	  - cuenta de descuentos configurada para la empresa.
 	"""
 	if not doc.get("is_return") or not doc.get("return_against"):
 		frappe.throw(_("Esta acción solo aplica a notas de crédito con factura de origen (return_against)."))
 	if doc.get("docstatus", 0) != 0:
 		frappe.throw(_("Solo se puede aplicar mientras la nota de crédito está en borrador."))
+
+	# Precondición operativa (ADR 0025): 'Enable Discount Accounting' de ERPNext debe estar OFF.
+	# Con ON y líneas que heredan discount_amount del origen, ERPNext activa su mecanismo nativo
+	# (exige discount_account por línea) e invierte/infla el asiento de la nota. Nuestro mecanismo
+	# usa cuenta_descuentos como income_account, NO discount_account. No se apaga el setting global
+	# automáticamente (afectaría otros procesos): se bloquea antes de tocar la nota.
+	if _discount_accounting_enabled():
+		frappe.throw(
+			_(
+				"La contabilidad de descuentos de ERPNext (Selling Settings → 'Enable Discount "
+				"Accounting') debe estar DESHABILITADA para emitir notas de crédito por descuento de "
+				"Facturación México. Deshabilítela y vuelva a intentar. No se modificó la nota."
+			),
+			title=_("Enable Discount Accounting Activo"),
+		)
 
 	cuenta = get_cuenta_descuentos(doc.get("company"))
 	if not cuenta:
@@ -40,6 +62,13 @@ def preparar_como_descuento(doc) -> dict:
 			).format(doc.get("company")),
 			title=_("Cuenta de Descuentos No Configurada"),
 		)
+
+	# Un descuento/bonificación NO es devolución física → no debe mover inventario.
+	# make_return_doc copió update_stock del origen; aquí se fuerza a 0.
+	# Reversible: el valor correcto de una devolución es return_against.update_stock, así que un
+	# futuro revert a "Devolución de mercancía" lo restaura desde el origen (determinista, 0 o 1).
+	if doc.get("update_stock"):
+		doc.update_stock = 0
 
 	lineas = apply_descuento_to_lines(doc, cuenta)
 	doc.save()
@@ -54,3 +83,83 @@ def aplicar_como_descuento(sales_invoice: str) -> dict:
 	"""
 	doc = frappe.get_doc("Sales Invoice", sales_invoice)
 	return preparar_como_descuento(doc)
+
+
+def preparar_reversion_a_devolucion(doc) -> dict:
+	"""Revertir una nota preparada como descuento de vuelta a "Devolución de mercancía" (motivo 03).
+
+	Restaura EXACTAMENTE desde el origen (sin adivinar cuentas): por cada línea usa su vínculo
+	`sales_invoice_item` (poblado por make_return_doc) para leer el renglón de la factura de origen y
+	restaurar `income_account` y `description`; restaura `update_stock` desde `return_against`.
+
+	Guards mínimos (servidor):
+	  - Return con factura de origen (return_against);
+	  - en borrador (tras Submit no se revierte: aplica cancelación SAT).
+
+	Si CUALQUIER línea no tiene vínculo exacto con su renglón de origen, se BLOQUEA sin modificar la
+	nota y se listan las líneas afectadas (no se inventan cuentas contables).
+	"""
+	if not doc.get("is_return") or not doc.get("return_against"):
+		frappe.throw(_("Esta acción solo aplica a notas de crédito con factura de origen (return_against)."))
+	if doc.get("docstatus", 0) != 0:
+		frappe.throw(_("Solo se puede revertir mientras la nota de crédito está en borrador."))
+
+	origen = frappe.get_doc("Sales Invoice", doc.get("return_against"))
+	origen_rows = {r.name: r for r in (origen.get("items") or [])}
+
+	# Validación previa (sin mutación): cada línea debe mapearse EXACTAMENTE a su renglón de origen.
+	faltantes = [
+		row
+		for row in (doc.get("items") or [])
+		if not row.get("sales_invoice_item") or row.get("sales_invoice_item") not in origen_rows
+	]
+	if faltantes:
+		detalle = ", ".join(
+			_("línea {0} ({1})").format(row.get("idx"), row.get("item_code")) for row in faltantes
+		)
+		frappe.throw(
+			_(
+				"No se puede revertir a devolución: estas líneas no tienen un vínculo exacto con su "
+				"renglón de la factura de origen, así que no es posible restaurar su cuenta contable sin "
+				"adivinar. No se modificó la nota. Líneas: {0}."
+			).format(detalle),
+			title=_("Reversión No Segura"),
+		)
+
+	# Restaurar income_account y description desde el origen (exacto).
+	n = 0
+	for row in doc.get("items") or []:
+		origen_row = origen_rows[row.get("sales_invoice_item")]
+		row.income_account = origen_row.income_account
+		row.description = origen_row.description
+		n += 1
+
+	# Restaurar update_stock desde el origen (cierra la reversibilidad del punto 1).
+	doc.update_stock = origen.update_stock
+
+	doc.save()
+	return {"ok": True, "lineas": n}
+
+
+@frappe.whitelist()
+def revertir_a_devolucion(sales_invoice: str) -> dict:
+	"""Punto de entrada desde la UI (botón inverso en Sales Invoice Return en borrador)."""
+	doc = frappe.get_doc("Sales Invoice", sales_invoice)
+	return preparar_reversion_a_devolucion(doc)
+
+
+@frappe.whitelist()
+def estado_nota_descuento(sales_invoice: str) -> dict:
+	"""Estado de la nota para decidir qué botón mostrar en la UI.
+
+	Se basa en el estado CONTABLE real (income_account de todas las líneas == cuenta de descuentos
+	configurada), no en la descripción (editable). Devuelve:
+	  - cuenta_configurada: hay cuenta de descuentos para la empresa;
+	  - es_descuento: la nota ya está preparada como descuento.
+	"""
+	doc = frappe.get_doc("Sales Invoice", sales_invoice)
+	cuenta = get_cuenta_descuentos(doc.get("company"))
+	return {
+		"cuenta_configurada": bool(cuenta),
+		"es_descuento": credit_note_lines_use_discount_account(doc, cuenta),
+	}

--- a/facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py
@@ -22,7 +22,10 @@ import frappe
 from frappe import _dict
 from frappe.tests.utils import FrappeTestCase
 
-from facturacion_mexico.facturacion_fiscal.api.nota_credito import preparar_como_descuento
+from facturacion_mexico.facturacion_fiscal.api.nota_credito import (
+	preparar_como_descuento,
+	preparar_reversion_a_devolucion,
+)
 from facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico import (
 	FacturaFiscalMexico,
 )
@@ -380,6 +383,50 @@ def _fake_si(**over):
 	return doc
 
 
+def _fake_cn_descuento(**over):
+	"""Nota de crédito YA convertida a descuento, con vínculo `sales_invoice_item` a cada origen."""
+	base = {
+		"is_return": 1,
+		"return_against": "SINV-ORIGEN",
+		"docstatus": 0,
+		"company": "_Test Company",
+		"update_stock": 0,
+		"items": [
+			_fake_line(
+				"LLANTA-A",
+				income_account=CUENTA_DESC,
+				description="Descuento - LLANTA-A mercancía",
+				sales_invoice_item="ORIG-1",
+			),
+			_fake_line(
+				"RIN-B",
+				income_account=CUENTA_DESC,
+				description="Descuento - RIN-B mercancía",
+				sales_invoice_item="ORIG-2",
+			),
+		],
+	}
+	base.update(over)
+	doc = _dict(base)
+	doc.save = lambda: None
+	return doc
+
+
+def _fake_origin(update_stock=1):
+	"""Factura de origen: renglones con nombre estable e income_account/description originales."""
+	return _dict(
+		{
+			"update_stock": update_stock,
+			"items": [
+				_dict(
+					{"name": "ORIG-1", "income_account": "Sales - _TC", "description": "LLANTA-A mercancía"}
+				),
+				_dict({"name": "ORIG-2", "income_account": "Ventas - _TC", "description": "RIN-B mercancía"}),
+			],
+		}
+	)
+
+
 class TestApplyDescuentoToLines(FrappeTestCase):
 	"""Conserva item_code; cambia description a 'Descuento - <origen>' e income_account."""
 
@@ -442,10 +489,16 @@ class TestApplyDescuentoToLines(FrappeTestCase):
 class TestAplicarComoDescuento(FrappeTestCase):
 	"""Acción de negocio: aplica descuento (sin cambiar Item) con guards; no expone cuentas/códigos."""
 
-	def _run(self, doc, cuenta=CUENTA_DESC):
-		with patch(
-			"facturacion_mexico.facturacion_fiscal.api.nota_credito.get_cuenta_descuentos",
-			return_value=cuenta,
+	def _run(self, doc, cuenta=CUENTA_DESC, discount_accounting=False):
+		with (
+			patch(
+				"facturacion_mexico.facturacion_fiscal.api.nota_credito.get_cuenta_descuentos",
+				return_value=cuenta,
+			),
+			patch(
+				"facturacion_mexico.facturacion_fiscal.api.nota_credito._discount_accounting_enabled",
+				return_value=discount_accounting,
+			),
 		):
 			return preparar_como_descuento(doc)
 
@@ -477,6 +530,102 @@ class TestAplicarComoDescuento(FrappeTestCase):
 		doc = _fake_si(docstatus=1)
 		with self.assertRaises(frappe.ValidationError):
 			self._run(doc)
+
+	def test_desmarca_actualizar_inventario(self):
+		"""Un descuento no es devolución física → la acción fuerza update_stock a 0 aunque
+		el origen lo haya heredado en 1 (evita que la NC mueva inventario)."""
+		doc = _fake_si(update_stock=1)
+		self._run(doc)
+		self.assertEqual(doc.update_stock, 0)
+
+	def test_respeta_inventario_ya_desmarcado(self):
+		"""Si el origen ya venía sin actualizar inventario, se conserva en 0 (no rompe nada)."""
+		doc = _fake_si(update_stock=0)
+		self._run(doc)
+		self.assertEqual(doc.update_stock, 0)
+
+	def test_bloquea_si_discount_accounting_activo_sin_modificar(self):
+		"""Precondición: con 'Enable Discount Accounting' = ON la acción bloquea ANTES de tocar la
+		nota (income_account, description y update_stock quedan intactos)."""
+		doc = _fake_si(update_stock=1)
+		income_original = [r.income_account for r in doc["items"]]
+		desc_original = [r.description for r in doc["items"]]
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc, discount_accounting=True)
+		# El documento NO se modificó
+		self.assertEqual([r.income_account for r in doc["items"]], income_original)
+		self.assertEqual([r.description for r in doc["items"]], desc_original)
+		self.assertEqual(doc.update_stock, 1)
+
+	def test_permite_si_discount_accounting_inactivo(self):
+		"""Con 'Enable Discount Accounting' = OFF la conversión procede normalmente."""
+		doc = _fake_si()
+		res = self._run(doc, discount_accounting=False)
+		self.assertTrue(res["ok"])
+		self.assertTrue(all(r.income_account == CUENTA_DESC for r in doc["items"]))
+
+
+class TestRevertirADevolucion(FrappeTestCase):
+	"""Reversión descuento → devolución (motivo 03): restaura EXACTO desde el origen vía
+	`sales_invoice_item`; bloquea sin modificar si alguna línea no mapea; solo en borrador."""
+
+	def _run(self, doc, origen):
+		with patch(
+			"facturacion_mexico.facturacion_fiscal.api.nota_credito.frappe.get_doc",
+			return_value=origen,
+		):
+			return preparar_reversion_a_devolucion(doc)
+
+	def test_restaura_income_y_description_desde_origen(self):
+		doc = _fake_cn_descuento()
+		res = self._run(doc, _fake_origin(update_stock=1))
+		self.assertTrue(res["ok"])
+		self.assertEqual(res["lineas"], 2)
+		self.assertEqual([r.income_account for r in doc["items"]], ["Sales - _TC", "Ventas - _TC"])
+		self.assertEqual([r.description for r in doc["items"]], ["LLANTA-A mercancía", "RIN-B mercancía"])
+
+	def test_restaura_update_stock_desde_origen_uno(self):
+		doc = _fake_cn_descuento(update_stock=0)
+		self._run(doc, _fake_origin(update_stock=1))
+		self.assertEqual(doc.update_stock, 1)
+
+	def test_restaura_update_stock_desde_origen_cero(self):
+		doc = _fake_cn_descuento(update_stock=0)
+		self._run(doc, _fake_origin(update_stock=0))
+		self.assertEqual(doc.update_stock, 0)
+
+	def test_bloquea_sin_vinculo_sin_modificar(self):
+		"""Una línea sin sales_invoice_item → bloquea y NO modifica la nota (no adivina cuentas)."""
+		doc = _fake_cn_descuento()
+		doc["items"][1].sales_invoice_item = None
+		income_original = [r.income_account for r in doc["items"]]
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc, _fake_origin())
+		self.assertEqual([r.income_account for r in doc["items"]], income_original)
+		self.assertEqual(doc.update_stock, 0)
+
+	def test_bloquea_vinculo_inexistente_en_origen(self):
+		"""Vínculo que no existe en el origen → bloquea sin modificar."""
+		doc = _fake_cn_descuento()
+		doc["items"][0].sales_invoice_item = "NO-EXISTE"
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc, _fake_origin())
+		self.assertEqual(doc["items"][0].income_account, CUENTA_DESC)
+
+	def test_bloquea_si_no_es_borrador(self):
+		doc = _fake_cn_descuento(docstatus=1)
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc, _fake_origin())
+
+	def test_bloquea_si_no_es_return(self):
+		doc = _fake_cn_descuento(is_return=0)
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc, _fake_origin())
+
+	def test_bloquea_si_no_hay_return_against(self):
+		doc = _fake_cn_descuento(return_against=None)
+		with self.assertRaises(frappe.ValidationError):
+			self._run(doc, _fake_origin())
 
 
 # ── Concepto del CFDI: usa net_rate y NO emite nodo Descuento ─────────────────

--- a/facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py
@@ -414,7 +414,7 @@ def _fake_cn_descuento(**over):
 
 def _fake_origin(update_stock=1):
 	"""Factura de origen: renglones con nombre estable e income_account/description originales."""
-	return _dict(
+	origen = _dict(
 		{
 			"update_stock": update_stock,
 			"items": [
@@ -425,6 +425,9 @@ def _fake_origin(update_stock=1):
 			],
 		}
 	)
+	# Boundary de permisos: no-op por defecto (los tests de permiso lo sobrescriben para lanzar).
+	origen.check_permission = lambda perm=None: None
+	return origen
 
 
 class TestApplyDescuentoToLines(FrappeTestCase):
@@ -626,6 +629,68 @@ class TestRevertirADevolucion(FrappeTestCase):
 		doc = _fake_cn_descuento(return_against=None)
 		with self.assertRaises(frappe.ValidationError):
 			self._run(doc, _fake_origin())
+
+
+def _perm_denegada(perm_denegado):
+	"""check_permission que lanza PermissionError solo para el permtype indicado."""
+
+	def _check(permtype="read", permlevel=None):
+		if permtype == perm_denegado:
+			raise frappe.PermissionError(f"sin permiso {permtype}")
+
+	return _check
+
+
+class TestPermisosNotaCredito(FrappeTestCase):
+	"""Hardening (CodeRabbit #2): los endpoints whitelisted exigen permiso antes de operar.
+	Un usuario sin permiso no puede ejecutar la acción y el documento no se modifica."""
+
+	def test_aplicar_como_descuento_exige_write(self):
+		from facturacion_mexico.facturacion_fiscal.api import nota_credito
+
+		doc = _fake_si()
+		doc.check_permission = _perm_denegada("write")
+		income_original = [r.income_account for r in doc["items"]]
+		with patch.object(nota_credito.frappe, "get_doc", return_value=doc):
+			with self.assertRaises(frappe.PermissionError):
+				nota_credito.aplicar_como_descuento("SINV-X")
+		# No se modificó la nota
+		self.assertEqual([r.income_account for r in doc["items"]], income_original)
+
+	def test_revertir_a_devolucion_exige_write(self):
+		from facturacion_mexico.facturacion_fiscal.api import nota_credito
+
+		doc = _fake_cn_descuento()
+		doc.check_permission = _perm_denegada("write")
+		income_original = [r.income_account for r in doc["items"]]
+		with patch.object(nota_credito.frappe, "get_doc", return_value=doc):
+			with self.assertRaises(frappe.PermissionError):
+				nota_credito.revertir_a_devolucion("SINV-X")
+		self.assertEqual([r.income_account for r in doc["items"]], income_original)
+
+	def test_estado_nota_descuento_exige_read(self):
+		from facturacion_mexico.facturacion_fiscal.api import nota_credito
+
+		doc = _fake_si()
+		doc.check_permission = _perm_denegada("read")
+		with patch.object(nota_credito.frappe, "get_doc", return_value=doc):
+			with self.assertRaises(frappe.PermissionError):
+				nota_credito.estado_nota_descuento("SINV-X")
+
+	def test_reversion_exige_read_en_origen(self):
+		"""La reversión lee la factura de origen → exige 'read' sobre ella antes de usar sus datos."""
+		doc = _fake_cn_descuento()
+		income_original = [r.income_account for r in doc["items"]]
+		origen = _fake_origin()
+		origen.check_permission = _perm_denegada("read")
+		with patch(
+			"facturacion_mexico.facturacion_fiscal.api.nota_credito.frappe.get_doc",
+			return_value=origen,
+		):
+			with self.assertRaises(frappe.PermissionError):
+				preparar_reversion_a_devolucion(doc)
+		# No se modificó la nota
+		self.assertEqual([r.income_account for r in doc["items"]], income_original)
 
 
 # ── Concepto del CFDI: usa net_rate y NO emite nodo Descuento ─────────────────

--- a/facturacion_mexico/public/js/si_nota_credito_descuento.js
+++ b/facturacion_mexico/public/js/si_nota_credito_descuento.js
@@ -1,33 +1,72 @@
-// Acción de negocio: "Aplicar como Descuento / Bonificación" en una Nota de Crédito (Sales Invoice
-// Return) en borrador. El operador NO selecciona cuentas ni códigos SAT: el sistema asigna
-// automáticamente la cuenta de descuentos configurada por empresa como income_account de las líneas.
+// Acciones de negocio sobre una Nota de Crédito (Sales Invoice Return) en borrador:
+//   - "Aplicar como Descuento / Bonificación": asigna la cuenta de descuentos por empresa como
+//     income_account de las líneas (el operador NO selecciona cuentas ni códigos SAT).
+//   - "Revertir a Devolución de mercancía": restaura income_account/description desde el origen.
+// Qué botón se muestra depende del estado CONTABLE real (income_account == cuenta de descuentos),
+// no de la descripción (editable). Se consulta al servidor en refresh.
 frappe.ui.form.on("Sales Invoice", {
 	refresh(frm) {
 		// Solo en documentos guardados, en borrador, que sean nota de crédito con factura de origen.
 		if (frm.is_new()) return;
 		if (!(frm.doc.is_return && frm.doc.docstatus === 0 && frm.doc.return_against)) return;
 
-		frm.add_custom_button(
-			__("Aplicar como Descuento / Bonificación"),
-			function () {
-				frappe.call({
-					method: "facturacion_mexico.facturacion_fiscal.api.nota_credito.aplicar_como_descuento",
-					args: { sales_invoice: frm.doc.name },
-					freeze: true,
-					freeze_message: __("Preparando nota de crédito como descuento…"),
-					callback: function (r) {
-						if (r.exc) return;
-						frappe.show_alert({
-							message: __(
-								"Nota de crédito preparada como Descuento / Bonificación."
-							),
-							indicator: "green",
-						});
-						frm.reload_doc();
-					},
-				});
+		frappe.call({
+			method: "facturacion_mexico.facturacion_fiscal.api.nota_credito.estado_nota_descuento",
+			args: { sales_invoice: frm.doc.name },
+			callback: function (r) {
+				if (r.exc || !r.message) return;
+				if (r.message.es_descuento) {
+					agregar_boton_revertir(frm);
+				} else {
+					agregar_boton_descuento(frm);
+				}
 			},
-			__("Acciones")
-		);
+		});
 	},
 });
+
+function agregar_boton_descuento(frm) {
+	frm.add_custom_button(
+		__("Aplicar como Descuento / Bonificación"),
+		function () {
+			frappe.call({
+				method: "facturacion_mexico.facturacion_fiscal.api.nota_credito.aplicar_como_descuento",
+				args: { sales_invoice: frm.doc.name },
+				freeze: true,
+				freeze_message: __("Preparando nota de crédito como descuento…"),
+				callback: function (r) {
+					if (r.exc) return;
+					frappe.show_alert({
+						message: __("Nota de crédito preparada como Descuento / Bonificación."),
+						indicator: "green",
+					});
+					frm.reload_doc();
+				},
+			});
+		},
+		__("Acciones")
+	);
+}
+
+function agregar_boton_revertir(frm) {
+	frm.add_custom_button(
+		__("Revertir a Devolución de mercancía"),
+		function () {
+			frappe.call({
+				method: "facturacion_mexico.facturacion_fiscal.api.nota_credito.revertir_a_devolucion",
+				args: { sales_invoice: frm.doc.name },
+				freeze: true,
+				freeze_message: __("Revirtiendo a devolución de mercancía…"),
+				callback: function (r) {
+					if (r.exc) return;
+					frappe.show_alert({
+						message: __("Nota de crédito revertida a Devolución de mercancía."),
+						indicator: "green",
+					});
+					frm.reload_doc();
+				},
+			});
+		},
+		__("Acciones")
+	);
+}

--- a/facturacion_mexico/public/js/si_nota_credito_descuento.js
+++ b/facturacion_mexico/public/js/si_nota_credito_descuento.js
@@ -15,6 +15,12 @@ frappe.ui.form.on("Sales Invoice", {
 			args: { sales_invoice: frm.doc.name },
 			callback: function (r) {
 				if (r.exc || !r.message) return;
+				// Evitar botones duplicados tras reload_doc: quitar ambos antes de agregar el actual.
+				frm.remove_custom_button(
+					__("Aplicar como Descuento / Bonificación"),
+					__("Acciones")
+				);
+				frm.remove_custom_button(__("Revertir a Devolución de mercancía"), __("Acciones"));
 				if (r.message.es_descuento) {
 					agregar_boton_revertir(frm);
 				} else {


### PR DESCRIPTION
## Objetivo

Endurecer el flujo de Nota de Crédito por descuento/bonificación tras validación GUI en
producción, acotado a la **Sales Invoice Return en borrador** (la FFM no participa). Corrige
tres fallos operativos (inventario, dependencia de configuración no protegida, reversión) sin
tocar la derivación de códigos SAT ni el timbrado.

## Versión
Versión objetivo: `v1.3.0`
Release: MINOR
(base upstream/main: `v1.2.0` → MINOR por nueva acción de reversión + endpoints whitelisted)

## Cambios principales

- **P1 — Inventario:** al «Aplicar como Descuento / Bonificación» la acción fuerza
  `update_stock = 0` (un descuento no es devolución física → no mueve inventario). Reversible:
  el valor correcto de una devolución es `return_against.update_stock`.
- **P2 — Guard Enable Discount Accounting:** la conversión se **bloquea antes de modificar la
  nota** si `Selling Settings.Enable Discount Accounting = ON`, con mensaje claro. **No** se
  apaga el setting global automáticamente. El mecanismo sigue usando `cuenta_descuentos` como
  `income_account`; nunca `discount_account`.
- **P3 — Reversión Descuento → Devolución (solo SI Return en Draft):** botón inverso
  «Revertir a Devolución de mercancía». Restaura `income_account`, `description` y `update_stock`
  **exactos desde el origen** (vía el vínculo nativo `sales_invoice_item`). **Fail-closed:** si
  alguna línea no mapea a su renglón de origen, bloquea sin modificar y lista las líneas. Ninguna
  acción disponible tras el Submit. La UX elige el botón por el **estado contable real**
  (`income_account == cuenta_descuentos`), no por la descripción.

## Documentación actualizada

- `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md` — nueva sección «Robustez operativa
  descuento ⇄ devolución en SI Return» (P1-P3), y P4-P5 documentados como pendientes + propuesta
  futura de bandera explícita en SI Return como fuente de verdad.
- `CONTINUITY.md` — regenerado; alineado con ADR 0025 en FormaPago 15 (confirmada, no pendiente).

## Validaciones realizadas

- Tests focalizados del módulo `test_nota_credito_descuento_relacion_01`: **17/17 verdes**
  (`bench --site test-facturacion.localhost run-tests --lightmode`), incluyendo inventario,
  guard de Discount Accounting, reversión, fail-closed y guards.
- `ruff check` + `ruff format`: limpios. `prettier@2.7.1`: OK. `mkdocs build --strict`: OK.

## Fuera de alcance

- **Puntos 4-5 (FFM) — PR independiente:** `fm_tipo_nota_credito` como dato derivado/read-only,
  derivación simétrica en `_set_tipo_from_context` (CodeRabbit #2/#8), visibilidad y textos de
  campos FFM (CodeRabbit #5). Este PR **no** toca `factura_fiscal_mexico.py/.js` ni
  `timbrado_api.py`.

## Riesgos / pendientes

- No requiere `bench migrate` (sin cambios de DocType/schema).
- Precondición operativa vigente: `Enable Discount Accounting = OFF` en Selling Settings (ahora
  protegida por guard). Documentada en ADR 0025.
- Pendiente normativo ajeno a este PR: otros escenarios FormaPago tipo E del Issue #136.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added actions to apply discounts or revert draft credit notes to merchandise returns.
  * Added status checks to identify credit notes configured as discounts.
  * Reversion restores original accounts, descriptions, and inventory settings.

* **Bug Fixes**
  * Prevented stock updates for discount-based credit notes.
  * Blocked discount conversion when discount accounting is enabled.
  * Added validation to prevent unsafe or incomplete reversions.

* **Documentation**
  * Updated guidance for discount flows, reversions, and pending fiscal scenarios.

* **Chores**
  * Updated the package version to 1.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->