### PR TITLE
fix: deriva el tipo de nota de crédito y corrige el botón fiscal

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,20 +2,20 @@
 
 **Fecha:** 2026-08-03
 **Rama activa:** `fix/ffm-tipo-nc-derivado-simetrico`
-**Tarea actual:** Corrección del control de visibilidad del botón "Crear Factura Fiscal" en Sales Invoice (+ aviso RFC).
+**Tarea actual:** Documentación de usuario del flujo de Notas de Crédito (Descuento/Bonificación ↔ Devolución) + botones fiscales.
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Fix de la lógica que decide cuándo mostrar el botón primario "Crear Factura Fiscal" y el aviso de RFC en la Sales Invoice. Se corrigió una regresión donde una FFM ya timbrada volvía a mostrar el botón, y se sumó el bloqueo para FFM en Draft, sin perder el aviso de RFC.
+Documentación de usuario del flujo de Notas de Crédito. El fix del botón fiscal + aviso RFC ya está commiteado (`3e22101`) y pusheado a `upstream`. Esta tarea agrega la página de usuario `docs/usuario/notas-credito.md`.
 
 Plan que estoy siguiendo:
-Instrucciones directas del usuario (sesión de depuración del botón). No hay issue/PR aún.
+Instrucciones directas del usuario. El PR de la rama está preparado pero NO creado aún (pendiente de autorización).
 
 Objetivo inmediato:
-Commit hecho de los 3 archivos + este CONTINUITY.md. Siguiente paso lo decide el usuario (posible push/PR + "escenario B" de limpieza arquitectónica aún NO autorizado).
+Commit documental (`docs/usuario/notas-credito.md` + `mkdocs.yml` + este CONTINUITY.md). Después, el usuario decide crear el PR (`/ship pr` ya validado: base main, versión 1.3.1 PATCH).
 
 Criterio de avance:
 `can_stamp=false` para FFM activa/timbrada Y para FFM Draft; `can_stamp=true` solo sin FFM y con condiciones normales; aviso RFC visible solo cuando `can_stamp=true`.

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,71 +1,77 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-08-01
+**Fecha:** 2026-08-03
 **Rama activa:** `fix/ffm-tipo-nc-derivado-simetrico`
-**Tarea actual:** Puntos 4-5 FFM — `fm_tipo_nota_credito` derivado/read-only + clasificación positiva fail-closed. Listo para commit; falta autorización de push + PR.
+**Tarea actual:** Corrección del control de visibilidad del botón "Crear Factura Fiscal" en Sales Invoice (+ aviso RFC).
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Hacer `fm_tipo_nota_credito` un **dato derivado y read-only** en la FFM: la decisión Descuento vs Devolución se toma en la **Sales Invoice Return**; la FFM la **clasifica desde el estado exacto del origen** (vía `sales_invoice_item`) de forma **positiva y fail-closed**. Devolución exacta → 01... no: **03/G02/FormaPago general**; descuento exacto → **01/G02/15**; estado ambiguo o vínculos faltantes → **bloquea** sin mutación parcial. Protección `docstatus` para no reinterpretar submitted/cancelled.
+Fix de la lógica que decide cuándo mostrar el botón primario "Crear Factura Fiscal" y el aviso de RFC en la Sales Invoice. Se corrigió una regresión donde una FFM ya timbrada volvía a mostrar el botón, y se sumó el bloqueo para FFM en Draft, sin perder el aviso de RFC.
 
 Plan que estoy siguiendo:
-ADR `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md`, sección «Puntos 4–5». Diseño aprobado: Opción A (no bandera en SI). PATCH 1.3.1.
+Instrucciones directas del usuario (sesión de depuración del botón). No hay issue/PR aún.
 
 Objetivo inmediato:
-`/ship push` → `/ship pr` (base `main`), con autorización explícita en cada paso.
+Commit hecho de los 3 archivos + este CONTINUITY.md. Siguiente paso lo decide el usuario (posible push/PR + "escenario B" de limpieza arquitectónica aún NO autorizado).
 
 Criterio de avance:
-Focalizados verdes (clasificación exacta, estados ambiguos, ciclo Draft→Submit, meta) + full suite en baseline (2 failures/11 errors preexistentes) + ruff/prettier/mkdocs limpios.
+`can_stamp=false` para FFM activa/timbrada Y para FFM Draft; `can_stamp=true` solo sin FFM y con condiciones normales; aviso RFC visible solo cuando `can_stamp=true`.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- Controller: `_classify_nota_credito` (positivo, fail-closed, no muta antes de derivar) reemplaza a `_detect_nota_credito_motivo`; derivación simétrica 01/03 con G02 en ambos; guard `docstatus`; `-> None`.
-- DocType JSON: `fm_tipo_nota_credito` `read_only:1` + description corta. JS: campo siempre bloqueado.
-- Tests: clasificación (7 escenarios), derivación, protección submitted/cancelled, ciclo Draft→Submit, meta.
-- Bump `1.3.0 → 1.3.1`. ADR actualizado.
-- `bench migrate` corrido **solo** en `test-facturacion.localhost` (metadata read_only/description).
+- `can_stamp` en `_compute_actions` excluye AMBAS: `has_active_ffm` (restaurada) y `has_draft_ffm` (nueva). Nuevo fact `has_draft_ffm = ffm.docstatus == 0`.
+- `sales_invoice.js`: guard choke-point en `add_timbrar_button` (`frm.__fm_can_stamp`); `_check_rfc_and_show_timbrar` gatea el aviso por `can_stamp` y trata RFC vacío/no-validado con el mismo aviso.
+- Tests aditivos de sesión (no se tocó ninguno previo). Validación GUI de 5 escenarios RFC/FFM + NC descuento OK.
+
+### En progreso
+- (nada abierto tras el commit)
 
 ### Pendiente inmediato
-1. `/ship push` (con autorización).
-2. `/ship pr` hacia `main` (con autorización) → tras merge: tag `v1.3.1` + Release.
+1. Esperar decisión del usuario sobre push/PR.
+2. "Escenario B" (quitar la llamada ungated `_check_rfc_and_show_timbrar` en `sales_invoice_block_cancel.js`) — NO autorizado; no ejecutar sin orden explícita.
+3. Versionado: el bump SemVer se valida al crear el PR (contra `upstream/main`), no en el commit.
 
 ### No repetir
-- **NO** reintroducir default «sin cuenta → devolución»: la clasificación es por **estado exacto**, fail-closed.
-- **NO** clasificar por prefijo de descripción; validar el estado completo (`build_descuento_description`, income_account, update_stock).
-- **NO** mutar campos fiscales antes de lanzar en estado ambiguo.
-- **NO** tocar `depends_on`/visibilidad ni otros pendientes CodeRabbit (#3 test guard, RG-001, IDs mocks, RG-003 get_doc, DRY JS SI).
+- No usar `git restore/reset/revert/checkout` para deshacer trabajo.
+- No reintroducir la regresión: `can_stamp` debe excluir `has_active_ffm` Y `has_draft_ffm` (no sustituir una por otra).
+- No meter conocimiento de FFM dentro de la validación RFC.
+- No tocar `redirect_to_fiscal_document` ni su query.
 
 ---
 
 ## Decisiones vigentes
-- `fm_tipo_nota_credito` es derivado/read-only; fuente de verdad = estado de la SI Return.
-- UsoCFDI **G02** aplica a **ambos** (descuento y devolución).
-- FormaPago de devolución: se limpia residuo de descuento y se delega en `_auto_populate_forma_pago_tipo_e` (política #136 sin cambios).
-- Clasificación fail-closed corre en `validate` de cada FFM Draft de nota de crédito y **puede lanzar** (a validar en GUI del despliegue).
+- Fuente autoritativa de visibilidad del botón = `can_stamp` (servidor). El JS solo dibuja si `can_stamp=true` (guard en `add_timbrar_button`).
+- FFM en ERROR es `docstatus=0` → cuenta como Draft → bloquea "Crear" (se reintenta abriendo la FFM). Confirmado como comportamiento deseado.
+- El snapshot `Sales Invoice.fm_fiscal_status` puede quedar desincronizado; por eso `can_stamp` NO puede depender solo de `fiscal_status`, necesita `has_active_ffm`.
 
 ---
 
 ## Archivos relevantes ahora
 
 ### Leer primero
-- `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md` (sección «Puntos 4–5»).
+- `facturacion_mexico/fiscal_state/sales_invoice_state.py` (`_compute_facts`, `_compute_actions`)
+- `facturacion_mexico/public/js/sales_invoice.js` (`_check_rfc_and_show_timbrar`, `add_timbrar_button`, callback de `get_fiscal_ui_state`)
+
+### Probablemente editar
+- `facturacion_mexico/public/js/sales_invoice_block_cancel.js` (solo si se autoriza el "escenario B")
 
 ### No tocar
-- `timbrado_api.py`, `api/nota_credito.py` (flujo SI-stage, ya en 1.3.0).
+- `redirect_to_fiscal_document` y su query en `sales_invoice.js`
+- tests preexistentes en `tests/test_fiscal_state_sales_invoice.py`
 
 ---
 
 ## Riesgos / cuidados
-- **Cambio de comportamiento:** una SI Return editada manualmente o sin `sales_invoice_item` bloquea la creación/guardado de la FFM (fail-closed). Devoluciones `make_return_doc` y descuentos por la acción pasan sin bloqueo (0 regresiones en full suite).
-- Este PR **requiere `bench migrate`** al instalar (metadata del DocType).
+- `_check_rfc_and_show_timbrar` se llama desde `sales_invoice.js` (gateado por can_stamp) y desde `block_cancel.js` (sin gate) → la coherencia se sostiene con el guard + el gate `frm.__fm_can_stamp` dentro del `.then`.
+- `clear_primary_action()` incondicional en el callback: pendiente evaluar si podría borrar acciones primarias estándar de ERPNext (riesgo señalado, no confirmado).
 
 ---
 
 ## Información faltante
-- Validación GUI del bloque de despliegue de 1.3.1 (estados válidos/ambiguos en el sitio real).
+- Decisión del usuario sobre push/PR y sobre el "escenario B".

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,7 +2,7 @@
 
 **Fecha:** 2026-08-03
 **Rama activa:** `fix/ffm-tipo-nc-derivado-simetrico`
-**Tarea actual:** Atención de la revisión de CodeRabbit del PR #222 (correcciones #2–#5; #1 diferido a issue).
+**Tarea actual:** PR #222 — corrección de permisos de cancelación de Sales Invoice (estado inválido `cancel=1, submit=0`) detectada durante instalación de HRMS.
 
 ---
 
@@ -34,10 +34,14 @@ CodeRabbit sin comentarios accionables pendientes salvo el #1 (que vive en el is
 - Botón fiscal + aviso RFC: `can_stamp` excluye `has_active_ffm` **y** `has_draft_ffm`; guard `frm.__fm_can_stamp` en `add_timbrar_button`; aviso RFC gateado por `can_stamp`.
 - Doc de usuario `docs/usuario/notas-credito.md` (en nav de MkDocs).
 - CodeRabbit revisado (reporte en `frappe-infrastructure/checkpoints/coderabbit-pr222-review.md`).
+- CodeRabbit #2/#3/#4/#5 atendidos y commiteados (`e856671`); #1 diferido al issue #223.
 
 ### En progreso
 
-- Correcciones de revisión CodeRabbit #2 (doc: el Item se conserva), #3/#4 (CONTINUITY/MD022), #5 (`NoReturn`).
+- Permisos Sales Invoice: `Facturacion Mexico Manager` y `System Manager` pasan a `submit=1, cancel=1`
+  (antes `cancel=1, submit=0`, inválido en Frappe). Corregido en `fixtures/docperm.json` y en la
+  segunda fuente `api/fiscal_operations.py::assign_facturacion_permissions()`. Test de fixture
+  agregado (`test_docperm_sales_invoice_permissions.py`). La lógica de cancelación no cambia.
 
 ### Pendiente inmediato
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,79 +1,71 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-07-30
-**Rama activa:** `feat/nc-descuento-inventario-reversion`
-**Tarea actual:** Robustez de la Nota de Crédito por descuento en la Sales Invoice Return (puntos 1-3). Listo para commit; falta autorización de commit + push + PR.
+**Fecha:** 2026-08-01
+**Rama activa:** `fix/ffm-tipo-nc-derivado-simetrico`
+**Tarea actual:** Puntos 4-5 FFM — `fm_tipo_nota_credito` derivado/read-only + clasificación positiva fail-closed. Listo para commit; falta autorización de push + PR.
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Endurecimiento del flujo de **Nota de Crédito por descuento/bonificación**, acotado a la **Sales Invoice Return en borrador** (la FFM no participa). Tres cambios: (1) al «Aplicar como Descuento» se fuerza `update_stock = 0` (reversible desde `return_against.update_stock`); (2) guard que bloquea la conversión si `Enable Discount Accounting = ON`, sin apagar el setting global; (3) acción inversa «Revertir a Devolución de mercancía» que restaura `income_account`/`description`/`update_stock` **exactos desde el origen** (vía `sales_invoice_item`), fail-closed si una línea no mapea, y solo en borrador.
+Hacer `fm_tipo_nota_credito` un **dato derivado y read-only** en la FFM: la decisión Descuento vs Devolución se toma en la **Sales Invoice Return**; la FFM la **clasifica desde el estado exacto del origen** (vía `sales_invoice_item`) de forma **positiva y fail-closed**. Devolución exacta → 01... no: **03/G02/FormaPago general**; descuento exacto → **01/G02/15**; estado ambiguo o vínculos faltantes → **bloquea** sin mutación parcial. Protección `docstatus` para no reinterpretar submitted/cancelled.
 
 Plan que estoy siguiendo:
-Puntos 1-3 de la revisión GUI post-#220. ADR `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md`, sección «Robustez operativa descuento ⇄ devolución en SI Return».
+ADR `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md`, sección «Puntos 4–5». Diseño aprobado: Opción A (no bandera en SI). PATCH 1.3.1.
 
 Objetivo inmediato:
-`/ship commit` → `/ship push` → `/ship pr` (base `main`), con autorización explícita en cada paso.
+`/ship push` → `/ship pr` (base `main`), con autorización explícita en cada paso.
 
 Criterio de avance:
-Tests focalizados verdes (13 nuevos + acción/reversión) + ruff/prettier/mkdocs `--strict` limpios + diff contra `upstream/main` solo con archivos en alcance + bump `1.3.0`.
+Focalizados verdes (clasificación exacta, estados ambiguos, ciclo Draft→Submit, meta) + full suite en baseline (2 failures/11 errors preexistentes) + ruff/prettier/mkdocs limpios.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- Puntos 1-3 implementados (4 archivos: `api/nota_credito.py`, JS del botón, tests, ADR 0025).
-- Bump `__version__` `1.2.0 → 1.3.0` (MINOR: nueva acción de reversión + endpoints).
-- Rama `feat/nc-descuento-inventario-reversion` creada **desde `upstream/main`** (PR #220 ya mergeado; la rama vieja quedó obsoleta).
-- PR #221 abierto (base `main`), CI verde.
-- **CodeRabbit #221 #1/#2/#4 atendidos**: #1 ADR lista el guard Enable Discount Accounting; #2 `check_permission` en endpoints whitelisted (write en aplicar/revertir, read en estado y sobre el origen); #4 JS quita ambos botones antes de agregar el actual. + tests de permisos.
-
-### En progreso
-- Ninguna edición de código pendiente en este PR.
+- Controller: `_classify_nota_credito` (positivo, fail-closed, no muta antes de derivar) reemplaza a `_detect_nota_credito_motivo`; derivación simétrica 01/03 con G02 en ambos; guard `docstatus`; `-> None`.
+- DocType JSON: `fm_tipo_nota_credito` `read_only:1` + description corta. JS: campo siempre bloqueado.
+- Tests: clasificación (7 escenarios), derivación, protección submitted/cancelled, ciclo Draft→Submit, meta.
+- Bump `1.3.0 → 1.3.1`. ADR actualizado.
+- `bench migrate` corrido **solo** en `test-facturacion.localhost` (metadata read_only/description).
 
 ### Pendiente inmediato
-1. Merge de PR #221 (lo hace el usuario) — tag `v1.3.0` + Release tras merge (con autorización).
-2. PR independiente de puntos 4-5 (FFM).
+1. `/ship push` (con autorización).
+2. `/ship pr` hacia `main` (con autorización) → tras merge: tag `v1.3.1` + Release.
 
 ### No repetir
-- **NO** reutilizar la rama vieja `feat/nota-credito-descuento-relacion-01` (PR #220 ya mergeado por squash; PR desde ahí saldría sucio).
-- **NO** tocar FFM en este PR: `fm_tipo_nota_credito`, derivación fiscal, visibilidad/textos → PR independiente de puntos 4-5.
-- **NO** usar `discount_account` para la NC de descuento (invierte/infla el asiento).
-- **NO** commitear `one_offs/` ni `working_docs/`.
+- **NO** reintroducir default «sin cuenta → devolución»: la clasificación es por **estado exacto**, fail-closed.
+- **NO** clasificar por prefijo de descripción; validar el estado completo (`build_descuento_description`, income_account, update_stock).
+- **NO** mutar campos fiscales antes de lanzar en estado ambiguo.
+- **NO** tocar `depends_on`/visibilidad ni otros pendientes CodeRabbit (#3 test guard, RG-001, IDs mocks, RG-003 get_doc, DRY JS SI).
 
 ---
 
 ## Decisiones vigentes
-- La reversión descuento ⇄ devolución vive **solo en la SI Return en borrador**; la FFM no participa.
-- El estado de la nota (qué botón mostrar) se decide por el **estado contable real** (`income_account == cuenta_descuentos`), no por la descripción.
-- Reversión **fail-closed**: sin vínculo `sales_invoice_item` exacto → bloquea sin modificar.
-- Precondición `Enable Discount Accounting = OFF` ahora **protegida por guard** en la acción (antes solo documentada).
-- **FormaPago `15 - Condonación` (PUE)** para la NC de descuento está **confirmada por el contador** (ADR 0025). No es un pendiente. Lo que permanece abierto en #136 son otros escenarios tipo E (p. ej. `outstanding=0` que hereda `99`), no el de descuento.
+- `fm_tipo_nota_credito` es derivado/read-only; fuente de verdad = estado de la SI Return.
+- UsoCFDI **G02** aplica a **ambos** (descuento y devolución).
+- FormaPago de devolución: se limpia residuo de descuento y se delega en `_auto_populate_forma_pago_tipo_e` (política #136 sin cambios).
+- Clasificación fail-closed corre en `validate` de cada FFM Draft de nota de crédito y **puede lanzar** (a validar en GUI del despliegue).
 
 ---
 
 ## Archivos relevantes ahora
 
 ### Leer primero
-- `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md` (sección «Robustez operativa descuento ⇄ devolución»).
-
-### Probablemente editar
-- (ninguno; puntos 1-3 cerrados salvo hallazgos en review/CI).
+- `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md` (sección «Puntos 4–5»).
 
 ### No tocar
-- `facturacion_fiscal/timbrado_api.py`, `factura_fiscal_mexico.py`/`.js` (pertenecen al PR de puntos 4-5).
+- `timbrado_api.py`, `api/nota_credito.py` (flujo SI-stage, ya en 1.3.0).
 
 ---
 
 ## Riesgos / cuidados
-- **CodeRabbit #221 pendientes deliberados:** #3 (no mockear `frappe.get_doc` en tests — deuda RG-003; no se cambian firmas de código productivo solo por el mock) y #5 (helper DRY de botones JS — bajo valor).
-- Pendientes para el PR independiente de puntos 4-5 (del review de #220): forzar TipoRelación 03 en `_set_tipo_from_context`, JS `fm_tipo_nota_credito` editable en `docstatus==2`, y `-> None` en `_set_tipo_from_context`.
-- Fuera por bajo valor/alcance: #1 (rename RG-001), #3 (test integración del guard), #6 (IDs de mocks in-memory).
+- **Cambio de comportamiento:** una SI Return editada manualmente o sin `sales_invoice_item` bloquea la creación/guardado de la FFM (fail-closed). Devoluciones `make_return_doc` y descuentos por la acción pasan sin bloqueo (0 regresiones en full suite).
+- Este PR **requiere `bench migrate`** al instalar (metadata del DocType).
 
 ---
 
 ## Información faltante
-- Confirmación normativa de otros escenarios FormaPago tipo E del Issue #136 (escenario `outstanding=0 → 99`). No aplica al flujo de descuento (ya confirmado) ni bloquea este PR.
+- Validación GUI del bloque de despliegue de 1.3.1 (estados válidos/ambiguos en el sitio real).

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,76 +2,88 @@
 
 **Fecha:** 2026-08-03
 **Rama activa:** `fix/ffm-tipo-nc-derivado-simetrico`
-**Tarea actual:** Documentación de usuario del flujo de Notas de Crédito (Descuento/Bonificación ↔ Devolución) + botones fiscales.
+**Tarea actual:** Atención de la revisión de CodeRabbit del PR #222 (correcciones #2–#5; #1 diferido a issue).
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Documentación de usuario del flujo de Notas de Crédito. El fix del botón fiscal + aviso RFC ya está commiteado (`3e22101`) y pusheado a `upstream`. Esta tarea agrega la página de usuario `docs/usuario/notas-credito.md`.
+
+Cierre de la revisión de CodeRabbit del PR #222. Se corrigen los comentarios #2 (doc), #3/#4 (CONTINUITY/MD022) y #5 (`NoReturn`). El comentario #1 (test que mockea `frappe.get_doc`) se difirió al issue #223.
 
 Plan que estoy siguiendo:
-Instrucciones directas del usuario. El PR de la rama está preparado pero NO creado aún (pendiente de autorización).
+
+Instrucciones directas del usuario para cerrar la revisión. PR #222 abierto; merge lo hace el usuario.
 
 Objetivo inmediato:
-Commit documental (`docs/usuario/notas-credito.md` + `mkdocs.yml` + este CONTINUITY.md). Después, el usuario decide crear el PR (`/ship pr` ya validado: base main, versión 1.3.1 PATCH).
+
+Commit de las correcciones de revisión → push para actualizar el PR #222 → re-ejecutar `/ship coderabbit`.
 
 Criterio de avance:
-`can_stamp=false` para FFM activa/timbrada Y para FFM Draft; `can_stamp=true` solo sin FFM y con condiciones normales; aviso RFC visible solo cuando `can_stamp=true`.
+
+CodeRabbit sin comentarios accionables pendientes salvo el #1 (que vive en el issue #223); suite en verde; docs consistente con el código.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- `can_stamp` en `_compute_actions` excluye AMBAS: `has_active_ffm` (restaurada) y `has_draft_ffm` (nueva). Nuevo fact `has_draft_ffm = ffm.docstatus == 0`.
-- `sales_invoice.js`: guard choke-point en `add_timbrar_button` (`frm.__fm_can_stamp`); `_check_rfc_and_show_timbrar` gatea el aviso por `can_stamp` y trata RFC vacío/no-validado con el mismo aviso.
-- Tests aditivos de sesión (no se tocó ninguno previo). Validación GUI de 5 escenarios RFC/FFM + NC descuento OK.
+
+- PR **#222** abierto (base `main`), rama publicada en `upstream`. Versión objetivo `1.3.1` (PATCH).
+- Botón fiscal + aviso RFC: `can_stamp` excluye `has_active_ffm` **y** `has_draft_ffm`; guard `frm.__fm_can_stamp` en `add_timbrar_button`; aviso RFC gateado por `can_stamp`.
+- Doc de usuario `docs/usuario/notas-credito.md` (en nav de MkDocs).
+- CodeRabbit revisado (reporte en `frappe-infrastructure/checkpoints/coderabbit-pr222-review.md`).
 
 ### En progreso
-- (nada abierto tras el commit)
+
+- Correcciones de revisión CodeRabbit #2 (doc: el Item se conserva), #3/#4 (CONTINUITY/MD022), #5 (`NoReturn`).
 
 ### Pendiente inmediato
-1. Esperar decisión del usuario sobre push/PR.
-2. "Escenario B" (quitar la llamada ungated `_check_rfc_and_show_timbrar` en `sales_invoice_block_cancel.js`) — NO autorizado; no ejecutar sin orden explícita.
-3. Versionado: el bump SemVer se valida al crear el PR (contra `upstream/main`), no en el commit.
+
+1. Commit + push de las correcciones → actualizar PR #222.
+2. Re-ejecutar `/ship coderabbit` para confirmar el estado.
+3. Merge: lo realiza el usuario (Squash & Merge). No lo hace Claude.
 
 ### No repetir
+
 - No usar `git restore/reset/revert/checkout` para deshacer trabajo.
-- No reintroducir la regresión: `can_stamp` debe excluir `has_active_ffm` Y `has_draft_ffm` (no sustituir una por otra).
+- No reintroducir la regresión: `can_stamp` debe excluir `has_active_ffm` Y `has_draft_ffm`.
 - No meter conocimiento de FFM dentro de la validación RFC.
 - No tocar `redirect_to_fiscal_document` ni su query.
+- No atender el comentario #1 dentro del PR #222 (vive en el issue #223): no tocar `_derivar`, sus mocks ni la carga por `frappe.get_doc`, ni añadir costura de pruebas a producción.
 
 ---
 
 ## Decisiones vigentes
-- Fuente autoritativa de visibilidad del botón = `can_stamp` (servidor). El JS solo dibuja si `can_stamp=true` (guard en `add_timbrar_button`).
-- FFM en ERROR es `docstatus=0` → cuenta como Draft → bloquea "Crear" (se reintenta abriendo la FFM). Confirmado como comportamiento deseado.
-- El snapshot `Sales Invoice.fm_fiscal_status` puede quedar desincronizado; por eso `can_stamp` NO puede depender solo de `fiscal_status`, necesita `has_active_ffm`.
+
+- El comentario #1 de CodeRabbit (mock de `frappe.get_doc` en `TestClasificacionNotaCredito`) se difiere al issue **#223**: `_classify_nota_credito` carga la SI/origen con `frappe.get_doc` directo; no se añade costura productiva ni infraestructura pesada dentro de este PR.
+- El flujo de descuento **conserva el `item_code` original** (ERPNext `validate_returned_items` lo exige); solo cambia `description` («Descuento - \<original\>»), `income_account` y `update_stock=0`. La doc se corrigió acorde.
+- Fuente autoritativa de visibilidad del botón = `can_stamp` (servidor).
 
 ---
 
 ## Archivos relevantes ahora
 
 ### Leer primero
-- `facturacion_mexico/fiscal_state/sales_invoice_state.py` (`_compute_facts`, `_compute_actions`)
-- `facturacion_mexico/public/js/sales_invoice.js` (`_check_rfc_and_show_timbrar`, `add_timbrar_button`, callback de `get_fiscal_ui_state`)
 
-### Probablemente editar
-- `facturacion_mexico/public/js/sales_invoice_block_cancel.js` (solo si se autoriza el "escenario B")
+- `docs/usuario/notas-credito.md` (corrección #2)
+- `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py` (`NoReturn`, #5)
 
 ### No tocar
-- `redirect_to_fiscal_document` y su query en `sales_invoice.js`
-- tests preexistentes en `tests/test_fiscal_state_sales_invoice.py`
+
+- `facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py` (`TestClasificacionNotaCredito._derivar`) → reservado al issue #223.
+- `redirect_to_fiscal_document` y su query en `sales_invoice.js`.
 
 ---
 
 ## Riesgos / cuidados
-- `_check_rfc_and_show_timbrar` se llama desde `sales_invoice.js` (gateado por can_stamp) y desde `block_cancel.js` (sin gate) → la coherencia se sostiene con el guard + el gate `frm.__fm_can_stamp` dentro del `.then`.
-- `clear_primary_action()` incondicional en el callback: pendiente evaluar si podría borrar acciones primarias estándar de ERPNext (riesgo señalado, no confirmado).
+
+- `NoReturn` debe ser el único cambio en Python de esta ronda (sin tocar lógica ni mensajes).
+- Mantener `docperm.json` limpio y no incluir untracked de `one_offs/` / `working_docs/`.
 
 ---
 
 ## Información faltante
-- Decisión del usuario sobre push/PR y sobre el "escenario B".
+
+- Ninguna pendiente para esta ronda; tras el push, confirmar la nueva revisión de CodeRabbit.

--- a/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
+++ b/docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md
@@ -322,21 +322,47 @@ el timbrado.
 
 **La reversión vive exclusivamente en la SI Return en borrador. La FFM no participa en la reversión.**
 
-### Pendiente — rama/PR independiente (puntos 4–5)
+### Puntos 4–5 — `fm_tipo_nota_credito` derivado/read-only y UX (implementado 2026-08-01)
 
-No se implementan en esta rama:
+`fm_tipo_nota_credito` es ahora un **dato derivado y read-only** en la FFM: la decisión Descuento vs
+Devolución se toma **exclusivamente en la Sales Invoice Return** (la FFM la refleja, no la redefine).
+La FFM cumple sus dos condiciones primordiales: **ser reflejo de la SI** y **cumplir los requisitos
+del SAT**.
 
-- **`fm_tipo_nota_credito` como dato derivado/no editable en FFM.** Hoy es editable en borrador pero su
-  cambio manual no re-deriva de forma simétrica los códigos SAT (la rama devolución conserva valores
-  del descuento por el `or` y por no resetear `fm_cfdi_use`/`fm_forma_pago_timbrado`) → «parece
-  editable pero no hace nada». Propuesta: derivarlo autoritativamente desde el estado contable y
-  volverlo read-only permanente. **No** hay caso legítimo de cambio manual en FFM (la intención se
-  decide y revierte en la SI Return).
-- **Visibilidad / textos de campos FFM** (`fm_tipo_nota_credito`, `fm_tipo_relacion_sat`,
-  `fm_uuid_relacionado`): sin bug de visibilidad activo (solo aparecen en tipo E); pendiente acortar el
-  `description` largo de `fm_tipo_nota_credito` (UX) y evaluar gating por existencia real de UUID.
-- **UsoCFDI en devolución:** hoy no se fuerza a `G02` (queda al default del cliente); confirmar con el
-  contador si debe ser `G02` como en descuento.
+- **Fuente de verdad y clasificación POSITIVA fail-closed** (`_classify_nota_credito()`): la FFM
+  clasifica el motivo comparando el **estado exacto** de la Sales Invoice Return contra su factura de
+  origen (vía el vínculo nativo `sales_invoice_item`). Solo en **Draft**, tipo **E**, con SI Return
+  válida. La clasificación **no muta ningún campo** y se ejecuta **antes** de derivar (si el estado es
+  ambiguo, bloquea el guardado sin dejar campos fiscales parcialmente escritos).
+  - **Devolución de mercancía:** cada línea conserva el `income_account` y la `description` de su
+    renglón de origen, y `update_stock == return_against.update_stock`. **Funciona aunque la Company no
+    tenga `cuenta_descuentos`.**
+  - **Descuento / Bonificación:** hay `cuenta_descuentos` configurada, **todas** las líneas la usan como
+    `income_account`, cada `description` == la generada por el flujo de descuento para su renglón de
+    origen (`build_descuento_description`, no solo el prefijo), y `update_stock == 0`.
+  - **Estado ambiguo o vínculos `sales_invoice_item` faltantes → se BLOQUEA** el guardado de la FFM
+    Draft con mensaje claro (no se clasifica por default, no se adivina). Así, si la configuración se
+    elimina/cambia o una línea se altera manualmente, la nota **no** se reclasifica silenciosamente como
+    03; exige revisión.
+  - **Protección explícita por `docstatus`**: no reinterpreta ni modifica documentos
+    **Submitted/Cancelled** (no depende de que `validate()` no se invoque).
+- **Derivación fiscal simétrica** (`_set_tipo_from_context`, forzada en ambos sentidos):
+  - Descuento / Bonificación → `fm_tipo_relacion_sat = 01`, `fm_cfdi_use = G02`,
+    `fm_forma_pago_timbrado = 15 Condonación`, MétodoPago PUE.
+  - Devolución de mercancía → `fm_tipo_relacion_sat = 03` (**forzado**, no conserva un `01` residual),
+    `fm_cfdi_use = G02` (**G02 aplica también a devoluciones**, criterio SAT). Para FormaPago se
+    elimina el residuo del modo descuento y se **delega** en `_auto_populate_forma_pago_tipo_e()`
+    (lógica existente por `outstanding`); **no** se cambia la política de FormaPago ni se resuelven los
+    escenarios abiertos de #136.
+- **UX:** `fm_tipo_nota_credito.read_only = 1` en el DocType; `description` corta
+  («Descuento/Bonificación → relación 01. Devolución de mercancía → relación 03.»); el JS deja de
+  re-habilitar el campo según `docstatus`. **No** se cambian `depends_on` ni la visibilidad: los tres
+  campos siguen visibles solo para tipo E; `fm_tipo_relacion_sat`/`fm_uuid_relacionado` siguen
+  read-only (no había bug de visibilidad).
+- **Documentos históricos:** Submitted/Cancelled **no** se reescriben ni se migran (sin patch).
+
+Pendientes CodeRabbit incluidos aquí (por ser P4/P5): forzar `03` en devolución, corregir la
+editabilidad de `fm_tipo_nota_credito`, y anotación `-> None` en `_set_tipo_from_context()`.
 
 ### Propuesta futura — bandera explícita en la SI Return como fuente de verdad
 

--- a/docs/usuario/notas-credito.md
+++ b/docs/usuario/notas-credito.md
@@ -1,0 +1,120 @@
+# Notas de Crédito
+
+Guía para emitir una Nota de Crédito (CFDI tipo **E - Egreso**) a partir de una devolución de venta,
+y para elegir entre **Devolución de mercancía** y **Descuento / Bonificación**.
+
+Una Nota de Crédito nace de un **Sales Invoice Return** (devolución) vinculado a una factura de origen.
+Mientras la devolución esté en **Borrador (Draft)** puedes decidir con qué tratamiento fiscal se
+emitirá; el sistema deriva el resto de los datos fiscales automáticamente.
+
+---
+
+## Punto de partida
+
+1. Crea el **Sales Invoice Return** contra la factura de origen (campo *Return Against*).
+2. **Guárdalo** (queda en Borrador).
+
+En una devolución guardada, en Borrador y con factura de origen, aparece —en el menú **Acciones**—
+**uno** de estos botones, según el estado actual del documento:
+
+- **Aplicar como Descuento / Bonificación** — si la devolución está tratada como devolución de mercancía.
+- **Revertir a Devolución de mercancía** — si la devolución ya está tratada como descuento.
+
+Solo se muestra un botón a la vez: el que te lleva al **otro** tratamiento.
+
+---
+
+## Aplicar como Descuento / Bonificación
+
+En el menú **Acciones**, pulsa **Aplicar como Descuento / Bonificación**.
+
+El sistema:
+
+- Cambia la línea al Item real **Descuento**.
+- Deja de afectar inventario (**update_stock = 0**).
+- Construye la descripción del descuento con referencia a la línea original.
+- Usa la **Cuenta de Descuentos y Bonificaciones** configurada para la empresa.
+- Conserva los vínculos con la factura y la línea original.
+
+Confirma con el mensaje: *"Nota de crédito preparada como Descuento / Bonificación."*
+
+Al **crear la Factura Fiscal** desde esta devolución, el sistema deriva automáticamente:
+
+| Dato fiscal | Valor derivado |
+|---|---|
+| Tipo de Nota de Crédito | **Descuento / Bonificación** |
+| TipoRelación SAT | **01** |
+| Uso CFDI | **G02** |
+| Forma de Pago | **15** |
+
+---
+
+## Revertir a Devolución de mercancía
+
+Mientras la devolución siga en **Borrador**, en el menú **Acciones** pulsa
+**Revertir a Devolución de mercancía**.
+
+El sistema:
+
+- Restaura el Item original.
+- Restaura la descripción original.
+- Restaura la cuenta de ingresos original.
+- Restaura el comportamiento de inventario original.
+- Conserva los vínculos con la factura de origen.
+
+Confirma con el mensaje: *"Nota de crédito revertida a Devolución de mercancía."*
+
+Al **crear la Factura Fiscal**, el sistema deriva:
+
+| Dato fiscal | Valor derivado |
+|---|---|
+| Tipo de Nota de Crédito | **Devolución de mercancía** |
+| TipoRelación SAT | **03** |
+| Uso CFDI | **G02** |
+| Forma de Pago | Conforme a la lógica normal aplicable |
+
+---
+
+## Alternar antes de guardar / enviar
+
+Mientras el documento permanezca en **Borrador**, puedes alternar entre ambas opciones tantas veces
+como necesites antes de guardar o enviar.
+
+El tipo fiscal que finalmente usa la Factura Fiscal **depende del estado real** en que quede la
+devolución: si la dejas como descuento, se emite como Descuento / Bonificación; si la dejas como
+devolución de mercancía, se emite como Devolución.
+
+---
+
+## Configuración requerida
+
+Cada empresa debe tener configurada la **Cuenta de Descuentos y Bonificaciones** en
+**Facturacion Mexico Company Settings**.
+
+Si falta esa cuenta, el sistema **bloquea la conversión a descuento** y muestra el mensaje
+correspondiente. Configúrala antes de usar *Aplicar como Descuento / Bonificación*.
+
+---
+
+## UUID relacionado
+
+Una Nota de Crédito requiere el **UUID fiscal real** del CFDI de la factura de origen. Al crear la
+Factura Fiscal se solicita cuando no puede obtenerse automáticamente.
+
+Usa siempre el UUID verdadero del comprobante origen. No uses UUID arbitrarios fuera de ambientes de
+prueba.
+
+---
+
+## Botones fiscales en la devolución
+
+El botón fiscal que ves en la devolución depende de su estado:
+
+- **Sin Factura Fiscal**, con condiciones fiscales y RFC válidos → **Crear Factura Fiscal**.
+- **Con Factura Fiscal ya creada** (en Borrador o Timbrada) → **Abrir Factura Fiscal**.
+
+No se crea una segunda Factura Fiscal desde la misma devolución: si ya existe una, se abre la
+existente.
+
+> Si el RFC del cliente está vacío o no validado, el botón **Crear Factura Fiscal** no aparece y se
+> muestra un aviso indicando que debe validarse el RFC antes de crear la Factura Fiscal.

--- a/docs/usuario/notas-credito.md
+++ b/docs/usuario/notas-credito.md
@@ -30,10 +30,10 @@ En el menú **Acciones**, pulsa **Aplicar como Descuento / Bonificación**.
 
 El sistema:
 
-- Cambia la línea al Item real **Descuento**.
-- Deja de afectar inventario (**update_stock = 0**).
-- Construye la descripción del descuento con referencia a la línea original.
-- Usa la **Cuenta de Descuentos y Bonificaciones** configurada para la empresa.
+- **Conserva el Item original** de la línea: el `item_code` (y su ClaveProdServ SAT) **no** cambia; no se sustituye por un Item «Descuento».
+- Cambia la **descripción** de la línea a **«Descuento - \<descripción original\>»**.
+- Cambia la **cuenta de ingresos** (`income_account`) a la **Cuenta de Descuentos y Bonificaciones** configurada para la empresa.
+- Deja de afectar inventario (**`update_stock = 0`**).
 - Conserva los vínculos con la factura y la línea original.
 
 Confirma con el mensaje: *"Nota de crédito preparada como Descuento / Bonificación."*
@@ -56,10 +56,10 @@ Mientras la devolución siga en **Borrador**, en el menú **Acciones** pulsa
 
 El sistema:
 
-- Restaura el Item original.
-- Restaura la descripción original.
-- Restaura la cuenta de ingresos original.
-- Restaura el comportamiento de inventario original.
+- El **Item nunca cambió**: sigue siendo el original (`item_code` intacto).
+- Restaura la **descripción** original.
+- Restaura la **cuenta de ingresos** (`income_account`) original.
+- Restaura el **comportamiento de inventario** original (`update_stock` desde la factura de origen).
 - Conserva los vínculos con la factura de origen.
 
 Confirma con el mensaje: *"Nota de crédito revertida a Devolución de mercancía."*

--- a/facturacion_mexico/__init__.py
+++ b/facturacion_mexico/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 # Trigger CI rebuild - GitHub Actions refresh

--- a/facturacion_mexico/api/fiscal_operations.py
+++ b/facturacion_mexico/api/fiscal_operations.py
@@ -341,11 +341,15 @@ def assign_facturacion_permissions():
 		},
 		# DocType: Sales Invoice
 		{"doctype": "Sales Invoice", "role": "Facturacion Mexico User", "perms": {"read": 1}},
-		{"doctype": "Sales Invoice", "role": "Facturacion Mexico Manager", "perms": {"read": 1, "cancel": 1}},
+		{
+			"doctype": "Sales Invoice",
+			"role": "Facturacion Mexico Manager",
+			"perms": {"read": 1, "submit": 1, "cancel": 1},
+		},
 		{
 			"doctype": "Sales Invoice",
 			"role": "Facturacion Mexico System Manager",
-			"perms": {"read": 1, "cancel": 1},
+			"perms": {"read": 1, "submit": 1, "cancel": 1},
 		},
 	]
 

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.js
@@ -1270,15 +1270,10 @@
 		lock("fm_facturar_venta_mostrador");
 		lock("fm_tipo_relacion_sat");
 		lock("fm_uuid_relacionado");
-		// Tipo de Nota de Crédito: es la ÚNICA entrada del usuario (intención de negocio).
-		// Editable mientras es borrador; se bloquea una vez enviado/timbrado.
-		if (frm.get_field("fm_tipo_nota_credito")) {
-			frm.set_df_property(
-				"fm_tipo_nota_credito",
-				"read_only",
-				frm.doc.docstatus === 1 ? 1 : 0
-			);
-		}
+		// Tipo de Nota de Crédito: dato DERIVADO (read-only por DocType). La decisión Descuento vs
+		// Devolución se toma en la Sales Invoice Return; la FFM solo la refleja. Se bloquea también
+		// aquí por consistencia (no se re-habilita según docstatus).
+		lock("fm_tipo_nota_credito");
 	}
 
 	function setup_payment_method_radio_buttons(frm) {

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.json
@@ -163,7 +163,8 @@
    "fieldtype": "Select",
    "options": "\nDevolución de mercancía\nDescuento / Bonificación",
    "depends_on": "eval:doc.fm_tipo_comprobante && doc.fm_tipo_comprobante.startsWith('E')",
-   "description": "Intención de negocio de la nota de crédito. 'Descuento / Bonificación' deriva automáticamente TipoRelación 01, UsoCFDI G02 y FormaPago 15 - Condonación. Vacío o 'Devolución de mercancía' mantiene TipoRelación 03 (devolución física)."
+   "read_only": 1,
+   "description": "Descuento/Bonificación → relación 01. Devolución de mercancía → relación 03."
   },
   {
    "fieldname": "fm_tipo_relacion_sat",

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -1,3 +1,5 @@
+from typing import NoReturn
+
 import frappe
 from frappe import _
 from frappe.contacts.doctype.address.address import get_address_display
@@ -322,7 +324,7 @@ class FacturaFiscalMexico(Document):
 		"""
 		return (self.get("fm_tipo_nota_credito") or "").strip() == NOTA_CREDITO_DESCUENTO
 
-	def _throw_estado_nc_invalido(self, msg: str) -> None:
+	def _throw_estado_nc_invalido(self, msg: str) -> NoReturn:
 		"""Bloquear el guardado de la FFM Draft por estado de nota de crédito no clasificable."""
 		frappe.throw(msg, title=_("Estado de Nota de Crédito No Válido"))
 

--- a/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
+++ b/facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py
@@ -322,58 +322,133 @@ class FacturaFiscalMexico(Document):
 		"""
 		return (self.get("fm_tipo_nota_credito") or "").strip() == NOTA_CREDITO_DESCUENTO
 
-	def _detect_nota_credito_motivo(self):
-		"""Opción X: preseleccionar el motivo a partir de la cuenta contable de la Credit Note.
+	def _throw_estado_nc_invalido(self, msg: str) -> None:
+		"""Bloquear el guardado de la FFM Draft por estado de nota de crédito no clasificable."""
+		frappe.throw(msg, title=_("Estado de Nota de Crédito No Válido"))
 
-		Si la nota de crédito ya se contabilizó (income_account de sus líneas) contra la cuenta
-		de descuentos configurada para la empresa, preseleccionar 'Descuento / Bonificación'.
+	def _classify_nota_credito(self) -> str:
+		"""Clasificación POSITIVA y fail-closed del motivo desde el estado EXACTO de la SI Return.
 
-		Solo actúa cuando el campo está VACÍO (preselección, no override de una elección explícita
-		del usuario). Si las cuentas no coinciden, NO infiere descuento y se conserva el
-		comportamiento histórico de devolución (relación 03) — punto 8 de la decisión.
+		Devuelve NOTA_CREDITO_DEVOLUCION o NOTA_CREDITO_DESCUENTO; NO muta ningún campo. Lanza si el
+		estado no coincide exactamente con ninguno, o si faltan los vínculos `sales_invoice_item`
+		necesarios para comprobarlo (no adivina, no clasifica por default).
+
+		- Devolución de mercancía: cada línea conserva el `income_account` y la `description` de su
+		  renglón de origen (vía `sales_invoice_item`), y `update_stock == return_against.update_stock`.
+		  Funciona aunque la Company no tenga `cuenta_descuentos`.
+		- Descuento / Bonificación: hay `cuenta_descuentos` configurada, TODAS las líneas la usan como
+		  `income_account`, cada `description` == la generada por el flujo de descuento para su renglón
+		  de origen, y `update_stock == 0`.
 		"""
-		if (self.get("fm_tipo_nota_credito") or "").strip():
-			return  # ya decidido (usuario o preselección previa) — no sobrescribir
-
 		from facturacion_mexico.facturacion_fiscal.utils import (
-			credit_note_lines_use_discount_account,
+			build_descuento_description,
 			get_cuenta_descuentos,
 		)
 
-		company = self.get("company") or frappe.db.get_value("Sales Invoice", self.sales_invoice, "company")
-		cuenta = get_cuenta_descuentos(company)
-		if cuenta and credit_note_lines_use_discount_account(self.sales_invoice, cuenta):
-			self.fm_tipo_nota_credito = NOTA_CREDITO_DESCUENTO
+		si = frappe.get_doc("Sales Invoice", self.sales_invoice)
+		return_against = si.get("return_against")
+		if not return_against:
+			self._throw_estado_nc_invalido(
+				_("La nota de crédito no tiene factura de origen (return_against).")
+			)
+		origen = frappe.get_doc("Sales Invoice", return_against)
+		origen_rows = {r.name: r for r in (origen.get("items") or [])}
+		lineas = si.get("items") or []
+		if not lineas:
+			self._throw_estado_nc_invalido(_("La nota de crédito no tiene líneas."))
 
-	def _set_tipo_from_context(self):
-		"""Establecer tipo automáticamente según contexto."""
+		# Vínculos con el origen obligatorios: sin ellos no se puede comprobar el estado (no adivinar).
+		faltantes = [
+			row
+			for row in lineas
+			if not row.get("sales_invoice_item") or row.get("sales_invoice_item") not in origen_rows
+		]
+		if faltantes:
+			detalle = ", ".join(
+				_("línea {0} ({1})").format(row.get("idx"), row.get("item_code")) for row in faltantes
+			)
+			self._throw_estado_nc_invalido(
+				_("Faltan vínculos con la factura de origen (sales_invoice_item): {0}.").format(detalle)
+			)
+
+		# Devolución de mercancía: estado idéntico al origen (income_account, description, update_stock).
+		mismo_update_stock = cint(si.get("update_stock")) == cint(origen.get("update_stock"))
+		es_devolucion = mismo_update_stock and all(
+			row.get("income_account") == origen_rows[row.get("sales_invoice_item")].get("income_account")
+			and (row.get("description") or "")
+			== (origen_rows[row.get("sales_invoice_item")].get("description") or "")
+			for row in lineas
+		)
+		if es_devolucion:
+			return NOTA_CREDITO_DEVOLUCION
+
+		# Descuento / Bonificación: estado completo generado por la acción (cuenta + descripción + stock).
+		company = self.get("company") or si.get("company")
+		cuenta = get_cuenta_descuentos(company)
+		es_descuento = (
+			bool(cuenta)
+			and cint(si.get("update_stock")) == 0
+			and all(
+				row.get("income_account") == cuenta
+				and (row.get("description") or "")
+				== build_descuento_description(
+					origen_rows[row.get("sales_invoice_item")].get("description")
+					or origen_rows[row.get("sales_invoice_item")].get("item_name")
+				)
+				for row in lineas
+			)
+		)
+		if es_descuento:
+			return NOTA_CREDITO_DESCUENTO
+
+		# Ni devolución ni descuento exactos → NO clasificar por default; bloquear.
+		self._throw_estado_nc_invalido(
+			_(
+				"La Sales Invoice Return no coincide exactamente con un estado válido de devolución de "
+				"mercancía ni de descuento/bonificación; revísela antes de timbrar."
+			)
+		)
+
+	def _set_tipo_from_context(self) -> None:
+		"""Establecer tipo y códigos SAT según contexto (derivación autoritativa, solo en Draft).
+
+		`fm_tipo_nota_credito` es derivado/read-only: refleja el estado exacto de la SI Return y de él
+		se derivan simétricamente los códigos SAT. La clasificación es fail-closed (bloquea estados
+		ambiguos) y no reinterpreta ni modifica documentos Submitted/Cancelled (guard de docstatus).
+		"""
+		# Protección explícita: no reinterpretar ni modificar documentos ya emitidos,
+		# independientemente de si validate() se invoca.
+		if cint(self.get("docstatus")) != 0:
+			return
+
 		if self._is_sales_invoice_return():
+			# Clasificación POSITIVA y fail-closed PRIMERO: si el estado es ambiguo lanza aquí, ANTES
+			# de mutar cualquier campo fiscal (no deja la FFM parcialmente derivada).
+			motivo = self._classify_nota_credito()
+
+			self.fm_tipo_nota_credito = motivo
 			self.fm_tipo_comprobante = "E - Egreso"
 			self.fm_payment_method_sat = "PUE"  # SAT: PPD not allowed on credit notes
 			self.fm_uuid_relacionado = self.fm_uuid_relacionado or self._find_uuid_cfdi_origen()
 
-			# Opción X: preseleccionar el motivo desde la cuenta contable si el operador ya
-			# asignó la cuenta de descuentos configurada en las líneas antes del Submit.
-			self._detect_nota_credito_motivo()
-
-			if self._is_nota_descuento():
-				# Descuento / bonificación (Issue #137): el usuario selecciona la intención de
-				# negocio en fm_tipo_nota_credito y aquí se derivan los códigos SAT.
+			if motivo == NOTA_CREDITO_DESCUENTO:
+				# Descuento / bonificación (Issue #137):
 				#   TipoRelación 01 · UsoCFDI G02 · FormaPago 15 (Condonación) · MetodoPago PUE.
-				# El concepto fiscal se describe como 'Descuento' en el payload (timbrado_api),
-				# conservando Item/ClaveProdServ e impuestos proporcionales.
 				self.fm_tipo_relacion_sat = "01 - " + TIPO_RELACION["01"]
 				self.fm_cfdi_use = CFDI_USE_DESCUENTO
 				self.fm_forma_pago_timbrado = FORMA_PAGO_DESCUENTO
 			else:
-				# Devolución física de mercancía → TipoRelación 03 (normativo, Issue #116).
-				# Sin regresión: comportamiento histórico intacto.
-				self.fm_tipo_relacion_sat = self.fm_tipo_relacion_sat or "03 - " + TIPO_RELACION["03"]
+				# Devolución física de mercancía → TipoRelación 03 (normativo, Issue #116), FORZADO.
+				# UsoCFDI G02 aplica también a devoluciones (criterio SAT).
+				self.fm_tipo_relacion_sat = "03 - " + TIPO_RELACION["03"]
+				self.fm_cfdi_use = CFDI_USE_DESCUENTO
+				# FormaPago: eliminar residuo del modo descuento y delegar en la lógica existente
+				# (basada en outstanding de la SI origen). No se cambia la política de FormaPago (#136).
+				if self.fm_forma_pago_timbrado == FORMA_PAGO_DESCUENTO:
+					self.fm_forma_pago_timbrado = None
+				self._auto_populate_forma_pago_tipo_e()
 
 			# Inherit venta-mostrador flag from origin — no customization allowed.
-			# FormaPago for tipo E (devolución física) is determined in
-			# auto_load_payment_method_from_sales_invoice() based on outstanding_amount of
-			# origin SI. Para descuento la FormaPago ya quedó fijada arriba (15 - Condonación).
 			origin_ffm = self._get_origin_ffm()
 			if origin_ffm:
 				self.fm_facturar_venta_mostrador = cint(origin_ffm.get("fm_facturar_venta_mostrador", 0))

--- a/facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py
@@ -45,9 +45,15 @@ CUENTA_DESC = "501-005 - Descuentos y bonificaciones - TC"
 UUID_ORIGEN_C = "550E8400-E29B-41D4-A716-446655440000"
 
 
-def _make_ffm(motivo, uuid=UUID_ORIGEN_C):
-	"""FFM de una nota de crédito (SI return) con la intención de negocio indicada."""
+def _make_ffm(motivo, uuid=UUID_ORIGEN_C, docstatus=0):
+	"""FFM de una nota de crédito (SI return) con la intención de negocio indicada.
+
+	Aísla la DERIVACIÓN de códigos SAT «dado un motivo»: se stubbea `_classify_nota_credito` para que
+	devuelva el `motivo` pasado (la clasificación desde el estado exacto de la SI Return se prueba en
+	`TestClasificacionNotaCredito`).
+	"""
 	inst = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+	inst.docstatus = docstatus
 	inst.sales_invoice = "SINV-C-RETORNO"
 	inst.fm_tipo_nota_credito = motivo
 	inst.fm_tipo_comprobante = None
@@ -59,8 +65,12 @@ def _make_ffm(motivo, uuid=UUID_ORIGEN_C):
 	inst.fm_facturar_venta_mostrador = 0
 	# Aislar dependencias de BD/SI origen (boundary)
 	inst._is_sales_invoice_return = lambda: True
+	inst._classify_nota_credito = lambda: motivo  # honrar el motivo pasado (no clasificar aquí)
 	inst._find_uuid_cfdi_origen = lambda: uuid
 	inst._get_origin_ffm = lambda: None
+	# FormaPago de devolución la resuelve _auto_populate_forma_pago_tipo_e (basada en outstanding):
+	# no-op por defecto en tests (los tests de orden la sobrescriben con un sentinel).
+	inst._auto_populate_forma_pago_tipo_e = lambda: None
 	return inst
 
 
@@ -100,18 +110,146 @@ class TestDerivacionFiscalNotaCredito(FrappeTestCase):
 		self.assertEqual(ffm.fm_uuid_relacionado, UUID_ORIGEN_C)
 
 	def test_devolucion_mercancia_relacion_03(self):
-		"""Devolución física → relación 03 (comportamiento histórico, sin regresión)."""
+		"""Devolución física → relación 03. UsoCFDI G02 aplica también a devoluciones (criterio SAT)."""
 		ffm = _make_ffm("Devolución de mercancía")
 		ffm._set_tipo_from_context()
 		self.assertTrue(ffm.fm_tipo_relacion_sat.startswith("03 - "))
-		# No debe forzar G02 ni FormaPago 15 en devolución física
-		self.assertIsNone(ffm.fm_cfdi_use)
+		self.assertEqual(ffm.fm_cfdi_use, "G02")
 
 	def test_vacio_es_devolucion_sin_regresion(self):
 		"""Vacío se comporta como devolución física (relación 03)."""
 		ffm = _make_ffm("")
 		ffm._set_tipo_from_context()
 		self.assertTrue(ffm.fm_tipo_relacion_sat.startswith("03 - "))
+
+
+# ── P4: derivación simétrica, autoritativa, read-only y protección de emitidos ─
+
+
+class TestDerivacionSimetricaYProteccion(FrappeTestCase):
+	"""Derivación simétrica descuento⇄devolución, auto-sanado desde SI Return, no-adivinar y
+	protección de documentos Submitted/Cancelled."""
+
+	def test_switch_descuento_a_devolucion_no_conserva_residuo(self):
+		"""Estado residual de descuento (01/G02/15) → al ser devolución fuerza 03 y limpia FormaPago."""
+		ffm = _make_ffm("Devolución de mercancía")
+		# Simula residuo de un estado previo de descuento
+		ffm.fm_tipo_relacion_sat = "01 - residuo de descuento"
+		ffm.fm_forma_pago_timbrado = "15 Condonación"
+		ffm._auto_populate_forma_pago_tipo_e = lambda: setattr(ffm, "fm_forma_pago_timbrado", "AUTO-POP")
+		ffm._set_tipo_from_context()
+		self.assertTrue(ffm.fm_tipo_relacion_sat.startswith("03 - "))  # forzado, no queda 01
+		self.assertEqual(ffm.fm_cfdi_use, "G02")
+		self.assertEqual(ffm.fm_forma_pago_timbrado, "AUTO-POP")  # residuo 15 eliminado + delegación
+
+	def test_switch_devolucion_a_descuento_no_conserva_residuo(self):
+		"""Estado residual de devolución (03) → al ser descuento fuerza 01/G02/15."""
+		ffm = _make_ffm("Descuento / Bonificación")
+		ffm.fm_tipo_relacion_sat = "03 - residuo de devolución"
+		ffm._set_tipo_from_context()
+		self.assertTrue(ffm.fm_tipo_relacion_sat.startswith("01 - "))
+		self.assertEqual(ffm.fm_cfdi_use, "G02")
+		self.assertEqual(ffm.fm_forma_pago_timbrado, "15 Condonación")
+
+	def test_devolucion_formapago_orden_delegacion(self):
+		"""El residuo 15 se limpia y luego _auto_populate_forma_pago_tipo_e aplica la lógica existente."""
+		ffm = _make_ffm("Devolución de mercancía")
+		ffm.fm_forma_pago_timbrado = "15 Condonación"
+		llamado = {"n": 0}
+
+		def _auto():
+			# Al ejecutarse, el residuo ya fue limpiado (None)
+			llamado["n"] += 1
+			llamado["forma_al_entrar"] = ffm.fm_forma_pago_timbrado
+			ffm.fm_forma_pago_timbrado = "99 Por definir"
+
+		ffm._auto_populate_forma_pago_tipo_e = _auto
+		ffm._set_tipo_from_context()
+		self.assertEqual(llamado["n"], 1)
+		self.assertIsNone(llamado["forma_al_entrar"])  # residuo limpiado antes de delegar
+		self.assertEqual(ffm.fm_forma_pago_timbrado, "99 Por definir")
+
+	def test_submitted_no_se_reinterpreta(self):
+		"""docstatus=1: la derivación no corre (protección explícita), no modifica el documento."""
+		ffm = _make_ffm("Descuento / Bonificación", docstatus=1)
+		ffm.fm_tipo_relacion_sat = "VALOR-PREVIO"
+		ffm.fm_cfdi_use = "USO-PREVIO"
+		ffm._set_tipo_from_context()
+		self.assertEqual(ffm.fm_tipo_relacion_sat, "VALOR-PREVIO")
+		self.assertEqual(ffm.fm_cfdi_use, "USO-PREVIO")
+
+	def test_cancelled_no_se_reinterpreta(self):
+		"""docstatus=2: idéntica protección — no se reinterpreta ni modifica."""
+		ffm = _make_ffm("Descuento / Bonificación", docstatus=2)
+		ffm.fm_tipo_relacion_sat = "VALOR-PREVIO"
+		ffm._set_tipo_from_context()
+		self.assertEqual(ffm.fm_tipo_relacion_sat, "VALOR-PREVIO")
+
+
+# ── P4 · Gate 2: ciclo Draft → Submit (documento real, sin PAC) ───────────────
+
+
+class TestCicloDraftSubmit(FrappeTestCase):
+	"""Confirma que la derivación ocurre en el guardado en Draft (docstatus=0) y que, al pasar a
+	docstatus=1 (Submit), el guard NO deja la FFM con valores vacíos ni residuales.
+
+	Flujo real: get_or_create_active_ffm inserta la FFM en Draft (validate deriva); el timbrado exige
+	FFM submitted (timbrado_api: 'debe estar submitted... Submit primero'). FFM no tiene on_submit →
+	el Submit solo cambia docstatus, sin contactar el PAC. Aquí se usa un Document real y se aíslan las
+	dependencias de SI origen (boundary); no se timbra."""
+
+	def _ffm_real(self, motivo):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Factura Fiscal Mexico",
+				"sales_invoice": "SINV-C-RETORNO",
+				"company": "_Test Company",
+			}
+		)
+		doc._is_sales_invoice_return = lambda: True
+		doc._classify_nota_credito = lambda: motivo  # clasificación aislada (se prueba aparte)
+		doc._find_uuid_cfdi_origen = lambda: UUID_ORIGEN_C
+		doc._get_origin_ffm = lambda: None
+		# FormaPago de devolución la resuelve la lógica existente (sentinel en test).
+		doc._auto_populate_forma_pago_tipo_e = lambda: setattr(
+			doc, "fm_forma_pago_timbrado", "15 Condonación"
+		)
+		return doc
+
+	def _draft_deriva_y_submit_preserva(self, motivo):
+		doc = self._ffm_real(motivo)
+		# FASE DRAFT (docstatus=0): el guardado deriva todo
+		doc.docstatus = 0
+		doc._set_tipo_from_context()
+		derivados = {
+			"fm_tipo_nota_credito": doc.fm_tipo_nota_credito,
+			"fm_tipo_relacion_sat": doc.fm_tipo_relacion_sat,
+			"fm_cfdi_use": doc.fm_cfdi_use,
+			"fm_forma_pago_timbrado": doc.fm_forma_pago_timbrado,
+		}
+		for campo, valor in derivados.items():
+			self.assertTrue(valor, f"{campo} quedó vacío en Draft antes de Submit")
+
+		# FASE SUBMIT (docstatus=1): validate re-corre; el guard NO altera ni vacía
+		doc.docstatus = 1
+		doc._set_tipo_from_context()
+		for campo, valor in derivados.items():
+			self.assertEqual(getattr(doc, campo), valor, f"{campo} cambió/residuo tras Submit")
+		return derivados
+
+	def test_ciclo_descuento_draft_deriva_submit_preserva(self):
+		d = self._draft_deriva_y_submit_preserva("Descuento / Bonificación")
+		self.assertEqual(d["fm_tipo_nota_credito"], "Descuento / Bonificación")
+		self.assertTrue(d["fm_tipo_relacion_sat"].startswith("01 - "))
+		self.assertEqual(d["fm_cfdi_use"], "G02")
+		self.assertEqual(d["fm_forma_pago_timbrado"], "15 Condonación")
+
+	def test_ciclo_devolucion_draft_deriva_submit_preserva(self):
+		d = self._draft_deriva_y_submit_preserva("Devolución de mercancía")
+		self.assertEqual(d["fm_tipo_nota_credito"], "Devolución de mercancía")
+		self.assertTrue(d["fm_tipo_relacion_sat"].startswith("03 - "))
+		self.assertEqual(d["fm_cfdi_use"], "G02")
+		self.assertTrue(d["fm_forma_pago_timbrado"])  # resuelta por la lógica general
 
 
 # ── Concepto fiscal e independencia de la ClaveProdServ ───────────────────────
@@ -233,6 +371,32 @@ class TestMetaCampoTipoNotaCredito(FrappeTestCase):
 		self.assertIn("Devolución de mercancía", opciones)
 		self.assertIn("Descuento / Bonificación", opciones)
 
+	def test_tipo_nota_credito_es_readonly(self):
+		"""P4/P5: el campo es derivado → read-only en el DocType (no editable en FFM)."""
+		meta = frappe.get_meta("Factura Fiscal Mexico")
+		field = next(f for f in meta.fields if f.fieldname == "fm_tipo_nota_credito")
+		self.assertEqual(field.read_only, 1)
+
+	def test_tipo_nota_credito_description_corta(self):
+		"""P5: description exacta y corta."""
+		meta = frappe.get_meta("Factura Fiscal Mexico")
+		field = next(f for f in meta.fields if f.fieldname == "fm_tipo_nota_credito")
+		self.assertEqual(
+			field.description,
+			"Descuento/Bonificación → relación 01. Devolución de mercancía → relación 03.",
+		)
+
+	def test_visibilidad_tres_campos_intacta(self):
+		"""P5: los 3 campos siguen visibles solo para tipo E; relación/uuid siguen read-only."""
+		meta = frappe.get_meta("Factura Fiscal Mexico")
+		esperado = "eval:doc.fm_tipo_comprobante && doc.fm_tipo_comprobante.startsWith('E')"
+		for fn in ("fm_tipo_nota_credito", "fm_tipo_relacion_sat", "fm_uuid_relacionado"):
+			field = next(f for f in meta.fields if f.fieldname == fn)
+			self.assertEqual(field.depends_on, esperado, fn)
+		for fn in ("fm_tipo_relacion_sat", "fm_uuid_relacionado"):
+			field = next(f for f in meta.fields if f.fieldname == fn)
+			self.assertEqual(field.read_only, 1, fn)
+
 	def test_company_settings_tiene_cuenta_descuentos(self):
 		meta = frappe.get_meta("Facturacion Mexico Company Settings")
 		field = next((f for f in meta.fields if f.fieldname == "cuenta_descuentos"), None)
@@ -266,62 +430,181 @@ class TestCreditNoteLinesUseDiscountAccount(FrappeTestCase):
 		self.assertFalse(credit_note_lines_use_discount_account(si, CUENTA_DESC))
 
 
-class TestPreseleccionMotivo(FrappeTestCase):
-	"""_detect_nota_credito_motivo: preselección solo cuando el campo está vacío (punto 6 y 8)."""
+_FFM_MOD = "facturacion_mexico.facturacion_fiscal.doctype.factura_fiscal_mexico.factura_fiscal_mexico"
+CUENTA_DESC_CFG = "401-001-003 - Descuentos - TC"
 
-	def _ffm(self, motivo_inicial=""):
+
+class TestClasificacionNotaCredito(FrappeTestCase):
+	"""_classify_nota_credito: clasificación POSITIVA y fail-closed desde el estado EXACTO de la SI
+	Return. Devolución/Descuento solo con coincidencia exacta; estado ambiguo o vínculos faltantes →
+	bloquea SIN mutación parcial de campos fiscales."""
+
+	def _origen(self, update_stock=1):
+		return _dict(
+			{
+				"name": "SINV-ORIGEN",
+				"company": "_Test Company",
+				"update_stock": update_stock,
+				"items": [
+					_dict(
+						{
+							"name": "O1",
+							"income_account": "Ventas - TC",
+							"description": "Llanta 205",
+							"item_name": "LLANTA-A",
+						}
+					),
+					_dict(
+						{
+							"name": "O2",
+							"income_account": "Ventas - TC",
+							"description": "Rin 16",
+							"item_name": "RIN-B",
+						}
+					),
+				],
+			}
+		)
+
+	def _linea(self, name, si_item, income, desc, item="LLANTA-A"):
+		return _dict(
+			{
+				"name": name,
+				"sales_invoice_item": si_item,
+				"income_account": income,
+				"description": desc,
+				"item_code": item,
+				"idx": 1,
+			}
+		)
+
+	def _si(self, lineas, update_stock, return_against="SINV-ORIGEN"):
+		return _dict(
+			{
+				"name": "SINV-C-RETORNO",
+				"return_against": return_against,
+				"company": "_Test Company",
+				"update_stock": update_stock,
+				"items": lineas,
+			}
+		)
+
+	def _ffm(self):
 		inst = FacturaFiscalMexico.__new__(FacturaFiscalMexico)
+		inst.docstatus = 0
 		inst.sales_invoice = "SINV-C-RETORNO"
 		inst.company = "_Test Company"
-		inst.fm_tipo_nota_credito = motivo_inicial
+		inst.fm_tipo_nota_credito = ""
+		inst.fm_tipo_comprobante = None
+		inst.fm_tipo_relacion_sat = None
+		inst.fm_uuid_relacionado = None
+		inst.fm_cfdi_use = None
+		inst.fm_forma_pago_timbrado = None
+		inst.fm_payment_method_sat = None
+		inst.fm_facturar_venta_mostrador = 0
+		inst._is_sales_invoice_return = lambda: True
+		inst._find_uuid_cfdi_origen = lambda: UUID_ORIGEN_C
+		inst._get_origin_ffm = lambda: None
+		inst._auto_populate_forma_pago_tipo_e = lambda: setattr(
+			inst, "fm_forma_pago_timbrado", "FORMA-GENERAL"
+		)
 		return inst
 
-	def test_preselecciona_descuento_si_cuenta_coincide(self):
-		inst = self._ffm("")
-		with (
-			patch(
-				"facturacion_mexico.facturacion_fiscal.utils.get_cuenta_descuentos",
-				return_value=CUENTA_DESC,
-			),
-			patch(
-				"facturacion_mexico.facturacion_fiscal.utils.credit_note_lines_use_discount_account",
-				return_value=True,
-			),
-		):
-			inst._detect_nota_credito_motivo()
-		self.assertEqual(inst.fm_tipo_nota_credito, "Descuento / Bonificación")
+	def _derivar(self, ffm, si, origen, cuenta):
+		def _side(doctype, name):
+			return si if name == "SINV-C-RETORNO" else origen
 
-	def test_no_infiere_si_cuenta_no_coincide(self):
-		"""Punto 8: si las cuentas no coinciden, no inferir → queda vacío (devolución)."""
-		inst = self._ffm("")
 		with (
+			patch(_FFM_MOD + ".frappe.get_doc", side_effect=_side),
 			patch(
 				"facturacion_mexico.facturacion_fiscal.utils.get_cuenta_descuentos",
-				return_value=CUENTA_DESC,
-			),
-			patch(
-				"facturacion_mexico.facturacion_fiscal.utils.credit_note_lines_use_discount_account",
-				return_value=False,
+				return_value=cuenta,
 			),
 		):
-			inst._detect_nota_credito_motivo()
-		self.assertEqual(inst.fm_tipo_nota_credito, "")
+			ffm._set_tipo_from_context()
 
-	def test_no_sobrescribe_seleccion_previa(self):
-		"""Preselección no debe sobrescribir una elección explícita del usuario."""
-		inst = self._ffm("Devolución de mercancía")
-		with (
-			patch(
-				"facturacion_mexico.facturacion_fiscal.utils.get_cuenta_descuentos",
-				return_value=CUENTA_DESC,
-			),
-			patch(
-				"facturacion_mexico.facturacion_fiscal.utils.credit_note_lines_use_discount_account",
-				return_value=True,
-			),
-		):
-			inst._detect_nota_credito_motivo()
-		self.assertEqual(inst.fm_tipo_nota_credito, "Devolución de mercancía")
+	# (1) devolución exacta SIN cuenta_descuentos → 03/G02 + FormaPago general
+	def test_devolucion_exacta_sin_cuenta(self):
+		lineas = [
+			self._linea("R1", "O1", "Ventas - TC", "Llanta 205", "LLANTA-A"),
+			self._linea("R2", "O2", "Ventas - TC", "Rin 16", "RIN-B"),
+		]
+		ffm = self._ffm()
+		self._derivar(ffm, self._si(lineas, update_stock=1), self._origen(update_stock=1), cuenta=None)
+		self.assertEqual(ffm.fm_tipo_nota_credito, "Devolución de mercancía")
+		self.assertTrue(ffm.fm_tipo_relacion_sat.startswith("03 - "))
+		self.assertEqual(ffm.fm_cfdi_use, "G02")
+		self.assertEqual(ffm.fm_forma_pago_timbrado, "FORMA-GENERAL")
+
+	# (2) descuento exacto CON configuración → 01/G02/15
+	def test_descuento_exacto_con_config(self):
+		lineas = [
+			self._linea("R1", "O1", CUENTA_DESC_CFG, build_descuento_description("Llanta 205"), "LLANTA-A"),
+			self._linea("R2", "O2", CUENTA_DESC_CFG, build_descuento_description("Rin 16"), "RIN-B"),
+		]
+		ffm = self._ffm()
+		self._derivar(ffm, self._si(lineas, update_stock=0), self._origen(), cuenta=CUENTA_DESC_CFG)
+		self.assertEqual(ffm.fm_tipo_nota_credito, "Descuento / Bonificación")
+		self.assertTrue(ffm.fm_tipo_relacion_sat.startswith("01 - "))
+		self.assertEqual(ffm.fm_cfdi_use, "G02")
+		self.assertEqual(ffm.fm_forma_pago_timbrado, "15 Condonación")
+
+	# (3) descuento cuya configuración fue eliminada después → bloquea (no deriva 03)
+	def test_descuento_config_eliminada_bloquea(self):
+		lineas = [
+			self._linea("R1", "O1", CUENTA_DESC_CFG, build_descuento_description("Llanta 205"), "LLANTA-A"),
+			self._linea("R2", "O2", CUENTA_DESC_CFG, build_descuento_description("Rin 16"), "RIN-B"),
+		]
+		ffm = self._ffm()
+		with self.assertRaises(frappe.ValidationError):
+			self._derivar(ffm, self._si(lineas, update_stock=0), self._origen(), cuenta=None)
+		self.assertIsNone(ffm.fm_tipo_comprobante)  # sin mutación parcial
+		self.assertIsNone(ffm.fm_tipo_relacion_sat)
+
+	# (4) cuenta configurada pero DISTINTA de la usada en la SI → bloquea
+	def test_cuenta_distinta_de_la_usada_bloquea(self):
+		lineas = [
+			self._linea("R1", "O1", "OTRA - TC", build_descuento_description("Llanta 205"), "LLANTA-A"),
+			self._linea("R2", "O2", "OTRA - TC", build_descuento_description("Rin 16"), "RIN-B"),
+		]
+		ffm = self._ffm()
+		with self.assertRaises(frappe.ValidationError):
+			self._derivar(ffm, self._si(lineas, update_stock=0), self._origen(), cuenta=CUENTA_DESC_CFG)
+		self.assertIsNone(ffm.fm_tipo_comprobante)
+
+	# (5) línea con descripción modificada manualmente → bloquea
+	def test_linea_modificada_manualmente_bloquea(self):
+		lineas = [
+			self._linea("R1", "O1", "Ventas - TC", "Llanta 205", "LLANTA-A"),
+			self._linea("R2", "O2", "Ventas - TC", "DESCRIPCIÓN MODIFICADA", "RIN-B"),
+		]
+		ffm = self._ffm()
+		with self.assertRaises(frappe.ValidationError):
+			self._derivar(ffm, self._si(lineas, update_stock=1), self._origen(), cuenta=CUENTA_DESC_CFG)
+		self.assertIsNone(ffm.fm_tipo_comprobante)
+
+	# (6) línea sin sales_invoice_item → bloquea SIN mutación parcial
+	def test_linea_sin_vinculo_bloquea_sin_mutacion(self):
+		lineas = [
+			self._linea("R1", None, "Ventas - TC", "Llanta 205", "LLANTA-A"),  # sin vínculo
+			self._linea("R2", "O2", "Ventas - TC", "Rin 16", "RIN-B"),
+		]
+		ffm = self._ffm()
+		with self.assertRaises(frappe.ValidationError):
+			self._derivar(ffm, self._si(lineas, update_stock=1), self._origen(), cuenta=None)
+		self.assertIsNone(ffm.fm_tipo_comprobante)
+		self.assertIsNone(ffm.fm_tipo_relacion_sat)
+
+	# (6b) vínculo inexistente en el origen → bloquea
+	def test_linea_vinculo_inexistente_bloquea(self):
+		lineas = [
+			self._linea("R1", "NO-EXISTE", "Ventas - TC", "Llanta 205", "LLANTA-A"),
+			self._linea("R2", "O2", "Ventas - TC", "Rin 16", "RIN-B"),
+		]
+		ffm = self._ffm()
+		with self.assertRaises(frappe.ValidationError):
+			self._derivar(ffm, self._si(lineas, update_stock=1), self._origen(), cuenta=None)
+		self.assertIsNone(ffm.fm_tipo_comprobante)
 
 
 class TestGuardTimbradoContrato(FrappeTestCase):

--- a/facturacion_mexico/fiscal_state/sales_invoice_state.py
+++ b/facturacion_mexico/fiscal_state/sales_invoice_state.py
@@ -65,6 +65,7 @@ def _compute_facts(si) -> dict:
 
 	has_active_ffm = False
 	has_cancelled_ffm = False
+	has_draft_ffm = False
 	has_stamped_ffm = False
 	has_uuid = False
 	has_xml = False
@@ -88,6 +89,8 @@ def _compute_facts(si) -> dict:
 				has_cancelled_ffm = True
 			elif ffm.get("docstatus") == 1:
 				has_active_ffm = True
+			elif ffm.get("docstatus") == 0:
+				has_draft_ffm = True
 
 			has_stamped_ffm = has_uuid
 
@@ -109,6 +112,7 @@ def _compute_facts(si) -> dict:
 		{
 			"has_active_ffm": has_active_ffm,
 			"has_cancelled_ffm": has_cancelled_ffm,
+			"has_draft_ffm": has_draft_ffm,
 			"has_stamped_ffm": has_stamped_ffm,
 			"has_uuid": has_uuid,
 			"has_xml": has_xml,
@@ -189,7 +193,17 @@ def _compute_actions(facts: dict) -> dict:
 	fiscal_status = facts["fiscal_status"]
 	is_submitted = facts["is_submitted"]
 
-	can_stamp = is_submitted and fiscal_status in _TIMBRABLE_STATUSES and not facts["has_active_ffm"]
+	# Crear FFM solo si NO hay ya una FFM que deba abrirse/reutilizarse: ni activa/timbrada
+	# (docstatus=1) ni Draft (docstatus=0). Ambas exclusiones son necesarias — el snapshot
+	# fm_fiscal_status de la SI puede quedar desincronizado (p. ej. "ERROR") aunque la FFM ya
+	# esté TIMBRADA, por eso no basta con el gate de fiscal_status. FFM cancelada no bloquea
+	# (fiscal_status=CANCELADO ya la excluye y la refacturación tiene su propia acción).
+	can_stamp = (
+		is_submitted
+		and fiscal_status in _TIMBRABLE_STATUSES
+		and not facts.get("has_active_ffm", False)
+		and not facts.get("has_draft_ffm", False)
+	)
 
 	can_cancel_cfdi = (
 		is_submitted

--- a/facturacion_mexico/fixtures/docperm.json
+++ b/facturacion_mexico/fixtures/docperm.json
@@ -136,7 +136,7 @@
   "role": "Facturacion Mexico Manager",
   "select": 0,
   "share": 1,
-  "submit": 0,
+  "submit": 1,
   "write": 1
  },
  {
@@ -164,7 +164,7 @@
   "role": "Facturacion Mexico System Manager",
   "select": 0,
   "share": 1,
-  "submit": 0,
+  "submit": 1,
   "write": 1
  }
 ]

--- a/facturacion_mexico/public/js/sales_invoice.js
+++ b/facturacion_mexico/public/js/sales_invoice.js
@@ -33,8 +33,8 @@ load_fiscal_states();
 
 frappe.ui.form.on("Sales Invoice", {
 	refresh: function (frm) {
-		frm.remove_custom_button(__("Timbrar Factura"));
-		frm.remove_custom_button(__("Ver Factura Fiscal"));
+		frm.remove_custom_button(__("Crear Factura Fiscal"));
+		frm.remove_custom_button(__("Abrir Factura Fiscal"));
 
 		if (frm.doc.docstatus !== 1) return;
 
@@ -45,6 +45,11 @@ frappe.ui.form.on("Sales Invoice", {
 			callback(r) {
 				if (!r.message) return;
 				const { actions } = r.message;
+				// Estado autoritativo del servidor: guardarlo en el frm para que cualquier vía
+				// (incluidas las asíncronas) respete can_stamp al decidir dibujar el botón.
+				frm.__fm_can_stamp = actions.can_stamp === true;
+				// Limpiar SIEMPRE la acción primaria antes de decidir.
+				frm.page.clear_primary_action();
 				if (actions.can_view_ffm) add_view_fiscal_button(frm);
 				// can_stamp: condiciones técnicas OK — RFC check decide si mostrar o avisar
 				if (actions.can_stamp) _check_rfc_and_show_timbrar(frm);
@@ -72,14 +77,18 @@ function should_show_timbrar_button(frm) {
 }
 
 function add_timbrar_button(frm) {
+	// Guard de choke-point: nunca colocar el botón si el estado fiscal autoritativo del servidor
+	// no permite timbrar. Bloquea cualquier vía (síncrona o asíncrona) que intente dibujarlo
+	// cuando can_stamp es false (p. ej. FFM en Draft ya vinculada).
+	if (frm.__fm_can_stamp !== true) return;
 	// Botón único y prominente: Timbrar Factura que redirije a Factura Fiscal Mexico
-	frm.page.set_primary_action(__("Timbrar Factura"), function () {
+	frm.page.set_primary_action(__("Crear Factura Fiscal"), function () {
 		redirect_to_fiscal_document(frm);
 	});
 }
 
 function add_view_fiscal_button(frm) {
-	frm.add_custom_button(__("Ver Factura Fiscal"), function () {
+	frm.add_custom_button(__("Abrir Factura Fiscal"), function () {
 		frappe.set_route("Form", "Factura Fiscal Mexico", frm.doc.fm_factura_fiscal_mx);
 	}).addClass("btn-info");
 }
@@ -515,12 +524,16 @@ function _check_rfc_and_show_timbrar(frm) {
 		.then((r) => {
 			const msg = (r && r.message) || {};
 
-			// RFC presente: sin RFC no se muestra botón ni alerta (comportamiento previo).
-			if (!msg.tax_id) return;
+			// Solo avisar/dibujar cuando el estado fiscal permite crear FFM (can_stamp autoritativo).
+			// Evita avisos engañosos de "valida el RFC para crear la FFM" en SI que ya tienen una FFM
+			// (can_stamp=false). No introduce lógica de FFM aquí: usa el flag fiscal ya calculado.
+			if (frm.__fm_can_stamp !== true) return;
 
-			// Validación SAT: solo un flag explícito = 1 habilita el botón; vacío/0 nunca se
-			// interpreta como validado.
-			const is_validated = msg.fm_rfc_validated === 1 || msg.fm_rfc_validated === "1";
+			// RFC válido = tiene tax_id Y está validado ante SAT (tolera 1 numérico o "1" string).
+			// RFC vacío o no validado se tratan igual: no se dibuja botón y se muestra el mismo aviso.
+			const is_validated =
+				Boolean(msg.tax_id) &&
+				(msg.fm_rfc_validated === 1 || msg.fm_rfc_validated === "1");
 			if (is_validated) {
 				if (should_show_timbrar_button(frm)) {
 					add_timbrar_button(frm);

--- a/facturacion_mexico/tests/test_docperm_sales_invoice_permissions.py
+++ b/facturacion_mexico/tests/test_docperm_sales_invoice_permissions.py
@@ -1,0 +1,44 @@
+"""
+Validación estática del fixture de permisos (docperm.json).
+
+Lee el JSON del repositorio (sin BD, sin mocks) y verifica invariantes de Frappe y la decisión
+autoritativa de permisos de cancelación de Sales Invoice:
+  - Ninguna fila DocPerm puede tener cancel=1 con submit=0 (estado inválido en Frappe).
+  - Los roles Manager/System Manager sobre Sales Invoice tienen submit=1 y cancel=1 (el flujo de
+    cancelación nativo del app depende del permiso `cancel`, que a su vez exige `submit`).
+"""
+
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+def _load_docperm():
+	path = frappe.get_app_path("facturacion_mexico", "fixtures", "docperm.json")
+	with open(path, encoding="utf-8") as fh:
+		return json.load(fh)
+
+
+class TestDocPermSalesInvoicePermissions(FrappeTestCase):
+	def test_ninguna_fila_cancel_sin_submit(self):
+		"""Frappe: cancel=1 exige submit=1. Ninguna fila del fixture puede violar ese invariante."""
+		invalidas = [
+			f"{p.get('parent')} / {p.get('role')}"
+			for p in _load_docperm()
+			if int(p.get("cancel") or 0) == 1 and int(p.get("submit") or 0) == 0
+		]
+		self.assertEqual(invalidas, [], f"Filas DocPerm con cancel=1 y submit=0 (inválidas): {invalidas}")
+
+	def test_roles_manager_sales_invoice_submit_y_cancel(self):
+		"""Manager y System Manager sobre Sales Invoice deben tener submit=1 y cancel=1."""
+		roles = {"Facturacion Mexico Manager", "Facturacion Mexico System Manager"}
+		filas = {
+			p.get("role"): p
+			for p in _load_docperm()
+			if p.get("parent") == "Sales Invoice" and p.get("role") in roles
+		}
+		self.assertEqual(set(filas), roles, "Faltan filas DocPerm de Sales Invoice para los roles Manager")
+		for role, p in filas.items():
+			self.assertEqual(int(p.get("submit") or 0), 1, f"{role} sobre Sales Invoice: submit debe ser 1")
+			self.assertEqual(int(p.get("cancel") or 0), 1, f"{role} sobre Sales Invoice: cancel debe ser 1")

--- a/facturacion_mexico/tests/test_fiscal_state_sales_invoice.py
+++ b/facturacion_mexico/tests/test_fiscal_state_sales_invoice.py
@@ -144,6 +144,18 @@ class TestFiscalStateSIFacts(FrappeTestCase):
 		self.assertTrue(facts["is_cancelled"])
 		self.assertFalse(facts["is_submitted"])
 
+	# ── Caso 8: FFM vinculada en Draft (docstatus=0) → has_draft_ffm ──────
+	def test_ffm_draft_marca_has_draft_ffm(self):
+		"""FFM vinculada con docstatus=0 (Draft, incl. ERROR) → has_draft_ffm=True.
+		Regresión: el botón Crear seguía visible por no detectar la FFM Draft."""
+		si = _mock_si(fm_fiscal_status="ERROR", fm_factura_fiscal_mx="FFMX-001")
+		ffm_data = _ffm(status="ERROR", fm_uuid=None, docstatus=0)
+		with patch("frappe.get_all", side_effect=[ffm_data, [], [], []]):
+			facts = _compute_facts(si)
+		self.assertTrue(facts["has_draft_ffm"])
+		self.assertFalse(facts["has_active_ffm"])
+		self.assertFalse(facts["has_cancelled_ffm"])
+
 
 class TestFiscalStateSIActions(FrappeTestCase):
 	def _base_facts(self, **overrides):
@@ -278,6 +290,47 @@ class TestFiscalStateSIActions(FrappeTestCase):
 		actions = _compute_actions(facts)
 		self.assertFalse(actions["can_register_payment"])
 
+	def test_can_stamp_false_con_ffm_draft(self):
+		"""FFM vinculada en BORRADOR (docstatus=0) → oculta Crear (can_stamp False), sí Abrir."""
+		facts = self._base_facts(
+			fiscal_status="BORRADOR",
+			has_ffm=True,
+			has_active_ffm=False,
+			has_cancelled_ffm=False,
+			has_draft_ffm=True,
+			has_stamped_ffm=False,
+			has_uuid=False,
+		)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_stamp"])
+		self.assertTrue(actions["can_view_ffm"])
+
+	def test_can_stamp_false_con_ffm_activa_snapshot_desincronizado(self):
+		"""FFM activa/timbrada (docstatus=1) con snapshot fiscal_status aún timbrable (p. ej. ERROR)
+		→ can_stamp=False. Protección contra FFM activa, independiente del snapshot de la SI."""
+		facts = self._base_facts(
+			fiscal_status="ERROR",
+			has_ffm=True,
+			has_active_ffm=True,
+			has_draft_ffm=False,
+			has_cancelled_ffm=False,
+		)
+		actions = _compute_actions(facts)
+		self.assertFalse(actions["can_stamp"])
+		self.assertTrue(actions["can_view_ffm"])
+
+	def test_can_stamp_true_sin_ffm_condiciones_normales(self):
+		"""Sin FFM (ni activa ni draft) y estado timbrable → can_stamp=True."""
+		facts = self._base_facts(
+			fiscal_status="BORRADOR",
+			has_ffm=False,
+			has_active_ffm=False,
+			has_draft_ffm=False,
+			has_cancelled_ffm=False,
+		)
+		actions = _compute_actions(facts)
+		self.assertTrue(actions["can_stamp"])
+
 
 class TestFiscalStateSIMessages(FrappeTestCase):
 	def _base(self, **overrides):
@@ -389,3 +442,28 @@ class TestFiscalStateSIMessages(FrappeTestCase):
 			m["code"] for m in _compute_messages(self._base(requires_complement=True, has_complement=True))
 		]
 		self.assertIn("COMPLEMENT_PENDING", codes)
+
+
+class TestSalesInvoiceJsEtiquetas(FrappeTestCase):
+	"""Contrato estático del JS de Sales Invoice.
+
+	Verifica que las etiquetas de acción se renombraron y —de forma explícita— que el query
+	original dentro de redirect_to_fiscal_document sigue presente. Esa preservación es
+	intencional: su eliminación NO está autorizada y esta prueba la protege de regresión.
+	"""
+
+	def _read_js(self):
+		path = frappe.get_app_path("facturacion_mexico", "public", "js", "sales_invoice.js")
+		with open(path, encoding="utf-8") as fh:
+			return fh.read()
+
+	def test_etiquetas_y_query_intacto(self):
+		"""Etiquetas nuevas presentes; las anteriores ya no se usan; el query de
+		redirect_to_fiscal_document permanece (su eliminación NO está autorizada)."""
+		js = self._read_js()
+		self.assertIn('__("Crear Factura Fiscal")', js)
+		self.assertIn('__("Abrir Factura Fiscal")', js)
+		self.assertNotIn('__("Timbrar Factura")', js)
+		self.assertNotIn('__("Ver Factura Fiscal")', js)
+		self.assertIn('method: "frappe.client.get_value"', js)
+		self.assertIn('fieldname: "fm_fiscal_status"', js)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
     - usuario/index.md
     - Primeros Pasos: usuario/getting-started.md
     - Emitir un CFDI: usuario/emitir-cfdi.md
+    - Notas de Crédito: usuario/notas-credito.md
     - Cancelar CFDI: usuario/cancelar-cfdi.md
     - Verificar estado en FacturAPI: usuario/verificar-estado-facturapi.md
     - Complemento de Pago: usuario/complemento-pago.md


### PR DESCRIPTION
## Objetivo

Correcciones fiscales en Sales Invoice / Factura Fiscal Mexico:
1. Derivar automáticamente y de forma read-only el **tipo de Nota de Crédito** (Descuento/Bonificación vs Devolución) en la FFM.
2. Corregir el control de visibilidad del botón **"Crear Factura Fiscal"** y del aviso de RFC.
3. Documentar el flujo de Notas de Crédito para el usuario.

## Versión
Versión objetivo: `v1.3.1`
Release: PATCH
(base upstream/main: `v1.3.0` → objetivo `1.3.1` — solo correcciones, sin funcionalidad nueva)

## Cambios principales

### Nota de Crédito — tipo derivado y bloqueado (`c0de29b`)
- Derivación automática y **read-only** del tipo de NC en la FFM.
- **Descuento/Bonificación:** TipoRelación `01`, Uso CFDI `G02`, Forma de Pago `15`.
- **Devolución:** TipoRelación `03`, Uso CFDI `G02`, Forma de Pago conforme a la lógica existente.
- Clasificación **fail-closed** de casos ambiguos.
- Alternancia mientras la Sales Invoice Return está en Draft, entre **"Aplicar como Descuento / Bonificación"** y **"Revertir a Devolución de mercancía"**, con restauración correcta de Item, descripción, cuenta e inventario.

### Botón fiscal + aviso RFC (`3e22101`)
- **"Crear Factura Fiscal"** se bloquea cuando existe una FFM **Draft** (`docstatus=0`) **o** una FFM **activa/timbrada** (`docstatus=1`) — ambas exclusiones (`has_active_ffm` + `has_draft_ffm`), no depende solo del snapshot `fm_fiscal_status`.
- **"Abrir Factura Fiscal"** permanece disponible cuando hay FFM.
- RFC **vacío** o **no validado**: no se muestra el botón y se muestra el aviso existente.
- Cuando `can_stamp=false`, no aparecen avisos RFC engañosos en facturas legacy con FFM.
- `redirect_to_fiscal_document` y su query permanecen intactos.

### Documentación (`675b7e1`)
- Nueva página de usuario `docs/usuario/notas-credito.md` (agregada a la navegación de MkDocs): configuración de la **Cuenta de Descuentos y Bonificaciones** (Facturacion Mexico Company Settings), alternancia en Draft, resultado fiscal derivado y comportamiento de los botones fiscales.

## Documentación actualizada
- `docs/usuario/notas-credito.md` — nueva (en `mkdocs.yml` nav).
- `docs/adr/0025-notas-credito-cfdi-tipo-e-issue116.md` — decisión de derivación/bloqueo del tipo de NC.
- `mkdocs build --strict`: OK.

## Validaciones realizadas
- `test_fiscal_state_sales_invoice`: **35 OK**.
- `test_nota_credito_descuento_relacion_01`: **79 OK**.
- Suite completa (`--lightmode`): sin regresiones nuevas respecto al baseline conocido.
- `bench build`: OK · `ruff check`/`ruff format`: OK · `prettier@2.7.1`: OK · `mkdocs build --strict`: OK · scan de datos de cliente: limpio.
- GUI: cinco escenarios de botón/RFC (FFM timbrada, FFM Draft, sin FFM + RFC validado, RFC vacío, RFC no validado) OK; Descuento/Bonificación y Devolución OK; alternancia antes de guardar OK.

## Fuera de alcance
- Ninguno pendiente en este PR.

## Riesgos / pendientes
- No requiere `bench migrate` (sin cambios de esquema). Requiere `bench build` (assets JS) al desplegar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas funcionalidades**
  * Las Notas de Crédito derivan automáticamente su tipo y datos fiscales según la devolución o descuento de origen.
  * Se agregan validaciones para impedir el guardado de información incompleta o ambigua.
  * Los documentos en borrador conservan correctamente sus datos fiscales al enviarse.

* **Correcciones**
  * Se evita crear facturas fiscales duplicadas, incluso cuando existe una factura en borrador.
  * Los botones fiscales y las validaciones de RFC reflejan correctamente la disponibilidad de timbrado.
  * Se actualiza la versión a 1.3.1.

* **Documentación**
  * Se incorpora una guía de usuario para emitir Notas de Crédito y se añade a la navegación.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->