### PR TITLE
docs: actualiza manual, referencias de configuración/campos y estado real de módulos (1.3.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,8 @@ con soporte multi-sucursal, addendas, e-receipts y complementos de pago.
 | `Factura Fiscal Mexico` | CFDI tipo I/E via FacturAPI. Submittable. | ✅ Funcional |
 | `Complemento Pago MX` | CFDI tipo P (PPD). Auto desde Payment Entry. | ✅ Funcional |
 | `EReceipt MX` | Recibo digital para autofacturación. | ✅ Funcional |
-| `Factura Global MX` | Agrupa E-Receipts en CFDI global. | ✅ Funcional |
-| `Facturacion Mexico Settings` | Single — credenciales FacturAPI, config global. | ✅ Funcional |
+| `Factura Global MX` | Agrupa E-Receipts en CFDI global. | ⚠️ API sin UI — sin validación integral |
+| `Facturacion Mexico Company Settings` | Config por **empresa**: credenciales FacturAPI (sandbox/prod), cuenta de descuentos, defaults. **No es Single** — el antiguo Single `Facturacion Mexico Settings` fue eliminado (ADR 0031). | ✅ Funcional |
 | `Configuracion Fiscal Mexico` | Config fiscal por empresa — wizard STCT/ITT. | ✅ Funcional |
 | `Configuracion Fiscal Sucursal` | Config fiscal por Branch con folios y series. | ✅ Funcional |
 | `IEPS Cuota SAT` | Cuotas fijas IEPS por producto/empresa/fecha. | ✅ Creado, sin datos |
@@ -88,13 +88,14 @@ Catálogos SAT propios: `Uso CFDI SAT`, `Forma Pago SAT`, `Metodo Pago SAT`,
 |---|---|
 | Timbrado CFDI (I/E/N) | ✅ Funcional |
 | Complemento de Pago PPD | ✅ Funcional |
-| E-Receipts / autofactura | ✅ Funcional |
-| Factura Global | ✅ Funcional |
+| E-Receipts / autofactura | ⚠️ Implementación parcial — pendiente validación integral (portal/expiración/autofactura sin aprobar) |
+| Factura Global | ⚠️ API existente sin UI completa ni validación integral |
 | Cancelación CFDI | ✅ Funcional |
 | Multi-sucursal (Branch) | ✅ Funcional |
 | Addendas genéricas | ✅ Funcional |
 | Validación RFC contra SAT | ✅ Funcional |
-| Recovery / resiliencia PAC | ⚠️ Funcional pero defecto crítico (datos en /tmp) |
+| Reconciliación FFM↔FacturAPI | ⚠️ Existe (scheduler + botón, solo GET); **pendiente prueba operativa controlada** |
+| Fallback de timbrado | ✅ Persistencia de la respuesta RAW del PAC en fallback file (`private/files`; `/tmp` solo último recurso) + advertencia visible. El archivo conserva evidencia, no es recuperación automática. `api_backup.py` eliminado (PR #142) |
 | Draft management | ❌ No funcional — todo MOCK |
 | Motor de reglas | ⚠️ Parcial — acciones clave deshabilitadas |
 | Dashboard KPIs | ⚠️ Parcial — alertas siempre en 0 |
@@ -116,11 +117,14 @@ Sales Invoice (submit)
 
 ### Custom Fields sobre DocTypes de ERPNext
 
-- **Sales Invoice:** ~40 campos (estado fiscal, timbrado, multi-sucursal, addenda)
-- **Branch:** 14 campos (folios, series, certificados)
-- **Customer:** 12 campos (RFC, régimen fiscal, uso CFDI)
-- **Item:** 3 campos (clave SAT)
-- **Payment Entry:** 5 campos (forma de pago SAT)
+**Total real: 97 custom fields** (`fixtures/custom_field.json`). No todos son configurables por el
+usuario: ~30 son estructura visual (Section/Column/Tab/HTML), varios son internos/legado. Solo ~48
+(configurables + informativos) se documentan como campos de usuario (ver `docs/referencia/campos-fiscales.md`).
+
+- **Sales Invoice:** 41 campos (estado fiscal, timbrado, multi-sucursal, addenda, e-receipt)
+- **Branch:** 20 campos (folios, series, certificados, estadísticas)
+- **Customer:** 19 campos (RFC, régimen fiscal, uso CFDI, GLN addenda)
+- **Payment Entry:** 5 campos · **Item:** 3 · **Address:** 2 · **Cost Center:** 2 · **Purchase Invoice:** 2 · **Item Customer Detail:** 2 · **Item Group:** 1
 
 Prefijo obligatorio: `fm_*` para todos los custom fields.
 
@@ -135,8 +139,8 @@ Prefijo obligatorio: `fm_*` para todos los custom fields.
 ### API externa
 
 - **FacturAPI.io** — PAC para timbrado CFDI
-- Sandbox/producción configurable en `Facturacion Mexico Settings`
-- Cliente HTTP en `facturacion_fiscal/timbrado_api.py`
+- Sandbox/producción configurable **por empresa** en `Facturacion Mexico Company Settings`
+- Cliente HTTP en `facturacion_fiscal/api_client.py` (timbrado en `facturacion_fiscal/timbrado_api.py`)
 
 ---
 
@@ -144,7 +148,7 @@ Prefijo obligatorio: `fm_*` para todos los custom fields.
 
 **Apps de Frappe requeridas:** erpnext (declarado en `required_apps`)  
 **Apps en el mismo bench (v16):** hrms, payments, facturacion_mexico  
-**API externa:** FacturAPI.io (credenciales en Facturacion Mexico Settings)
+**API externa:** FacturAPI.io (credenciales por empresa en `Facturacion Mexico Company Settings`)
 
 ---
 
@@ -181,14 +185,28 @@ facturacion_mexico.patches.v1_0.migrate_customer_tax_category_to_fm_tax_regime
 1. **`draft_management/api.py`** — completamente simulado con MOCKs. Flujos con
    `fm_create_as_draft = True` no generan CFDI real. Falla silenciosamente.
 
-2. **`facturacion_fiscal/api_backup.py`** — fallback de recovery escribe en `/tmp/`.
-   Se pierde en reinicio. Viola cumplimiento fiscal (respuestas PAC tienen valor legal).
+2. **Resiliencia PAC.** El antiguo `api_backup.py` (recovery a `/tmp/`) fue **removido** (PR #142).
+   Hoy la resiliencia = **reconciliación FFM↔FacturAPI** (GET, pendiente de prueba operativa) +
+   **fallback file de timbrado** (respuesta RAW en `private/files`; `/tmp` solo último recurso). Ver
+   `docs/tecnico/reconciliacion-fallback.md`. (Existe deuda de código legacy en la ruta de
+   cancelación, gestionada en issue aparte — no forma parte de la arquitectura vigente.)
 
 3. **IEPS Cuota $0 en submit** (issue #81) — cuotas `charge_type="Actual"` se vuelven $0
-   al hacer submit. Hooks comentados (`# E4 DISABLED`). No bloquea timbrado de IVA estándar.
+   al hacer submit. Hooks **deshabilitados** (`# E4 DISABLED`). Funcionalidad IEPS cuota fija:
+   **deshabilitada** (candidata a roadmap). No bloquea timbrado de IVA estándar.
 
-4. **Motor de reglas** — `execute_call_api_manual()` y similares retornan strings de error,
+4. **Motor de reglas** — parcial: `execute_call_api_manual()` y similares retornan strings de error,
    no ejecutan nada.
+
+5. **Dashboard fiscal** — parcial: scores/uptime **hardcodeados**, alertas en 0, UI en **inglés**
+   (viola RG-001). No apto para manual.
+
+6. **E-Receipts / Factura Global** — implementación parcial/API sin UI; **sin validación integral**.
+   No presentar como operativos.
+
+> **Config:** la configuración vigente es **por empresa** (`Facturacion Mexico Company Settings`);
+> el Single `Facturacion Mexico Settings` fue eliminado (ADR 0031). **`patches.txt` está vacío** y
+> `patches/legacy/` **no es ejecutable** (solo referencia histórica).
 
 ---
 

--- a/docs/referencia/campos-fiscales.md
+++ b/docs/referencia/campos-fiscales.md
@@ -1,0 +1,169 @@
+# Referencia — Campos fiscales (custom fields de usuario)
+
+Referencia de los **custom fields** de `facturacion_mexico` que son **visibles y relevantes
+para el usuario**: los que el usuario **captura** (categoría 1, visible-configurable) y los que
+el **sistema calcula o refleja** en solo lectura (categoría 2, visible-informativo).
+
+**Alcance:** 48 campos (31 configurables + 17 informativos/solo-lectura), agrupados por DocType.
+
+**Fuera de alcance (no se documentan aquí):** Section/Column/Tab Break y widgets HTML
+(estructura visual), campos ocultos internos, campos MOCK de *Draft management*
+(`fm_draft_*`, `fm_create_as_draft`) y campos legados sin consumo real en código.
+
+**Cómo leer la columna "Origen":**
+
+- **Usuario captura** → el usuario escribe o selecciona el valor (campo configurable).
+- **Sistema calcula / solo lectura** → el sistema lo escribe automáticamente; el usuario
+  no debe llenarlo (informativo).
+
+> Los atributos (etiqueta, tipo, solo-lectura, obligatorio, default) están validados contra
+> `facturacion_mexico/fixtures/custom_field.json`.
+
+---
+
+## Sales Invoice
+
+Campos fiscales sobre la factura de venta. Aparecen en la sección **Información Fiscal México**
+(y subsecciones de multi-sucursal, e-receipt y addenda) de la Sales Invoice.
+
+| Etiqueta | fieldname | Tipo | Origen | Propósito | Cuándo aparece | Flujo que lo usa |
+|---|---|---|---|---|---|---|
+| Estado Fiscal | `fm_fiscal_status` | Select | Sistema calcula / solo lectura | Estado fiscal del CFDI de la factura (refleja el estado de la FFM) | Siempre, en la sección fiscal | Timbrado I/E, cancelación, capa de estado fiscal UI |
+| Folio Fiscal FFM | `fm_folio_fiscal` | Data | Sistema calcula / solo lectura | Folio fiscal (UUID) reflejado desde la Factura Fiscal México | Tras timbrado exitoso | Timbrado; reflejo desde FFM (`utils.py`, `tasks.py`) |
+| Factura Fiscal México | `fm_factura_fiscal_mx` | Link | Sistema calcula / solo lectura | Liga al documento Factura Fiscal México (CFDI) generado | Tras crear la Factura Fiscal | Creación de FFM; resumen CFDI en la SI |
+| Requiere Complemento de Pago | `fm_es_ppd` | Check | Sistema calcula / solo lectura | Marca la factura como PPD (requiere complemento de pago) | Según método de pago de la factura | Complemento de Pago PPD |
+| Sucursal Fiscal | `fm_branch` | Link | Usuario captura | Sucursal responsable de la facturación fiscal | Cuando la factura requiere timbrado (`fm_requires_stamp`) | Multi-sucursal; asignación automática STCT; impuestos automatizados |
+| Modo de Facturación | `fm_ereceipt_mode` | Select | Usuario captura | Normal = timbrado directo; E-Receipt = recibo para autofacturación (default: `Normal`) | Siempre, en la sección E-Receipt | E-Receipts / autofactura |
+| Tipo de Vencimiento | `fm_ereceipt_expiry_type` | Select | Usuario captura | Tipo de vencimiento del E-Receipt (default: `Fixed Days`) | Solo si `fm_ereceipt_mode == "E-Receipt"` | E-Receipts |
+| Días de Vencimiento | `fm_ereceipt_expiry_days` | Int | Usuario captura | Días de vigencia del E-Receipt (default: `3`) | Si es E-Receipt y tipo `Fixed Days` | E-Receipts |
+| Fecha de Vencimiento | `fm_ereceipt_expiry_date` | Date | Usuario captura | Fecha de vencimiento del E-Receipt | Si es E-Receipt y tipo `Custom Date` | E-Receipts |
+| E-Receipt MX | `fm_ereceipt_mx` | Link | Sistema calcula / solo lectura | Liga al EReceipt MX generado | Tras generar el E-Receipt | E-Receipts |
+| Requiere Addenda | `fm_addenda_required` | Check | Usuario captura | Indica si la factura requiere addenda (default: `0`) | Siempre, en la sección de addenda | Addendas |
+| Tipo de Addenda | `fm_addenda_type` | Link | Usuario captura | Tipo de addenda a generar | Si `fm_addenda_required` | Addendas |
+| Estado de Addenda | `fm_addenda_status` | Select | Sistema calcula / solo lectura | Estado de generación de la addenda | Si `fm_addenda_required` | Addendas |
+| XML de Addenda | `fm_addenda_xml` | Code | Sistema calcula / solo lectura | XML de addenda generado | Cuando el estado de addenda es `Completada` | Addendas |
+| Errores de Addenda | `fm_addenda_errors` | Small Text | Sistema calcula / solo lectura | Errores de generación de la addenda | Cuando el estado de addenda es `Error` | Addendas |
+| Fecha Generación Addenda | `fm_addenda_generated_date` | Datetime | Sistema calcula / solo lectura | Fecha de generación de la addenda | Cuando el estado de addenda es `Completada` | Addendas |
+
+---
+
+## Customer
+
+Campos fiscales sobre el cliente. Aparecen en la pestaña **Fiscal México** y en la sección
+**Configuración de Addendas** del Customer.
+
+| Etiqueta | fieldname | Tipo | Origen | Propósito | Cuándo aparece | Flujo que lo usa |
+|---|---|---|---|---|---|---|
+| Centro de Costo Por Defecto | `fm_customer_default_cost_center` | Link | Usuario captura | Centro de costo que se asigna automáticamente en facturas de este cliente | Siempre | Impuestos automatizados; JS de Sales Invoice |
+| Envío automático de CFDI | `fm_envio_email_cliente` | Select | Usuario captura | Preferencia de envío automático de CFDI por email (default: `Default (usar settings)`) | Siempre, en la pestaña fiscal | Envío de CFDI por email (FFM) |
+| Régimen Fiscal SAT | `fm_tax_regime` | Link | Usuario captura | Régimen fiscal del cliente según catálogo SAT | Siempre | Timbrado; factura global; FFM |
+| Puede facturar como Venta Mostrador | `fm_allow_generic_rfc` | Check | Usuario captura | Permite emitir CFDI con RFC genérico XAXX010101000 — venta mostrador (default: `0`) | Siempre | Venta mostrador / CFDI individual con RFC genérico |
+| Uso CFDI por Defecto | `fm_uso_cfdi_default` | Link | Usuario captura | Uso de CFDI por defecto para este cliente | Siempre | Timbrado; catálogos SAT; validación de SI |
+| RFC Validado con SAT | `fm_rfc_validated` | Check | Sistema calcula / solo lectura | Indica si el RFC fue validado ante el SAT | Siempre, en la sección Validación SAT | Validación RFC contra SAT |
+| Fecha Validación RFC | `fm_rfc_validation_date` | Date | Sistema calcula / solo lectura | Fecha de la validación del RFC | Siempre, en la sección Validación SAT | Validación RFC contra SAT |
+| Requiere Addenda | `fm_requires_addenda` | Check | Usuario captura | Indica que el cliente requiere addenda (default: `0`) | Siempre, en la sección de addendas | Addendas; propagación a la SI |
+| Tipo de Addenda Por Defecto | `fm_default_addenda_type` | Link | Usuario captura | Tipo de addenda por defecto del cliente | Si `fm_requires_addenda` | Addendas; propagación a la SI |
+| GLN Comprador (Addenda) | `fm_buyer_gln` | Data | Usuario captura | GLN (Global Location Number) del comprador para addendas EDI | Si `fm_requires_addenda` | Addendas EDI |
+| Días de Crédito (Addenda) | `fm_dias_credito_addenda` | Int | Usuario captura | Días de crédito a incluir en addendas EDI (default: `0`) | Si `fm_requires_addenda` | Addendas EDI |
+| GLN Proveedor (Addenda) | `fm_seller_gln` | Data | Usuario captura | GLN asignado por el cliente a nuestra empresa como proveedor | Si `fm_requires_addenda` | Addendas EDI |
+| ID Proveedor (Addenda) | `fm_seller_id` | Data | Usuario captura | Número de proveedor asignado por el cliente a nuestra empresa | Si `fm_requires_addenda` | Addendas EDI |
+| GLN Invoice Creator (Addenda) | `fm_invoice_creator_gln` | Data | Usuario captura | GLN del nodo InvoiceCreator requerido por el cliente | Si `fm_requires_addenda` | Addendas EDI |
+
+---
+
+## Branch
+
+Campos fiscales multi-sucursal sobre el Branch. Aparecen en las secciones **Configuración Fiscal**
+y **Gestión de Folios**.
+
+| Etiqueta | fieldname | Tipo | Origen | Propósito | Cuándo aparece | Flujo que lo usa |
+|---|---|---|---|---|---|---|
+| Company | `company` | Link | Usuario captura | Empresa asociada a la sucursal (**obligatorio**) | Siempre | Multi-sucursal; impuestos; factura global |
+| Habilitar para Facturación Fiscal | `fm_enable_fiscal` | Check | Usuario captura | Activa la sucursal para emisión de CFDI (default: `0`) | Siempre | Multi-sucursal |
+| Lugar de Expedición (Código Postal) | `fm_lugar_expedicion` | Data | Usuario captura | Código postal fiscal donde se expiden las facturas | Si `fm_enable_fiscal` | Timbrado (lugar de expedición) |
+| Zona Fronteriza (MX) | `fm_is_border_zone` | Check | Usuario captura | Marca la sucursal en zona fronteriza para aplicar IVA Frontera (default: `0`) | Si `fm_enable_fiscal` | Impuestos automatizados (IVA frontera) |
+| Patrón de Serie | `fm_serie_pattern` | Data | Usuario captura | Patrón para generar series de folios, ej. `SUC1-{yyyy}` (default: `{abbr}-{yyyy}`) | Si `fm_enable_fiscal` | Gestión de folios y series |
+| Folio Inicial | `fm_folio_start` | Int | Usuario captura | Primer folio disponible para esta sucursal (default: `1`) | Si `fm_enable_fiscal` | Gestión de folios |
+| Folio Final | `fm_folio_end` | Int | Usuario captura | Último folio disponible para esta sucursal | Si `fm_enable_fiscal` | Gestión de folios |
+
+---
+
+## Payment Entry
+
+Campos fiscales sobre el registro de pago. Aparecen en la sección **Información Fiscal MX**.
+
+| Etiqueta | fieldname | Tipo | Origen | Propósito | Cuándo aparece | Flujo que lo usa |
+|---|---|---|---|---|---|---|
+| Complemento Pago Generado | `fm_complemento_pago` | Link | Sistema calcula / solo lectura | Liga al Complemento de Pago MX generado | Tras generarse el complemento | Complemento de Pago PPD |
+| Requiere Complemento | `fm_require_complement` | Check | Usuario captura | Indica que el pago requiere complemento PPD | Siempre, en la sección fiscal | Complemento de Pago PPD |
+| Complemento Generado | `fm_complement_generated` | Check | Sistema calcula / solo lectura | Indica si ya se generó el complemento de pago | Siempre, en la sección fiscal | Complemento de Pago PPD |
+
+---
+
+## Item
+
+Campo de clasificación SAT sobre el artículo. Aparece en la sección **Clasificación SAT**.
+
+| Etiqueta | fieldname | Tipo | Origen | Propósito | Cuándo aparece | Flujo que lo usa |
+|---|---|---|---|---|---|---|
+| SAT Producto/Servicio | `fm_producto_servicio_sat` | Link | Usuario captura | Clave SAT Producto/Servicio del artículo | Siempre | Timbrado (obligatorio por línea); factura global |
+
+---
+
+## Cost Center
+
+Campos de mapeo del centro de costo a la operación fiscal.
+
+| Etiqueta | fieldname | Tipo | Origen | Propósito | Cuándo aparece | Flujo que lo usa |
+|---|---|---|---|---|---|---|
+| Sucursal Fiscal Mapeada | `fm_mapped_branch` | Link | Usuario captura | Asocia el Centro de Costo a una sucursal fiscal | Cuando hay company definida | Multi-sucursal; selección automática de sucursal |
+| Price List Ventas por Defecto | `fm_default_selling_price_list` | Link | Usuario captura | Price List por defecto al facturar desde este Centro de Costo | Siempre | Impuestos automatizados; JS de Sales Invoice |
+
+---
+
+## Purchase Invoice
+
+Campos de trazabilidad de CFDI recibidos sobre la factura de compra.
+
+| Etiqueta | fieldname | Tipo | Origen | Propósito | Cuándo aparece | Flujo que lo usa |
+|---|---|---|---|---|---|---|
+| UUID CFDI Recibido | `fm_cfdi_uuid` | Data | Sistema calcula / solo lectura | UUID del CFDI recibido de origen (único; garantiza idempotencia y recupera PI huérfano en reintento) | Al generar la PI desde un CFDI recibido | CFDI recibidos |
+| CFDI Recibido | `fm_cfdi_recibido` | Link | Sistema calcula / solo lectura | Liga al CFDI Recibido del que se generó esta factura de compra | Al generar la PI desde un CFDI recibido | CFDI recibidos |
+
+---
+
+## Item Customer Detail
+
+Campos de addenda por combinación artículo/cliente (tabla hija dentro de Item).
+
+| Etiqueta | fieldname | Tipo | Origen | Propósito | Cuándo aparece | Flujo que lo usa |
+|---|---|---|---|---|---|---|
+| UOM Addenda (Cliente) | `fm_customer_uom` | Data | Usuario captura | Código de unidad EDI que el cliente espera en la addenda (ej. EA, KGM, PCE) | En la tabla de detalle por cliente del Item | Addendas EDI |
+| Descripción Addenda (Cliente) | `fm_customer_description` | Data | Usuario captura | Descripción del producto según el catálogo del cliente para la addenda | En la tabla de detalle por cliente del Item | Addendas EDI |
+
+---
+
+## Item Group
+
+Campo de clasificación SAT de gasto para CFDI recibidos.
+
+| Etiqueta | fieldname | Tipo | Origen | Propósito | Cuándo aparece | Flujo que lo usa |
+|---|---|---|---|---|---|---|
+| Sufijo SAT de gasto | `fm_codigo_sufijo_sat` | Data | Usuario captura | Sufijo del Código Agrupador SAT (Anexo 24) para la categoría de gasto — 2 dígitos sin punto (ej. 48 combustibles, 50 teléfono) | Siempre | CFDI recibidos (resolución de cuenta de gasto) |
+
+---
+
+## Notas de reconciliación
+
+- **Address:** sus dos custom fields quedan fuera de esta referencia. `fm_gln` (GLN para
+  addenda EDI) no tiene consumidor funcional en código (solo declaración) → categoría legado;
+  `is_your_company_address` es un campo legado sin prefijo `fm_`. Por eso Address no tiene tabla.
+- **Campos calculados de sucursal** (`fm_folio_current`, `fm_last_invoice_date`,
+  `fm_monthly_average`) y **administrativos de folios/certificados**
+  (`fm_folio_warning_threshold`, `fm_share_certificates`, `fm_certificate_ids`) se tratan como
+  configuración operativa/administrativa y se documentan en `referencia/configuracion.md`, no aquí.
+- **Excluidos por legado/sin-consumo** (categoría 5): `fm_folio_reserved`, `fm_pending_amount`,
+  `fm_complementos_count`, `fm_certificate_info`, `fm_branch_health_status`,
+  `fm_auto_selected_branch`, `fm_lista_69b_status`, `fm_gln`, `fm_last_invoice_date`,
+  `fm_monthly_average`, y los 7 campos MOCK de *Draft management*.
+- **Ocultos internos** (categoría 3): `ffm_substitution_source_uuid` (Data, `hidden=1`).

--- a/docs/referencia/configuracion.md
+++ b/docs/referencia/configuracion.md
@@ -1,0 +1,182 @@
+# Referencia de configuración
+
+Esta página es la **referencia de los campos de configuración** de `facturacion_mexico`,
+organizados por su alcance: **por empresa**, **por sucursal** y **por cliente**.
+
+Solo se documentan los campos **configurables aprobados** (obligatorios de implementación,
+opcionales de negocio y operativos/administrativos). Se excluyen los campos calculados,
+de solo lectura sin valor operativo, los metadatos sin uso y los módulos no aprobados
+(Dashboard fiscal, Panel de control, Monitor de salud del sistema, gestión de borradores y
+motor de reglas).
+
+Cada tabla se agrupa por DocType. Los datos (etiqueta, obligatoriedad y valor por defecto) se
+tomaron directamente de la definición `.json` real de cada DocType.
+
+> **Alcance:** "empresa" = un registro por Company · "sucursal" = un registro por Branch ·
+> "cliente" = un registro por Customer/tipo de addenda.
+
+---
+
+## Facturacion Mexico Company Settings — por empresa
+
+DocType de settings principal del app. Un registro por Company (`FMCS-{Company}`).
+Roles con escritura: System Manager y Facturacion Mexico System Manager (Facturacion Mexico
+Manager solo lectura).
+
+| Etiqueta visible | fieldname | Alcance | Obligatorio | Default | Propósito | Si se deja vacío | Funcionalidad que lo usa |
+|---|---|---|---|---|---|---|---|
+| Company | `company` | empresa | Sí (único) | — | Empresa a la que aplica esta configuración. | No aplica (obligatorio). | Clave del registro; todas las lecturas de configuración por empresa. |
+| Modo Sandbox | `sandbox_mode` | empresa | No | 1 (activo) | Activa el modo de pruebas de FacturAPI. | Falsy → opera en modo producción. | Cliente FacturAPI (selección sandbox vs producción). |
+| API Key Producción | `api_key` | empresa | No | — | API Key de producción de FacturAPI.io. | Sin key de producción, el timbrado en producción falla. | Cliente FacturAPI (producción). |
+| API Key Pruebas | `test_api_key` | empresa | No | — | API Key de pruebas (sandbox) de FacturAPI.io. | Sin key sandbox, el timbrado en sandbox falla. | Cliente FacturAPI (sandbox). |
+| Modo Facturación por Defecto | `ereceipt_mode_default` | empresa | No | Normal | Modo por defecto de nuevas Sales Invoice: Normal (timbrado directo) o E-Receipt (recibo para autofacturación). | Se asume Normal. | Handler JS de e-receipts (asigna `fm_ereceipt_mode` en la Sales Invoice). |
+| Método de Pago por Defecto | `metodo_pago_default` | empresa | No | PUE | Método de pago SAT asignado a nuevas Facturas Fiscales Mexico (PUE/PPD). | Fallback a PUE. | Asignación de método de pago en Factura Fiscal Mexico. |
+| Cuenta de Descuentos y Bonificaciones | `cuenta_descuentos` | empresa | No | — | Cuenta de ingresos para notas de crédito por descuento/bonificación (CFDI E, TipoRelación 01). | No se auto-detecta el motivo "Descuento / Bonificación". | Auto-detección de motivo en notas de crédito por descuento. |
+| Enviar Email por Defecto | `send_email_default` | empresa | No | 0 (no) | Envía XML y PDF del CFDI al cliente automáticamente al timbrar. | Falsy → no se envía email automático. | Timbrado (envío de correo). |
+| Descargar PDF/XML automáticamente | `download_files_default` | empresa | No | 1 (sí) | Descarga y adjunta PDF y XML automáticamente al timbrar Factura Fiscal Mexico y Complemento Pago MX. | Falsy → no descarga PDF/XML. | Timbrado (descarga de archivos). |
+| Email Fallback Cliente | `customer_email_fallback` | empresa | No | — | Destinatario usado cuando el cliente no tiene email. | Si el cliente no tiene email, no se envía correo. | Resolución de destinatario de email (3er nivel). |
+| Tipo Vencimiento por Defecto | `ereceipt_expiry_type_default` | empresa | No | Fixed Days | Tipo de vencimiento por defecto de E-Receipts (Fixed Days / End of Month / Custom Date). | Se asume Fixed Days. | Creación de E-Receipts. |
+| Días Vencimiento por Defecto | `ereceipt_expiry_days_default` | empresa | No | 3 | Días de vencimiento por defecto de E-Receipts (aplica con tipo Fixed Days). | Se asume 3 días. | Creación de E-Receipts. |
+| Forma de Pago E-Receipt por Defecto | `ereceipt_payment_form_default` | empresa | No | 28 | Forma de pago SAT para E-Receipts cuando no se obtiene del Payment Entry (28=débito, 04=crédito, 01=efectivo, 03=transferencia). | Fallback a 28 (tarjeta débito). | Creación de E-Receipts. |
+| Forma de Pago Global por Defecto | `global_payment_form_default` | empresa | No | 01 | Forma de pago SAT para facturas globales cuando no hay una forma clara de los receipts. | Fallback a 01 (efectivo). | Construcción de factura global. |
+| Notificar al Timbrar Factura Global | `notify_global_generation` | empresa | No | 0 (no) | Envía notificación por email al timbrar una Factura Global. | Falsy → no notifica. | Notificación al timbrar factura global. |
+| Emails de Notificación Factura Global | `global_notification_emails` | empresa | No | — | Emails (separados por coma) que reciben la notificación de factura global. Depende de "Notificar al Timbrar Factura Global". | Solo se notifica al usuario creador. | Notificación al timbrar factura global. |
+| Incluir Orden de Compra | `pdf_incluir_po_no` | empresa | No | 1 (sí) | Incluye el número de orden de compra del cliente (po_no) en el PDF del CFDI. | Falsy → no incluye po_no en el PDF. | Generación del PDF del CFDI. |
+| Incluir Observaciones | `pdf_incluir_remarks` | empresa | No | 1 (sí) | Incluye el campo Observaciones (remarks) de la Sales Invoice en el PDF del CFDI. | Falsy → no incluye remarks en el PDF. | Generación del PDF del CFDI. |
+| Leyenda PUE | `pdf_nota_pue` | empresa | No | — | Leyenda opcional para facturas con método de pago PUE. | Se omite la leyenda PUE. | Generación del PDF del CFDI. |
+| Leyenda PPD | `pdf_nota_ppd` | empresa | No | — | Leyenda opcional para facturas con método de pago PPD. Admite variables {company}, {total}, {due_date}. | Se omite la leyenda PPD. | Generación del PDF del CFDI. |
+
+!!! warning "E-Receipts y Factura Global — pendientes de validación integral"
+    Los campos con prefijo `ereceipt_*` (modo, vencimiento, forma de pago) configuran el módulo
+    **E-Receipts**, que **no está validado integralmente** (portal/autofactura/expiración sin
+    aprobar). Los campos `global_*` (`notify_global_generation`, `global_notification_emails`,
+    `global_payment_form_default`, y `global_customer`/`global_item`) pertenecen a **Factura
+    Global**, funcionalidad **sin interfaz operable ni validación integral**. Puedes capturarlos,
+    pero **no** están aprobados como operativos. `global_customer` y `global_item` se detallan en la
+    sección final "Factura Global — funcionalidad pendiente de interfaz y validación integral".
+
+---
+
+## Configuracion Fiscal Mexico — por empresa
+
+Configuración fiscal por empresa (wizard STCT/ITT). Un registro por Company (`CFM-{Company}`).
+Roles con escritura: System Manager y Accounts Manager.
+
+| Etiqueta visible | fieldname | Alcance | Obligatorio | Default | Propósito | Si se deja vacío | Funcionalidad que lo usa |
+|---|---|---|---|---|---|---|---|
+| Empresa | `company` | empresa | Sí (único) | — | Empresa a la que aplica la configuración fiscal. | No aplica (obligatorio). | Clave del registro; generador de templates y hooks IEPS. |
+| IVA Exento | `enable_exento` | empresa | No | 0 (no) | Habilita productos/servicios legalmente exentos de IVA. | Falsy → régimen exento no habilitado; no genera fila de mapeo. | Generación de templates fiscales (STCT/ITT). |
+| Zona Fronteriza | `enable_frontera` | empresa | No | 0 (no) | Habilita IVA 8% para la franja fronteriza norte. | Falsy → sin IVA 8% frontera. | Generación de templates fiscales. |
+| IVA tasa 0% / Exportación | `enable_exportacion` | empresa | No | 0 (no) | Habilita IVA tasa 0% (alimentos no industrializados y exportaciones). | Falsy → sin tasa 0%. | Generación de templates fiscales. |
+| IEPS Alcohol | `enable_ieps_alcohol` | empresa | No | 0 (no) | Habilita IEPS de bebidas alcohólicas. | Falsy → IEPS alcohol no disponible. | Generación de templates fiscales. |
+| IEPS Azúcar/Bebidas | `enable_ieps_azucar` | empresa | No | 0 (no) | Habilita IEPS de bebidas con azúcar añadida. | Falsy → no disponible. | Generación de templates fiscales. |
+| IEPS Combustibles | `enable_ieps_combustibles` | empresa | No | 0 (no) | Habilita IEPS de combustibles (cuota fija por litro). | Falsy → no disponible. | Generación de templates fiscales. |
+| IEPS Tabaco | `enable_ieps_tabaco` | empresa | No | 0 (no) | Habilita IEPS de tabaco. | Falsy → no disponible. | Generación de templates fiscales. |
+| Retenciones Honorarios | `enable_ret_honorarios` | empresa | No | 0 (no) | Habilita retenciones de servicios profesionales (ISR + IVA). | Falsy → sin retención de honorarios. | Generación de templates fiscales. |
+| Retenciones Arrendamiento | `enable_ret_arrendamiento` | empresa | No | 0 (no) | Habilita retenciones por arrendamiento de inmuebles (ISR + IVA). | Falsy → sin retención de arrendamiento. | Generación de templates fiscales. |
+| Retenciones Autotransporte | `enable_ret_autotransporte` | empresa | No | 0 (no) | Habilita retención IVA 4% de autotransporte terrestre de carga federal. | Falsy → sin retención de autotransporte. | Generación de templates fiscales. |
+| Retenciones RESICO | `enable_ret_resico` | empresa | No | 0 (no) | Habilita retenciones RESICO (ISR + IVA) a personas físicas. | Falsy → sin retención RESICO. | Generación de templates fiscales. |
+| Tasa ISR RESICO | `tasa_isr_resico` | empresa | No (depende de Retenciones RESICO) | 1.25 | Porcentaje de retención ISR para RESICO. | Se usa 1.25% por defecto. | Cálculo de retención RESICO. |
+| Cuentas de Impuestos | `mapeo_cuentas` | empresa | Sí | — | Tabla de mapeo de cuentas contables de impuestos (Mapeo Cuenta Fiscal Mexico). | Bloquea el guardado (obligatorio); sin filas no hay cuentas de impuesto. | Hooks IEPS y generación de templates. |
+| Precios de venta incluyen impuestos | `sales_prices_include_tax` | empresa | No | 0 (no) | Marca el impuesto como incluido en el precio capturado en los STCT de venta generados por el app. | Falsy → el STCT no marca impuesto incluido en el precio. | Generación de templates fiscales (STCT). |
+
+---
+
+## Configuracion Fiscal Sucursal — por sucursal
+
+Configuración fiscal por Branch. Un registro por sucursal (naming `CFS-.YYYY.-`). La empresa se
+obtiene automáticamente de la sucursal. Roles con escritura: System Manager y Accounts Manager
+(Accounts User solo lectura).
+
+| Etiqueta visible | fieldname | Alcance | Obligatorio | Default | Propósito | Si se deja vacío | Funcionalidad que lo usa |
+|---|---|---|---|---|---|---|---|
+| Series | `naming_series` | sucursal | Sí | — | Serie de nomenclatura del registro (CFS-.YYYY.-). | No aplica (obligatorio). | Nomenclatura del documento. |
+| Sucursal | `branch` | sucursal | Sí (único) | — | Branch al que aplica la configuración. | No aplica (obligatorio). | Clave del registro; selector de certificados y migración. |
+| IDs de Certificados | `certificate_ids` | sucursal | No | — | Certificados (CSD) asignados a esta sucursal (arreglo JSON). | Sin certificados asignados a la sucursal. | Selector de certificados multi-sucursal. |
+| Umbral de Advertencia | `folio_warning_threshold` | sucursal | No | 100 | Folios restantes que disparan una advertencia de folios bajos. | Se asume 100. | Alertas de folios de la sucursal. |
+| Umbral Crítico | `folio_critical_threshold` | sucursal | No | 50 | Folios restantes que disparan una alerta crítica. | Se asume 50. | Validación (debe ser menor que el umbral de advertencia). |
+| Activa | `is_active` | sucursal | No | 1 (activa) | Indica si la sucursal está activa para facturación. | Falsy → sucursal inactiva. | Filtro de sucursales activas. |
+| Necesita Atención | `needs_attention` | sucursal | No | 0 (no) | Marca que la sucursal requiere atención del usuario. | Falsy → sin alerta. | Gestor de sucursales (branch manager). |
+
+> Los demás campos del DocType (`company`, `serie_fiscal`, `folio_current`) se obtienen
+> automáticamente del Branch (`fetch_from`), y las estadísticas (`last_invoice_date`,
+> `monthly_average`, `days_until_exhaustion`, `total_invoices_generated`, `last_sync_date`,
+> `created_automatically`) son de solo lectura y calculadas; no son configurables y se excluyen.
+
+---
+
+## Configuracion CFDI Recibidos — por empresa
+
+Configuración del wizard de CFDIs recibidos. Un registro por Company (`CFDI-REC-CFG-{Company}`).
+Roles con escritura: System Manager, Accounts Manager y Facturacion Mexico Manager.
+
+| Etiqueta visible | fieldname | Alcance | Obligatorio | Default | Propósito | Si se deja vacío | Funcionalidad que lo usa |
+|---|---|---|---|---|---|---|---|
+| Empresa | `company` | empresa | Sí (único) | — | Empresa a la que aplica la configuración de CFDIs recibidos. | No aplica (obligatorio). | Clave del registro; servicios de CFDI recibidos. |
+| Reglas de Impuesto | `reglas_impuesto` | empresa | No | — | Tabla de reglas por tipo de impuesto recibido en CFDIs de proveedores (Regla Impuesto CFDI Recibido). | Sin reglas de impuesto de compra. | Generación del Purchase Taxes and Charges Template. |
+| Condiciones de Pago por Defecto (Proveedor) | `default_payment_terms_supplier` | empresa | No | — | Condiciones de pago asignadas a proveedores nuevos creados desde CFDI Recibidos (no sobrescribe existentes). | No asigna condiciones a proveedores nuevos. | Resolución de proveedor (supplier_resolver). |
+| Mapeo de Departamentos | `mapeo_departamentos` | empresa | No | — | Tabla que mapea cada Departamento ERPNext a la familia de gasto SAT 601-604 (Mapeo Departamento CFDI Recibido). | Sin clasificación de departamento a familia SAT. | Procesamiento/clasificación de CFDIs recibidos. |
+| Modo de resolución contable | `modo_resolucion_contable` | empresa | No | Manual | Define cómo se obtiene la cuenta de gasto al generar Purchase Invoice Drafts (Manual / Automatico CoA SAT). | Se asume Manual (el usuario asigna la cuenta por concepto). | Constructor de Purchase Invoice desde CFDI recibido. |
+| Formato CoA | `formato_coa` | empresa | No (depende de modo Automatico CoA SAT) | — | Formato del account_number del CoA de la empresa (########, ###-##-###, ###.##.###). | Solo aplica en modo automático; sin formato no resuelve la cuenta. | Constructor de Purchase Invoice (modo automático). |
+| Tolerancia Absoluta (MXN) | `tolerancia_total_absoluta` | empresa | No | 1.00 | Diferencia máxima en MXN entre el total del XML CFDI y el total calculado por ERPNext. | Se asume 1.00 MXN. | Validación de totales al construir Purchase Invoice. |
+| Tolerancia Porcentual (%) | `tolerancia_total_porcentual` | empresa | No | 0.5 | Porcentaje máximo del total del XML admitido como diferencia (0.5 = 0.5%). | Se asume 0.5%; el valor 0 desactiva esta tolerancia. | Validación de totales al construir Purchase Invoice. |
+
+> Los campos `purchase_taxes_template`, `wizard_completado` y `ultima_generacion` son de solo
+> lectura (los escribe el wizard) y se excluyen.
+
+---
+
+## Configuracion Reclasificacion Fiscal Mexico — por empresa
+
+Configuración de reclasificación de impuestos al cobro/pago. Un registro por Company
+(`CRFM-{Company}`). Roles con escritura: System Manager y Accounts Manager.
+
+| Etiqueta visible | fieldname | Alcance | Obligatorio | Default | Propósito | Si se deja vacío | Funcionalidad que lo usa |
+|---|---|---|---|---|---|---|---|
+| Empresa | `company` | empresa | Sí (único) | — | Empresa a la que aplica la reclasificación fiscal. | No aplica (obligatorio). | Clave del registro. |
+| Reglas | `reglas` | empresa | No | — | Tabla de reglas de reclasificación de impuestos (Regla Reclasificacion Fiscal): cuenta origen → cuenta destino al cobro/pago. | Sin reglas que aplicar. | Acciones "Cargar Reglas" y "Aplicar" del DocType. |
+
+> Los campos `ultima_deteccion`, `ultima_generacion` (de solo lectura) e `instrucciones_html`
+> (contenido HTML estático informativo) se excluyen por no ser configurables.
+
+---
+
+## Addenda Configuration — por cliente
+
+Configuración de addenda por Customer y tipo de addenda (`ADCFG-{Customer}-{Addenda Type}-{###}`).
+Roles con escritura: System Manager y Accounts Manager (Accounts User solo lectura).
+
+| Etiqueta visible | fieldname | Alcance | Obligatorio | Default | Propósito | Si se deja vacío | Funcionalidad que lo usa |
+|---|---|---|---|---|---|---|---|
+| Cliente | `customer` | cliente | Sí | — | Cliente al que aplica esta configuración de addenda. | No aplica (obligatorio). | Clave del registro. |
+| Tipo de Addenda | `addenda_type` | cliente | Sí | — | Tipo de addenda asociado (Addenda Type). | No aplica (obligatorio). | Detector automático de addenda. |
+| Activo | `is_active` | cliente | No | 1 (activo) | Indica si esta configuración de addenda está activa. | Falsy → la configuración se ignora. | Filtro de configuraciones activas en detección/aplicación. |
+| Aplicar Automáticamente | `auto_apply` | cliente | No | 1 (sí) | Aplica la addenda automáticamente al facturar. | Falsy → no se aplica automáticamente. | Aplicación automática de addenda. |
+| Fecha de Inicio | `effective_date` | cliente | No | — | Inicio de vigencia de la configuración. | Sin límite inferior de vigencia. | Validación de vigencia. |
+| Fecha de Fin | `expiry_date` | cliente | No | — | Fin de vigencia de la configuración. | Sin límite superior de vigencia. | Validación de vigencia. |
+| Valores de Campos | `field_values` | cliente | No | — | Tabla de valores de los campos de la addenda (Addenda Field Value). | Sin valores de campos para la addenda. | Gestor de addendas multi-sucursal. |
+
+> Los campos de auditoría (`creation_date`, `modified_date`, `created_by`, `modified_by`) son de
+> solo lectura y se excluyen.
+>
+> **Nota de metadata:** el DocType declara `sort_field: priority` y `search_fields: customer,addenda_type`,
+> pero el campo `priority` **no está definido** en la lista de campos del `.json`. Es una
+> inconsistencia de metadata (no un campo configurable).
+
+---
+
+## Factura Global — funcionalidad pendiente de interfaz y validación integral
+
+Los siguientes campos de **Facturacion Mexico Company Settings** pertenecen a la Factura Global.
+**No están operativos desde la interfaz de usuario**: la Factura Global es funcional a nivel de
+API/integración pero **no tiene un camino operable desde la UI**, y no ha pasado validación
+integral. Se listan solo como referencia; **no** se consideran configuración aprobada para uso
+desde interfaz.
+
+| Etiqueta visible | fieldname | Alcance | Obligatorio | Default | Propósito | Si se deja vacío | Funcionalidad que lo usa |
+|---|---|---|---|---|---|---|---|
+| Customer Público en General | `global_customer` | empresa | No | — | Customer configurado como Público en General (RFC XAXX010101000, régimen 616), receptor de las facturas globales. | No se puede construir la factura global (receptor faltante). | Constructor CFDI de factura global. |
+| Item Concepto Factura Global | `global_item` | empresa | No | — | Item que representa el concepto de ventas agrupadas en la factura global (debe tener clave y unidad SAT). | Falta el concepto para la factura global. | Constructor CFDI de factura global. |
+
+> Advertencia: mientras la Factura Global no cuente con interfaz operable ni validación integral,
+> configurar estos campos no habilita el flujo desde la UI.

--- a/docs/tecnico/reconciliacion-fallback.md
+++ b/docs/tecnico/reconciliacion-fallback.md
@@ -1,0 +1,254 @@
+# Reconciliación FFM ↔ FacturAPI y fallback de timbrado
+
+> **Estado:** este documento describe los mecanismos de resiliencia **vigentes**:
+>
+> 1. **Reconciliación FFM ↔ FacturAPI** (consultas GET de solo lectura, por scheduler y botón
+>    manual): el código está presente; **pendiente de una prueba operativa controlada** (no
+>    ejecutada aún).
+> 2. **Fallback de timbrado**: persistencia de la respuesta RAW del PAC en un archivo bajo
+>    **archivos privados del sitio**, con advertencia visible al usuario. El archivo conserva la
+>    evidencia, pero **no es por sí mismo una recuperación automática**.
+>
+> El mecanismo histórico de recuperación por `/tmp` con `api_backup.py` fue **removido** (PR #142) y
+> **ya no forma parte de la arquitectura**; no se documenta aquí.
+
+---
+
+## 1. Propósito
+
+La reconciliación mantiene el estado local de cada **Factura Fiscal Mexico (FFM)** alineado
+con el estado real del CFDI en **FacturAPI** (el PAC). Su única operación contra el PAC es
+un **GET de solo lectura** (`client.get_invoice(facturapi_id)`); nunca timbra ni cancela.
+
+Resuelve el hueco entre "el PAC ya hizo algo" y "el sistema local lo refleja": timbrados o
+cancelaciones cuya respuesta se perdió por timeout, fallo de BD o error posterior a una
+respuesta exitosa del PAC. La verdad fiscal siempre reside en el PAC/SAT; el estado local
+es una proyección que la reconciliación acerca a esa verdad.
+
+**Fuente:** `facturacion_fiscal/services/ffm_reconciliation.py` (docstring del módulo y
+`_reconcile_ffm`).
+
+> **Garantía de diseño (docstring del módulo):** *"nunca create_invoice / cancel_invoice;
+> nunca busca otro FFM por Sales Invoice; nunca cancela ni guarda la Sales Invoice"*. La
+> reconciliación **no debe retimbrar ni cancelar** documentos por iniciativa propia fuera de
+> los flujos diseñados. La única excepción acotada es completar la cancelación **documental**
+> (no fiscal, sin llamar al PAC) de un CFDI ya CANCELADO que es origen de una sustitución
+> motivo 01 con sustituto TIMBRADO vigente (`_reconcile_substitution_documental`).
+
+---
+
+## 2. Ejecución automática por scheduler
+
+Frecuencias reales declaradas en `hooks.py` (`scheduler_events`):
+
+| Frecuencia | Función | Rol |
+|---|---|---|
+| `hourly_long` | `facturacion_fiscal.services.ffm_reconciliation.run_auto_reconciliation` | Reconciliación FFM ↔ FacturAPI por lote. Solo GET; nunca timbra ni cancela. |
+| `cron: * * * * *` (cada minuto) | `facturacion_fiscal.timbrado_api.retry_pending_substitution_cancellations` | Reintento diferido de cancelaciones motivo 01 (sustitución) que quedaron `PENDIENTE_CANCELACION`. |
+| `weekly` | `facturacion_fiscal.tasks.sync_folio_fiscal_scheduled` | Red de seguridad: reconcilia `SI.fm_folio_fiscal` con `FFM.folio`. Idempotente, **sin** FacturAPI. |
+
+`run_auto_reconciliation(limit=None)` es el punto de entrada del scheduler y de ejecución
+manual por lote. Adquiere el lock global de lote, selecciona candidatos, procesa cada FFM de
+forma aislada (un fallo no detiene el lote: `frappe.log_error` + continúa) y devuelve un
+resumen con `selected/processed/changed/unchanged/pending/errors/locked`.
+
+**Fuente:** `hooks.py` (líneas 447–479); `ffm_reconciliation.py::run_auto_reconciliation`.
+
+---
+
+## 3. Botón manual "Verificar estado en FacturAPI"
+
+En el formulario de **Factura Fiscal Mexico** existe el botón **"Verificar estado en
+FacturAPI"** (grupo "Comprobantes"), visible para cualquier FFM guardado que tenga
+`facturapi_id`, sin importar su estado de sync/cancelación.
+
+- Llama a `ffm_reconciliation.reconcile_ffm(ffm_name)` (whitelisted) con `freeze: true`
+  (congela la UI e impide doble clic durante la consulta).
+- El JS **solo** consulta, traduce el `outcome` a un texto breve
+  (`changed/unchanged/locked/pending/error`) y recarga el formulario. **No** interpreta
+  `status`/`cancellation_status`, **no** decide estados ni escribe campos: toda la lógica y
+  la seguridad viven en el servidor.
+- `reconcile_ffm` valida que el FFM exista y aplica `frappe.only_for(FISCAL_ROLES)` — los
+  mismos roles que la cancelación fiscal (`System Manager`, `Facturacion Mexico System
+  Manager`, `Facturacion Mexico Manager`, idénticos a `cancel_ffm_keep_si`, PR #197).
+
+Tanto el botón manual como el lote automático ejecutan **exactamente** el mismo núcleo
+`_reconcile_ffm`.
+
+**Fuente:** `factura_fiscal_mexico.js` (líneas ~2735–2778);
+`ffm_reconciliation.py::reconcile_ffm`.
+
+---
+
+## 4. Selección de candidatos, locks e idempotencia
+
+### Selección de candidatos
+
+`_select_candidates(limit=None)` (SQL de **solo lectura**) selecciona FFM que tengan
+`facturapi_id` **y** estén `fm_sync_status = 'pending'` **o** `status =
+'PENDIENTE_CANCELACION'`. Orden de prioridad:
+
+1. Cancelación (`PENDIENTE_CANCELACION`) primero.
+2. `pending` primero.
+3. `fm_last_pac_sync` más antiguo (NULL primero).
+4. `name`.
+
+`BATCH_SIZE = 100` es el límite por defecto. El SQL crudo se usa porque el `ORDER BY` con
+`CASE` no es expresable en `frappe.get_all`; no modifica datos.
+
+### Locks (Redis, distribuidos, no bloqueantes, con TTL)
+
+| Lock | Prefijo | TTL |
+|---|---|---|
+| Lote global | `facturacion_mexico:ffm_auto_reconciliation` | 2 horas |
+| Por FFM | `facturacion_mexico:ffm_reconciliation:<ffm>` | 5 minutos |
+
+- Adquisición atómica no bloqueante con `SET NX EX` (`_acquire_lock`); devuelve un token de
+  propietario o `None` si ya está ocupado.
+- Liberación segura por **compare-and-delete atómico** vía script Lua (`_release_lock`): solo
+  borra la clave si su valor sigue siendo el token del dueño, evitando que un proceso cuyo
+  lock expiró borre el de otro. Se libera **siempre** en `finally`.
+- Namespacing por sitio (`_lock_key` → `frappe.local.site:...`) para benches multi-sitio.
+- Si el FFM ya está bloqueado, `_reconcile_ffm` devuelve `outcome = "locked"` sin tocar nada.
+- Para la cancelación documental de sustitución se usa el mismo lock por documento que la
+  cascada/scheduler (`ffm:cascade:<ffm>`) para evitar carreras.
+
+### Idempotencia
+
+- Sin cambios detectados: **no** se crea Response Log; solo se sella `fm_last_pac_sync` con la
+  hora de la consulta exitosa.
+- Los errores de consulta (timeout / 4xx / 5xx) **conservan** `fm_last_pac_sync` previo: un
+  error no cuenta como última consulta exitosa (`_log_and_set_sync`).
+- La aplicación del estado de cancelación (`apply_cancellation_state`) es **idempotente y
+  monotónica**: relee siempre desde BD, escribe solo campos que cambian, y una fecha de
+  cancelación existente nunca se sobrescribe.
+
+**Fuente:** `ffm_reconciliation.py` (`_select_candidates`, `_acquire_lock`, `_release_lock`,
+`_lock_key`, `_reconcile_ffm`); `cancellation_state.py::apply_cancellation_state`.
+
+---
+
+## 5. Estados que actualiza y protección contra degradar CANCELADOS
+
+Tras un GET exitoso, la reconciliación valida **primero** la correlación estricta
+(`_resolve_validated_ffm`: el FFM explícito debe coincidir por `name`, pertenecer a la misma
+Sales Invoice, y no contradecir UUID/`facturapi_id`). Una contradicción lanza
+`FiscalCorrelationError`, registra alerta crítica, marca `fm_sync_status = error` y **no**
+toca el estado fiscal.
+
+Luego decide **explícitamente** si la respuesta corresponde a una cancelación
+(`is_cancellation`): lo es si el FFM ya está en `PENDIENTE_CANCELACION`/`CANCELADO`, si el
+estado remoto es `canceled`, o si hay `cancellation_status` en
+`pending/verifying/accepted/rejected/expired`. Según eso deriva estado con
+`derive_cancellation_reconciliation` (acotado, fail-closed) o `derive_pac_reconciliation`.
+
+Estados objetivo posibles: `TIMBRADO`, `PENDIENTE_CANCELACION`, `CANCELADO`, y
+`fm_sync_status` en `synced/pending/error`.
+
+### Protecciones contra degradar un estado de cancelación
+
+- **CORR-1 (decisión explícita):** una FFM ya `CANCELADO` **no** se degrada por una respuesta
+  `valid` que carezca de estado de cancelación. El branch de cancelación se elige por
+  decisión explícita, no solo por el estado derivado.
+- **Monotonicidad (`apply_cancellation_state`):** *"una FFM CANCELADO no se degrada a
+  PENDIENTE/TIMBRADO por una respuesta vieja"*. `CANCELADO → CANCELADO` sí ejecuta la parte
+  reparadora (completa `reason`/`date`/`sync`/snapshot SI faltantes) sin degradar.
+- **GAP 2 (sustitución en curso):** si A está `PENDIENTE_CANCELACION`, es origen de una
+  sustitución motivo 01 con sustituto B TIMBRADO vigente, y la reconciliación derivaría
+  `TIMBRADO` (el DELETE aún no se registró en el PAC), se **conserva** `PENDIENTE_CANCELACION
+  + pending` para que el scheduler dedicado siga reintentando. `run_auto_reconciliation`
+  **no** envía DELETE ni cancela: solo evita borrar un estado de cancelación activa con
+  evidencia de sustitución.
+- **Persistencia autoritativa separada:** en cancelación, el estado de negocio lo persiste
+  **exclusivamente** `apply_cancellation_state` (`skip_state_persist=True` en el writer), que
+  crea el Response Log pero **no** persiste el estado fiscal, evitando doble escritura.
+
+**Fuente:** `ffm_reconciliation.py::_reconcile_ffm` (CORR-1, GAP 2);
+`cancellation_state.py` (`derive_cancellation_reconciliation`, `apply_cancellation_state`);
+`api/__init__.py::PACResponseWriter._resolve_validated_ffm`.
+
+---
+
+## 6. Sincronización del folio fiscal
+
+`SI.fm_folio_fiscal` es una **proyección de cache de solo lectura** para reportes de Cuentas
+por Cobrar; la fuente fiscal sigue siendo la FFM. Se sincroniza con el consecutivo del CFDI
+**vigente** (`FFM.folio` — el consecutivo, **no** el UUID/timbre).
+
+- **En vivo:** `apply_cancellation_state` invoca `sincronizar_folio_fiscal(si)` al proyectar
+  el snapshot de la SI (limpia el folio si la FFM dejó de ser vigente, p. ej. CANCELADO).
+- **Red de seguridad (weekly):** `sync_folio_fiscal_scheduled` recorre SIs con FFM ligada o
+  folio ya escrito, y reconcilia/limpia el folio. Es **idempotente**, escribe con
+  `update_modified=False` (no altera el timestamp de auditoría) y **no** usa FacturAPI: solo
+  lee campos internos ya persistidos. Vigente = la FFM ligada tiene folio y su status está en
+  `{TIMBRADO, PENDIENTE_CANCELACION}`.
+
+**Fuente:** `facturacion_fiscal/utils.py::sincronizar_folio_fiscal`;
+`facturacion_fiscal/tasks.py::sync_folio_fiscal_scheduled`;
+`cancellation_state.py::apply_cancellation_state`.
+
+---
+
+## 7. Persistencia de respuestas RAW del PAC (fallback de timbrado)
+
+### Persistencia de respuestas RAW del PAC (`PACResponseWriter`)
+
+La persistencia se apoya en `PACResponseWriter` (`api/__init__.py`). Principio: **PAC
+Response First** — la respuesta del PAC se registra íntegra y su estado fiscal se persiste
+**primero e independientemente** del Response Log de auditoría:
+
+- **PASO 1 — estado fiscal:** `_update_factura_fiscal` valida correlación estricta y persiste
+  estado/UUID/`facturapi_id`/`fm_sync_status` en el FFM, con commit. Un fallo aquí **relanza**
+  (alerta crítica) y **no** se crea Response Log ni se reporta éxito.
+- **PASO 2 — Response Log:** `_write_to_database` crea el "FacturAPI Response Log" con la
+  respuesta **RAW** completa (`raw_response` si existe, o el payload completo) y adjunta el
+  JSON como File privado. Va **aislado con savepoint**: si su inserción falla, se revierte
+  **solo** el log (rollback al savepoint); el FFM ya persistido permanece intacto y **no** se
+  degrada.
+- **PASO 3 — enlace de auditoría:** se enlaza `fm_last_response_log`; su fallo no revierte ni
+  el FFM ni el log.
+
+`FiscalCorrelationError` **nunca** se degrada a `{success: False}` ni al fallback de
+filesystem: representa una contradicción de integridad fiscal, no una indisponibilidad de BD;
+se propaga para detener el flujo.
+
+### Comportamiento ante fallo posterior a una respuesta exitosa del PAC
+
+- **Timbrado (PAC OK, persistencia principal del writer falló):** se hace una **lectura nueva
+  de BD** con `_verify_timbrado_persisted` (¿el FFM quedó `TIMBRADO` con UUID/`facturapi_id`
+  coincidentes?). Si la FASE 3 lo recuperó → `sync = synced`; si no → `sync = error` e
+  intervención manual. **No** se re-llama al PAC.
+- **Cancelación (PAC OK, Frappe falló después):** si el writer sí persistió, se conserva el
+  manejo existente; si la persistencia principal también falló, el estado local puede quedar
+  temporalmente **sin reflejar** la cancelación. El mecanismo que realinea el estado local con la
+  verdad de FacturAPI en una corrida posterior es la **reconciliación** (GET, ver §1–§5). **No** se
+  re-llama al PAC en el momento del fallo.
+
+**Fuente:** `api/__init__.py::PACResponseWriter` (`write_pac_response`, `_update_factura_fiscal`,
+`_write_to_database`, `_resolve_validated_ffm`); `timbrado_api.py::_verify_timbrado_persisted`.
+
+---
+
+## 8. Aclaraciones explícitas (con evidencia)
+
+- **Ya NO se usa recuperación mediante `/tmp`.** El directorio de fallback se calcula por
+  sitio en `sites/<site>/private/files/facturacion_mexico_pac_fallback`
+  (`_get_fallback_dir`, con `chmod 0700`). La ruta `/tmp/facturacion_mexico_pac_fallback`
+  solo aparece como **último recurso** dentro del `except` de `_get_fallback_dir` (si no se
+  puede resolver el path del sitio) y en código de tests/validadores — **no** como mecanismo
+  primario. La estrategia primaria de persistencia es **BD**; el fallback file conserva la
+  evidencia RAW pero **no constituye por sí mismo una recuperación automática**.
+- **`api_backup.py` ya NO existe.** Verificado: `find . -iname "*api_backup*"` no devuelve
+  ningún archivo en el repositorio.
+- **Reconciliación pendiente de validación operativa.** La reconciliación (GET) está presente pero
+  **pendiente de una prueba operativa controlada** (roadmap interno). No debe describirse como
+  "operativa" ni "validada" hasta ejecutar esa prueba.
+- **La reconciliación NO retimbra ni cancela por iniciativa propia.** Su única llamada al PAC
+  es un GET de solo lectura; nunca `create_invoice`/`cancel_invoice`, nunca cancela/guarda la
+  Sales Invoice, nunca busca otro FFM por Sales Invoice. La única acción de convergencia fuera
+  del GET es completar la cancelación **documental** (sin PAC) de un caso de sustitución
+  motivo 01 ya CANCELADO fiscalmente, de forma idempotente y acotada.
+
+**Fuente:** `api/__init__.py::_get_fallback_dir`; verificación `find`;
+`working_docs/active/auditoria_manual/I_scope_roadmap.md`;
+`ffm_reconciliation.py` (docstring del módulo y `_reconcile_ffm`).

--- a/docs/usuario/addendas.md
+++ b/docs/usuario/addendas.md
@@ -123,6 +123,16 @@ El paso 4 anterior cubre la Address de la Company. Antes de emitir, confirma que
 - `fm_invoice_creator_gln` en el Customer tiene el GLN correcto del nodo `InvoiceCreator`
 - Todos los campos GLN del Customer están llenos (pasos 2)
 
+### 7. Propagación automática y generación
+
+Los datos de addenda del **Customer** se **propagan automáticamente** a la Sales Invoice al validarla:
+si el cliente tiene `fm_requires_addenda` activo, la SI hereda `fm_requires_addenda` y
+`fm_default_addenda_type`. No hay que capturar el tipo de addenda en cada factura.
+
+La **addenda se genera antes del timbrado** (pre-timbrado): al crear la Factura Fiscal / timbrar, el
+sistema construye el XML de addenda a partir del template del *Addenda Type* y los datos EDI
+(GLN, códigos de producto por cliente, UOM, descripción) y lo incorpora al CFDI.
+
 ---
 
 ## Emitir una factura con addenda

--- a/docs/usuario/cancelar-cfdi.md
+++ b/docs/usuario/cancelar-cfdi.md
@@ -35,8 +35,13 @@ Este camino cancela el CFDI sin emitir uno nuevo.
 ### Pasos
 
 1. Abrir el **Sales Invoice** timbrado (`fm_fiscal_status = TIMBRADO`)
-2. Desde el Sales Invoice → abrir la **Factura Fiscal Mexico** (botón **"Ver Factura Fiscal"**)
+2. Desde el Sales Invoice → abrir la **Factura Fiscal Mexico** (botón **"Abrir Factura Fiscal"**)
 3. En el FFM → sección **Cancelación** → seleccionar el **motivo** (02, 03 o 04)
+
+> Los motivos **02, 03 y 04** se procesan **desde la Factura Fiscal Mexico**. El motivo **01
+> no se ejecuta mediante cancelación directa**: se realiza por **sustitución**, que inicia desde el
+> Sales Invoice con el botón **"Sustituir CFDI (01)"** (ver Camino B). El sistema crea una factura de
+> reemplazo y cancela el CFDI anterior mediante la cascada de sustitución.
 4. Confirmar
 
 El sistema envía la **solicitud** de cancelación a FacturAPI.io. Que FacturAPI reciba la solicitud

--- a/docs/usuario/cfdi-recibidos.md
+++ b/docs/usuario/cfdi-recibidos.md
@@ -20,6 +20,34 @@ Cargar XML → Resolver proveedor → Asignar departamento → Clasificar items 
 | `Convertido a PI` | Purchase Invoice Draft creada |
 | `Error conversión` | Falló la conversión — revisar `error_message` |
 
+Además: **`No Procesar`** — CFDI marcado para excluirlo del flujo (reversible con *Reactivar CFDI*).
+
+---
+
+## Acciones disponibles (lista y formulario)
+
+**Desde la vista de lista** (procesamiento por lotes):
+
+| Botón | Qué hace |
+|---|---|
+| **Cargar XML** | Sube uno o varios XML de CFDI recibidos (dedup por UUID). |
+| **Generar proveedores faltantes** | Crea los Supplier que faltan a partir del RFC/nombre del emisor. |
+| **Asignar Departamentos** | Asigna el departamento (cost center) según el mapeo configurado. |
+| **Clasificar automáticamente** | Clasifica los conceptos con `item_code` según las reglas de mapeo. |
+| **Generar PIs pendientes** | Crea en lote las Purchase Invoice de los CFDI ya `Clasificado`. |
+
+**Desde el formulario del CFDI Recibido:**
+
+| Botón | Qué hace |
+|---|---|
+| **Resolver Items pendientes** | Asigna manualmente el item_code de los conceptos sin clasificar. |
+| **Generar Purchase Invoice** | Crea la Purchase Invoice (Draft) de ese CFDI. |
+| **Marcar No Procesar** | Excluye el CFDI del flujo (pasa a `No Procesar`). |
+| **Reactivar CFDI** | Revierte *No Procesar* y devuelve el CFDI al flujo. |
+
+Las etapas por las que transita cada CFDI son las de la tabla anterior: **Falta proveedor → Falta
+departamento → Falta clasificación → Clasificado → Convertido a PI** (o **No Procesar**).
+
 ---
 
 ## Paso 1 — Cargar XMLs

--- a/docs/usuario/complemento-pago.md
+++ b/docs/usuario/complemento-pago.md
@@ -26,6 +26,26 @@ No se requiere acción manual — el complemento se genera al hacer Submit del P
 
 ---
 
+## Botón manual, bloqueos y reclasificación
+
+**Botón manual.** Cuando corresponda (por ejemplo, si el complemento no se generó automáticamente),
+el Payment Entry ofrece el botón **"Crear Complemento de Pago"**. Si ya existe uno vinculado, en su
+lugar aparece **"Ver Complemento de Pago"**.
+
+**Bloqueo al cancelar el Payment Entry.** Si el Payment Entry tiene un **complemento fiscal activo**,
+el sistema **impide cancelarlo**: primero debes cancelar el Complemento de Pago. El bloqueo se muestra
+con un mensaje claro.
+
+**Bloqueo al cancelar la factura.** Mientras exista un complemento activo asociado, no se permite
+cancelar la Sales Invoice: hay que cancelar antes el complemento.
+
+**Reclasificación fiscal del Payment Entry (automatismo administrativo).** Al validar el Payment
+Entry, el sistema **carga/reclasifica automáticamente los impuestos** del pago según las reglas
+fiscales configuradas por empresa. Es un proceso interno de contabilidad fiscal; no requiere
+intervención del operador.
+
+---
+
 ## Prerequisitos
 
 - La Sales Invoice debe tener `fm_payment_method_sat = PPD`

--- a/docs/usuario/emitir-cfdi.md
+++ b/docs/usuario/emitir-cfdi.md
@@ -9,7 +9,7 @@ Guía del flujo completo: Sales Invoice → Factura Fiscal Mexico → Timbrado.
 El timbrado en facturacion_mexico tiene dos documentos:
 
 - **Sales Invoice** — la venta en ERPNext. Se submittea normalmente.
-- **Factura Fiscal Mexico (FFM)** — el documento fiscal. Se crea la primera vez que haces clic en **"Timbrar Factura"** sobre el Sales Invoice, y es donde ocurre el timbrado real.
+- **Factura Fiscal Mexico (FFM)** — el documento fiscal. Se crea la primera vez que haces clic en **"Crear Factura Fiscal"** sobre el Sales Invoice, y es donde ocurre el timbrado real.
 
 > **Un solo FFM activo por Sales Invoice.** La creación del FFM la resuelve el servidor: la primera vez crea el documento y lo vincula; las siguientes veces reutiliza el mismo. No se pueden generar dos facturas fiscales activas para la misma venta.
 
@@ -58,12 +58,16 @@ Antes de hacer Submit, verificar:
 ### 2. Submit del Sales Invoice
 
 Al hacer Submit:
-- El Sales Invoice muestra el botón **"Timbrar Factura"** como acción primaria
+- El Sales Invoice muestra el botón **"Crear Factura Fiscal"** como acción primaria
 - Todavía **no** existe Factura Fiscal Mexico — se crea en el siguiente paso
 
 ### 3. Generar / abrir la Factura Fiscal Mexico
 
-Clic en **"Timbrar Factura"** en el Sales Invoice:
+> **Dos pasos, dos botones distintos:**
+> 1. En el **Sales Invoice** → **"Crear Factura Fiscal"** (crea/abre la Factura Fiscal Mexico).
+> 2. Dentro de la **Factura Fiscal Mexico** → **"Timbrar con FacturAPI"** (envía el CFDI al PAC; paso 5).
+
+Clic en **"Crear Factura Fiscal"** en el Sales Invoice:
 - Si la venta aún no tiene FFM, el servidor **crea** uno en estado `BORRADOR`, lo vincula y te lleva a él.
 - Si ya tiene un FFM activo, **reutiliza** el existente y te lleva a él (no crea otro).
 - Si el FFM ya está `TIMBRADO`, el sistema avisa que no se puede volver a timbrar.

--- a/docs/usuario/ereceipts.md
+++ b/docs/usuario/ereceipts.md
@@ -1,5 +1,13 @@
 # E-Receipts y Autofactura
 
+!!! warning "Funcionalidad pendiente de validación integral"
+    Existe implementación parcial de E-Receipts, pero **el flujo completo contra FacturAPI y el
+    portal de autofacturación no ha sido validado integralmente ni aprobado para producción ni
+    capacitación**. Esta página describe el comportamiento **de diseño según el código**; no debe
+    tomarse como guía operativa aprobada. En particular, **no** están validados: el portal de
+    autofactura, la autofacturación por el receptor, ni la expiración automática. Ver el estado en
+    `working_docs/active/auditoria_manual/I_scope_roadmap.md` (F-01).
+
 Los E-Receipts son recibos digitales para ventas a público en general. El cliente puede
 autofacturarse en un portal web con su RFC, sin intervención del operador.
 
@@ -123,15 +131,18 @@ estado operativo (`fm_fiscal_status = E-RECEIPT`). Los datos fiscales se leen de
 
 ## Factura Global
 
-Si el cliente no se autofactura antes de que expire el receipt, la empresa puede incluirlo
-en una **Factura Global** periódica (mensual, quincenal, etc.) que cubre todos los receipts
-abiertos del período.
+!!! warning "Factura Global — pendiente de interfaz y validación integral"
+    La **Factura Global** existe a nivel de API (métodos del servidor) pero **no cuenta con una
+    interfaz de usuario completa** ni con validación integral end-to-end. **No** está aprobada como
+    flujo operativo: no la uses como procedimiento de producción hasta que exista UI y validación.
 
-Ver [Factura Global](../tecnico/arquitectura.md#flujo-e-receipt--autofactura) para detalles técnicos.
+En el diseño, si el cliente no se autofactura antes de que expire el receipt, la empresa podría
+incluirlo en una **Factura Global** periódica que agrupa los receipts abiertos del período. Hoy ese
+agrupamiento y su timbrado solo están disponibles vía API del servidor, sin pantalla operable.
 
-!!! note "Limitación actual"
+!!! note "Limitación de diseño"
     Los E-Receipts con **IEPS** no pueden incluirse en Factura Global hasta que se implemente
-    el modelo line-level de impuestos (issue #182). El sistema bloqueará con un mensaje claro.
+    el modelo line-level de impuestos (issue #182).
 
 ---
 

--- a/docs/usuario/notas-credito.md
+++ b/docs/usuario/notas-credito.md
@@ -86,6 +86,22 @@ devolución de mercancía, se emite como Devolución.
 
 ---
 
+## Bloqueo por estado ambiguo (fail-closed)
+
+El sistema **deriva el tipo de forma read-only a partir del estado contable real** de la devolución,
+no de lo que el usuario "quiso". La clasificación es **fail-closed**: si el estado de las líneas **no
+coincide exactamente** con un patrón válido —ni el de *devolución de mercancía* (misma cuenta de
+ingresos, misma descripción y mismo comportamiento de inventario que el origen) ni el de *descuento /
+bonificación* (cuenta de descuentos configurada en todas las líneas, descripción "Descuento - …" y
+`update_stock = 0`)— la creación/timbrado de la Factura Fiscal se **bloquea con un mensaje** y no se
+asigna ningún tipo por defecto.
+
+También se bloquea si falta el vínculo con la línea de origen (`sales_invoice_item`): el sistema **no
+adivina** la cuenta contable. En ese caso, corrige el estado de la devolución (o reviértela con el
+botón correspondiente) antes de volver a intentar.
+
+---
+
 ## Configuración requerida
 
 Cada empresa debe tener configurada la **Cuenta de Descuentos y Bonificaciones** en

--- a/facturacion_mexico/__init__.py
+++ b/facturacion_mexico/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 # Trigger CI rebuild - GitHub Actions refresh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,14 +74,15 @@ nav:
     - Setup: tecnico/setup.md
     - Email CFDI: tecnico/email-system.md
     - Regeneración STCT: tecnico/proceso-regeneracion-stct-e4.md
+    - Reconciliación y fallback: tecnico/reconciliacion-fallback.md
     - ADRs:
       - adr/index.md
       - adr/0000-estado-real-pre-migracion.md
       - adr/0002-verificacion-arranque-v16.md
       - adr/0003-verificacion-configuracion-fiscal.md
       - adr/0004-verificacion-timbrado.md
-      - adr/0005-workflow-configuracion-inicial-v2.md
-      - adr/0005-workflow-configuracion-inicial.md
+      - "0005 Workflow configuración inicial (v2, vigente)": adr/0005-workflow-configuracion-inicial-v2.md
+      - "0005 Workflow configuración inicial (obsoleto — superseded por v2)": adr/0005-workflow-configuracion-inicial.md
       - adr/0006-analisis-branches-wip.md
       - adr/0007-analisis-checkout-e4.md
       - adr/0008-analisis-9-commits-wip.md
@@ -119,6 +120,8 @@ nav:
     - DocTypes: referencia/doctypes.md
     - Hooks: referencia/hooks.md
     - API: referencia/api.md
+    - Configuración: referencia/configuracion.md
+    - Campos fiscales: referencia/campos-fiscales.md
 
 # Extra
 extra:
@@ -127,11 +130,10 @@ extra:
     default: latest
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/tu-org/facturacion_mexico
+      link: https://github.com/luisrms69/facturacion_mexico
       name: GitHub
-  analytics:
-    provider: google
-    property: G-XXXXXXXXXX
+  # Google Analytics deshabilitado: no hay ID real configurado (antes placeholder G-XXXXXXXXXX).
+  # No inventar un ID; reactivar solo cuando exista una propiedad real.
   consent:
     title: Consentimiento de cookies
     description: >


### PR DESCRIPTION
## Objetivo

Actualización integral del manual y de las referencias de `facturacion_mexico`: corrige etiquetas de
botones desactualizadas, agrega referencias de **configuración** y **campos fiscales**, documenta
**reconciliación y fallback**, y alinea `CLAUDE.md` con el estado real del código. **Solo documentación
+ bump de versión.**

## Versión
Versión objetivo: `v1.3.2`
Release: PATCH
(base upstream/main: `v1.3.1` → `1.3.2` — solo documentación, sin funcionalidad nueva)

## Cambios principales

- **Correcciones críticas de etiquetas** (`docs/usuario/`):
  - `emitir-cfdi.md`: "Timbrar Factura" → **"Crear Factura Fiscal"** (botón de Sales Invoice); se
    distingue del botón **"Timbrar con FacturAPI"** (dentro de Factura Fiscal Mexico).
  - `cancelar-cfdi.md`: "Ver Factura Fiscal" → **"Abrir Factura Fiscal"**; el **motivo 01** solo se
    documenta mediante **sustitución** ("Sustituir CFDI (01)"), no cancelación directa.
- **Nuevas páginas de referencia:** `docs/referencia/configuracion.md` (~57 campos de config
  aprobados) y `docs/referencia/campos-fiscales.md` (48 custom fields visibles/informativos).
- **Nueva página técnica:** `docs/tecnico/reconciliacion-fallback.md` — reconciliación FFM↔FacturAPI
  (GET, pendiente de validación operativa) y fallback de timbrado (RAW en `private/files`).
- **Ampliaciones de usuario:** notas de crédito (conserva `item_code` + bloqueo fail-closed),
  complemento de pago (auto-creación PPD, bloqueos, reclasificación), cfdi-recibidos (acciones y
  etapas), addendas (propagación y generación pre-timbrado).
- **`CLAUDE.md`:** Single removido → `Company Settings` por empresa; `/tmp`/`api_backup.py`
  contextualizados; `patches.txt` vacío; 97 custom fields; estado real de módulos.
- **`mkdocs.yml`:** nav de las 3 páginas nuevas; placeholders `tu-org` → repo real; Google Analytics
  deshabilitado (sin ID inventado); ADR 0005 base marcado obsoleto.

## Documentación actualizada
- Nuevas: `docs/referencia/configuracion.md`, `docs/referencia/campos-fiscales.md`,
  `docs/tecnico/reconciliacion-fallback.md`.
- Modificadas: 7× `docs/usuario/*.md`, `CLAUDE.md`, `mkdocs.yml`.

## Funcionalidades NO presentadas como operativas
Se documentan explícitamente como **no operativas / no validadas**: **Factura Global** (API sin UI),
**Carta Porte** (no implementada), **E-Receipt** (pendiente de validación integral), **Dashboard
Fiscal**, **Motor de reglas**, **Draft management** (MOCK) e **IEPS cuota fija** (deshabilitada).

## Validaciones realizadas
- `mkdocs build --strict`: **OK (exit 0)** — nav resuelve, enlaces internos OK.
- `git diff --check`: **OK**.
- Búsqueda de etiquetas viejas / mecanismos eliminados en docs activas: **0** (solo en ADR
  históricos, contextualizados).

## Fuera de alcance
- La limpieza del **código legacy** de `Fiscal Recovery Task` (referencia residual en la cancelación)
  quedó separada en el **issue #224** (`chore`, integridad fiscal). No se toca código en este PR.
- No se incluyen los archivos de auditoría `working_docs/active/auditoria_manual/A–I` ni ningún otro
  untracked.

## Riesgos / pendientes
- No requiere `bench migrate` (sin cambios de esquema). Requiere `mkdocs`/build de docs al publicar.
- Reconciliación y E-Receipt siguen **pendientes de validación operativa** (documentado como tal).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Spanish references for fiscal fields, configuration, reconciliation, fallback handling, addendas, and CFDI workflows.
  * Clarified invoice creation and stamping steps, cancellation options, payment complements, received CFDIs, and credit notes.
  * Documented current limitations for E-Receipts and Factura Global, including production-readiness warnings.
  * Updated navigation and project documentation with current workflows and configuration guidance.

* **Chores**
  * Updated the application version to 1.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->