### PR TITLE
feat(fiscal): guarda de ambiente por sitio (fm_environment) para el PAC (1.4.0)

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,59 +2,58 @@
 
 **Fecha:** 2026-08-14
 **Rama activa:** `feat/issue-215-fm-environment-guard`
-**Tarea actual:** Issue #215 — guarda de ambiente fiscal por sitio (`fm_environment`) para el PAC.
+**Tarea actual:** Issue #215 — guarda de ambiente fiscal por sitio (`fm_environment`); PR #226 abierto, atendiendo CodeRabbit.
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-La implementación del issue #215: evitar que un entorno no productivo (p. ej. restaurado desde
-producción) emita CFDIs reales contra FacturAPI.
+PR #226 (issue #215). Ya se aplicaron los fixes de CodeRabbit F-01 y F-03; F-02 y F-04 diferidos.
 
 Plan que estoy siguiendo:
-Issue #215 + ADR-0038 (`docs/adr/0038-guarda-ambiente-fiscal-fm-environment.md`).
+Issue #215 + ADR-0038 + reporte CodeRabbit en
+`frappe-infrastructure/checkpoints/coderabbit-pr226-review.md`.
 
 Objetivo inmediato:
-Commit hecho en la rama. Siguiente paso concreto: `/ship push` (con autorización) y luego `/ship pr`.
+Commit de F-01/F-03 hecho en la rama. Siguiente paso: `/ship push` (actualiza PR #226) — con autorización.
 
 Criterio de avance:
-Gates verdes (datos-cliente, documental, ruff, mkdocs --strict) y tests de la guarda 9/9 OK.
+Gates verdes y tests focalizados (`test_pac_environment_guard` 10/10, `test_facturacion_mexico_company_settings` 9/9).
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- Guarda central en `FacturAPIClient` (`_make_request` / `_make_request_silent`) + módulo
-  `pac_environment.py`. Credencial seleccionada por `fm_environment` (site_config.json).
-- `sandbox_mode` pasa a valor derivado (compat). Sin fallback entre credenciales.
-- Docs: `docs/tecnico/ambiente-fiscal.md` + ADR-0038 + nav MkDocs.
-- Tests: `test_pac_environment_guard` (9/9) + `test_facturacion_mexico_company_settings` (actualizado, 9/9).
-- Validación local: sandbox real (`sk_test_`) POST permitido con `livemode=false`; bloqueo con
-  `fm_environment` ausente y con `sk_live_` en sandbox. Sin datos de cliente alterados.
-- Bump `__version__` 1.3.2 → 1.4.0 (MINOR).
+- Guarda central `pac_environment.py` en `FacturAPIClient` + selección de credencial por `fm_environment`.
+- **F-01 (CodeRabbit):** `get_fm_environment()` lee el `site_config.json` DEL SITIO directamente
+  (`frappe.get_site_path`), NO la config mergeada → un `fm_environment` en `common_site_config.json`
+  se ignora. Test de regresión `test_common_only_environment_is_rejected`.
+- **F-03 (CodeRabbit):** JSON de ejemplo válido en `docs/tecnico/ambiente-fiscal.md`.
+- Docs: tecnico + ADR-0038 (con lectura site-only) + nav. Bump `__version__` = 1.4.0 (MINOR).
+- PR #226 abierto contra `main` (no mergeado).
 
 ### En progreso
-- Nada; commit de la rama listo.
+- Nada; commit de F-01/F-03 listo en la rama.
 
 ### Pendiente inmediato
-1. `/ship push` (autorización aparte).
-2. `/ship pr` contra `main` (base upstream/main 1.3.2 → objetivo 1.4.0).
+1. `/ship push` (actualiza PR #226) — autorización aparte.
+2. Merge (usuario) → luego `/sync-check` + `/ship release` (tag + Release v1.4.0).
 3. Configurar `fm_environment` en `site_config.json` de producción/staging antes del deploy.
 
 ### No repetir
-- No intentar el timbrado sandbox sobre FFM BORRADOR de fixtures: fallan por validaciones locales
-  (UOM fuera de `c_ClaveUnidad`, `ObjetoImp=02` sin impuestos) ajenas a #215. Para probar el
-  happy-path usar `one_offs/verificar_215.demo_sandbox_call` (POST directo a sandbox).
+- No usar `frappe.conf` / `frappe.get_site_config()` para el ambiente: combinan common + site.
+  El ambiente es estrictamente por-sitio (lectura directa del archivo del sitio).
+- No timbrar FFM BORRADOR de fixtures (fallan por UOM/`ObjetoImp`, ajeno a #215); para probar el
+  happy-path usar `one_offs/verificar_215.demo_sandbox_call`.
 
 ---
 
 ## Decisiones vigentes
-- Fuente de verdad del ambiente = `fm_environment` en `site_config.json` (a prueba de restore).
+- Fuente de verdad del ambiente = `fm_environment` en `site_config.json` **del sitio** (no common).
 - Guarda solo bloquea mutaciones (POST/PUT/PATCH/DELETE); GET permitido.
-- `fm_environment` debe fijarse en TODOS los sitios que timbran (prod=`production`, dev=`sandbox`),
-  antes de activar la guarda (orden de despliegue crítico).
+- F-02 (tests con registros reales, RG-003) y F-04 (MD022 en plantilla CONTINUITY) → diferidos a issues.
 
 ---
 
@@ -62,11 +61,8 @@ Gates verdes (datos-cliente, documental, ruff, mkdocs --strict) y tests de la gu
 
 ### Leer primero
 - `facturacion_mexico/facturacion_fiscal/pac_environment.py`
-- `facturacion_mexico/facturacion_fiscal/api_client.py`
 - `docs/adr/0038-guarda-ambiente-fiscal-fm-environment.md`
-
-### Probablemente editar
-- (ninguno pendiente)
+- `frappe-infrastructure/checkpoints/coderabbit-pr226-review.md`
 
 ### No tocar
 - `facturacion_mexico/one_offs/verificar_215.py` (diagnóstico; nunca se commitea).
@@ -74,8 +70,8 @@ Gates verdes (datos-cliente, documental, ruff, mkdocs --strict) y tests de la gu
 ---
 
 ## Riesgos / cuidados
-- Deploy: si se activa la guarda sin `fm_environment="production"` en producción, se bloquea el
-  timbrado legítimo. Fijar la variable primero.
+- Deploy: fijar `fm_environment="production"` en el `site_config.json` de producción antes de activar
+  la guarda, o el timbrado legítimo se bloquea.
 
 ---
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,93 +1,83 @@
 # CONTINUITY.md — facturacion_mexico
 
-**Fecha:** 2026-08-03
-**Rama activa:** `fix/ffm-tipo-nc-derivado-simetrico`
-**Tarea actual:** PR #222 — corrección de permisos de cancelación de Sales Invoice (estado inválido `cancel=1, submit=0`) detectada durante instalación de HRMS.
+**Fecha:** 2026-08-14
+**Rama activa:** `feat/issue-215-fm-environment-guard`
+**Tarea actual:** Issue #215 — guarda de ambiente fiscal por sitio (`fm_environment`) para el PAC.
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-
-Cierre de la revisión de CodeRabbit del PR #222. Se corrigen los comentarios #2 (doc), #3/#4 (CONTINUITY/MD022) y #5 (`NoReturn`). El comentario #1 (test que mockea `frappe.get_doc`) se difirió al issue #223.
+La implementación del issue #215: evitar que un entorno no productivo (p. ej. restaurado desde
+producción) emita CFDIs reales contra FacturAPI.
 
 Plan que estoy siguiendo:
-
-Instrucciones directas del usuario para cerrar la revisión. PR #222 abierto; merge lo hace el usuario.
+Issue #215 + ADR-0038 (`docs/adr/0038-guarda-ambiente-fiscal-fm-environment.md`).
 
 Objetivo inmediato:
-
-Commit de las correcciones de revisión → push para actualizar el PR #222 → re-ejecutar `/ship coderabbit`.
+Commit hecho en la rama. Siguiente paso concreto: `/ship push` (con autorización) y luego `/ship pr`.
 
 Criterio de avance:
-
-CodeRabbit sin comentarios accionables pendientes salvo el #1 (que vive en el issue #223); suite en verde; docs consistente con el código.
+Gates verdes (datos-cliente, documental, ruff, mkdocs --strict) y tests de la guarda 9/9 OK.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-
-- PR **#222** abierto (base `main`), rama publicada en `upstream`. Versión objetivo `1.3.1` (PATCH).
-- Botón fiscal + aviso RFC: `can_stamp` excluye `has_active_ffm` **y** `has_draft_ffm`; guard `frm.__fm_can_stamp` en `add_timbrar_button`; aviso RFC gateado por `can_stamp`.
-- Doc de usuario `docs/usuario/notas-credito.md` (en nav de MkDocs).
-- CodeRabbit revisado (reporte en `frappe-infrastructure/checkpoints/coderabbit-pr222-review.md`).
-- CodeRabbit #2/#3/#4/#5 atendidos y commiteados (`e856671`); #1 diferido al issue #223.
+- Guarda central en `FacturAPIClient` (`_make_request` / `_make_request_silent`) + módulo
+  `pac_environment.py`. Credencial seleccionada por `fm_environment` (site_config.json).
+- `sandbox_mode` pasa a valor derivado (compat). Sin fallback entre credenciales.
+- Docs: `docs/tecnico/ambiente-fiscal.md` + ADR-0038 + nav MkDocs.
+- Tests: `test_pac_environment_guard` (9/9) + `test_facturacion_mexico_company_settings` (actualizado, 9/9).
+- Validación local: sandbox real (`sk_test_`) POST permitido con `livemode=false`; bloqueo con
+  `fm_environment` ausente y con `sk_live_` en sandbox. Sin datos de cliente alterados.
+- Bump `__version__` 1.3.2 → 1.4.0 (MINOR).
 
 ### En progreso
-
-- Permisos Sales Invoice: `Facturacion Mexico Manager` y `System Manager` pasan a `submit=1, cancel=1`
-  (antes `cancel=1, submit=0`, inválido en Frappe). Corregido en `fixtures/docperm.json` y en la
-  segunda fuente `api/fiscal_operations.py::assign_facturacion_permissions()`. Test de fixture
-  agregado (`test_docperm_sales_invoice_permissions.py`). La lógica de cancelación no cambia.
+- Nada; commit de la rama listo.
 
 ### Pendiente inmediato
-
-1. Commit + push de las correcciones → actualizar PR #222.
-2. Re-ejecutar `/ship coderabbit` para confirmar el estado.
-3. Merge: lo realiza el usuario (Squash & Merge). No lo hace Claude.
+1. `/ship push` (autorización aparte).
+2. `/ship pr` contra `main` (base upstream/main 1.3.2 → objetivo 1.4.0).
+3. Configurar `fm_environment` en `site_config.json` de producción/staging antes del deploy.
 
 ### No repetir
-
-- No usar `git restore/reset/revert/checkout` para deshacer trabajo.
-- No reintroducir la regresión: `can_stamp` debe excluir `has_active_ffm` Y `has_draft_ffm`.
-- No meter conocimiento de FFM dentro de la validación RFC.
-- No tocar `redirect_to_fiscal_document` ni su query.
-- No atender el comentario #1 dentro del PR #222 (vive en el issue #223): no tocar `_derivar`, sus mocks ni la carga por `frappe.get_doc`, ni añadir costura de pruebas a producción.
+- No intentar el timbrado sandbox sobre FFM BORRADOR de fixtures: fallan por validaciones locales
+  (UOM fuera de `c_ClaveUnidad`, `ObjetoImp=02` sin impuestos) ajenas a #215. Para probar el
+  happy-path usar `one_offs/verificar_215.demo_sandbox_call` (POST directo a sandbox).
 
 ---
 
 ## Decisiones vigentes
-
-- El comentario #1 de CodeRabbit (mock de `frappe.get_doc` en `TestClasificacionNotaCredito`) se difiere al issue **#223**: `_classify_nota_credito` carga la SI/origen con `frappe.get_doc` directo; no se añade costura productiva ni infraestructura pesada dentro de este PR.
-- El flujo de descuento **conserva el `item_code` original** (ERPNext `validate_returned_items` lo exige); solo cambia `description` («Descuento - \<original\>»), `income_account` y `update_stock=0`. La doc se corrigió acorde.
-- Fuente autoritativa de visibilidad del botón = `can_stamp` (servidor).
+- Fuente de verdad del ambiente = `fm_environment` en `site_config.json` (a prueba de restore).
+- Guarda solo bloquea mutaciones (POST/PUT/PATCH/DELETE); GET permitido.
+- `fm_environment` debe fijarse en TODOS los sitios que timbran (prod=`production`, dev=`sandbox`),
+  antes de activar la guarda (orden de despliegue crítico).
 
 ---
 
 ## Archivos relevantes ahora
 
 ### Leer primero
+- `facturacion_mexico/facturacion_fiscal/pac_environment.py`
+- `facturacion_mexico/facturacion_fiscal/api_client.py`
+- `docs/adr/0038-guarda-ambiente-fiscal-fm-environment.md`
 
-- `docs/usuario/notas-credito.md` (corrección #2)
-- `facturacion_mexico/facturacion_fiscal/doctype/factura_fiscal_mexico/factura_fiscal_mexico.py` (`NoReturn`, #5)
+### Probablemente editar
+- (ninguno pendiente)
 
 ### No tocar
-
-- `facturacion_mexico/facturacion_fiscal/tests/test_nota_credito_descuento_relacion_01.py` (`TestClasificacionNotaCredito._derivar`) → reservado al issue #223.
-- `redirect_to_fiscal_document` y su query en `sales_invoice.js`.
+- `facturacion_mexico/one_offs/verificar_215.py` (diagnóstico; nunca se commitea).
 
 ---
 
 ## Riesgos / cuidados
-
-- `NoReturn` debe ser el único cambio en Python de esta ronda (sin tocar lógica ni mensajes).
-- Mantener `docperm.json` limpio y no incluir untracked de `one_offs/` / `working_docs/`.
+- Deploy: si se activa la guarda sin `fm_environment="production"` en producción, se bloquea el
+  timbrado legítimo. Fijar la variable primero.
 
 ---
 
 ## Información faltante
-
-- Ninguna pendiente para esta ronda; tras el push, confirmar la nueva revisión de CodeRabbit.
+- Ninguna para cerrar el PR.

--- a/docs/adr/0038-guarda-ambiente-fiscal-fm-environment.md
+++ b/docs/adr/0038-guarda-ambiente-fiscal-fm-environment.md
@@ -1,0 +1,64 @@
+# ADR 0038 — Guarda de ambiente fiscal por sitio (`fm_environment`) para el PAC
+
+**Estado:** Aceptado
+**Issue:** #215
+**Fecha:** 2026-08-14
+
+## Contexto
+
+La selección de credencial de FacturAPI dependía exclusivamente del campo `sandbox_mode`
+almacenado en la **base de datos** (`Facturacion Mexico Company Settings`). El cliente elegía
+`test_api_key` o `api_key` según ese flag, contra la misma URL de FacturAPI (el ambiente real
+lo determina el prefijo de la Secret Key: `sk_live_` vs `sk_test_`).
+
+`bench restore` restaura la **BD** pero no sanea las credenciales fiscales. Un sitio de
+desarrollo restaurado desde producción hereda `sandbox_mode` y `api_key` productivos; con
+`sandbox_mode=0` + `api_key` `sk_live_`, cualquier timbrado desde ese entorno emitiría un
+**CFDI real ante el SAT**. La única condición para facturar en real vivía en la BD — justo lo
+que el restore sobreescribe.
+
+## Decisión
+
+La fuente de verdad del ambiente fiscal pasa a ser una variable **explícita por sitio** en
+`site_config.json`: `fm_environment` con valores `"production"` o `"sandbox"`.
+
+1. La credencial se elige por `fm_environment` (`production` → `api_key`, `sandbox` →
+   `test_api_key`), **sin fallback** entre campos. `sandbox_mode` deja de decidir la credencial
+   y se conserva solo como valor **derivado** (`sandbox_mode == (fm_environment == "sandbox")`)
+   por compatibilidad de UI.
+2. Una **guarda central** en el único chokepoint (`FacturAPIClient._make_request` y
+   `_make_request_silent`) bloquea las operaciones **mutantes** (POST/PUT/PATCH/DELETE) antes de
+   contactar al PAC cuando:
+   - falta `fm_environment` o su valor es inválido (fail-closed);
+   - la credencial del ambiente no existe;
+   - la credencial efectiva empieza con `sk_live_` y `fm_environment != "production"`.
+   Los **GET** (reconciliación, verificación de estado, validación de RFC) siguen permitidos.
+3. El bloqueo usa `frappe.throw` con mensaje explícito ("no se contactó a FacturAPI"); en
+   background jobs, Frappe registra la excepción en Error Log (sin infraestructura de alertas
+   adicional).
+
+`site_config.json` es a prueba de restore (no se copia con la BD) y es un mecanismo estándar
+de Frappe (`frappe.conf`).
+
+## Consecuencias
+
+- Un entorno restaurado desde producción queda **incapaz de emitir CFDIs reales** salvo que su
+  `site_config.json` declare explícitamente `fm_environment="production"` **y** tenga `api_key`
+  `sk_live_`.
+- **Todos** los sitios que timbran deben declarar `fm_environment` (producción → `production`;
+  staging/desarrollo → `sandbox`); si falta, las mutaciones quedan bloqueadas (fail-closed).
+- **Orden de despliegue crítico:** fijar `fm_environment="production"` en el `site_config.json`
+  de producción **antes** de activar la guarda, o el timbrado legítimo de producción quedaría
+  bloqueado.
+- El ambiente fiscal pasa a ser **por sitio**, no por Company: un mismo sitio es todo
+  `production` o todo `sandbox`. No hay cambios en la lógica fiscal, cálculo ni payload.
+
+## Alternativa descartada
+
+Se evaluó un esquema de **defensa en profundidad** con múltiples capas (autorizador server-side
+por filesystem, allowlist por IP/identidad de red, saneo automático post-restore vía
+`after_migrate`, e indicador visual). Se descartó por ser innecesariamente complejo y frágil
+(las IP cambian; el saneo automático corre en cada migrate) frente al objetivo. Como todo el
+tráfico mutante pasa por un **único chokepoint**, una sola guarda explícita basada en
+`site_config.json` cumple el objetivo fail-closed con cambios mínimos. El indicador visual y el
+saneo se remiten a issues separados (p. ej. #171).

--- a/docs/adr/0038-guarda-ambiente-fiscal-fm-environment.md
+++ b/docs/adr/0038-guarda-ambiente-fiscal-fm-environment.md
@@ -37,8 +37,12 @@ La fuente de verdad del ambiente fiscal pasa a ser una variable **explícita por
    background jobs, Frappe registra la excepción en Error Log (sin infraestructura de alertas
    adicional).
 
-`site_config.json` es a prueba de restore (no se copia con la BD) y es un mecanismo estándar
-de Frappe (`frappe.conf`).
+`site_config.json` es a prueba de restore (no se copia con la BD) y es un mecanismo estándar de
+Frappe. La lectura es **estrictamente por-sitio**: `get_fm_environment()` lee el `site_config.json`
+del sitio **directamente** (vía `frappe.get_site_path`), **no** la configuración mergeada
+(`frappe.conf` / `frappe.get_site_config()` combinan `common_site_config.json` + `site_config.json`).
+Así, un `fm_environment` colocado en `common_site_config.json` **no se hereda** ni habilita el
+ambiente de ningún sitio (evita una habilitación accidental global).
 
 ## Consecuencias
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -41,3 +41,4 @@ Registro permanente de decisiones de arquitectura. Un ADR nunca se modifica — 
 | [0035](0035-motor-reconciliacion-ffm.md) | Motor de reconciliación FFM ↔ FacturAPI |
 | [0036](0036-integridad-proyeccion-cancelacion.md) | Integridad de la proyección de cancelación y consolidación del flujo manual |
 | [0037](0037-resiliencia-cancelacion-sustitucion-motivo-01.md) | Resiliencia de la cancelación de sustitución (motivo 01) ante fallos transitorios del PAC |
+| [0038](0038-guarda-ambiente-fiscal-fm-environment.md) | Guarda de ambiente fiscal por sitio (`fm_environment`) para el PAC |

--- a/docs/tecnico/ambiente-fiscal.md
+++ b/docs/tecnico/ambiente-fiscal.md
@@ -1,0 +1,57 @@
+# Ambiente fiscal del sitio (`fm_environment`)
+
+La emisión real de CFDIs depende de una variable **explícita por sitio**, no de la base de datos.
+Esto evita que una copia restaurada de producción (staging/dev) timbre CFDIs reales por accidente.
+
+## Variable
+
+- **Nombre:** `fm_environment`
+- **Ubicación:** `site_config.json` del sitio (no en la BD, no en `common_site_config.json`).
+- **Valores permitidos:** `"production"` o `"sandbox"`.
+
+```json
+// sites/<sitio>/site_config.json
+{
+  "fm_environment": "production"
+}
+```
+
+## Comportamiento
+
+| `fm_environment` | Credencial usada | Operación mutante al PAC |
+|---|---|---|
+| `"production"` | `api_key` (obligatoria) | Permitida si hay `api_key` |
+| `"sandbox"` | `test_api_key` (obligatoria) | Permitida si hay `test_api_key` |
+| ausente / valor inválido | ninguna | **Bloqueada (fail-closed)** |
+
+Reglas adicionales:
+
+- **Sin fallback** entre `api_key` y `test_api_key`: si falta la credencial del ambiente, se bloquea.
+- **Protección extra:** si la credencial efectiva empieza con `sk_live_` y el ambiente **no** es
+  `production`, se bloquea (protege contra una llave productiva colocada por error en `test_api_key`).
+- **Solo se bloquean mutaciones** (POST/PUT/PATCH/DELETE: timbrar, cancelar, complementos, E-Receipts,
+  Factura Global). Los **GET** (reconciliación, verificación de estado, validación de RFC) siguen
+  permitidos.
+- El bloqueo ocurre en el punto central `FacturAPIClient` **antes** de contactar a FacturAPI; el
+  mensaje indica explícitamente que **no se contactó al PAC**. En background jobs, la excepción queda
+  registrada en **Error Log** por el comportamiento estándar de Frappe.
+
+`sandbox_mode` (campo de BD) **ya no decide** la credencial; se conserva como valor derivado
+(`sandbox_mode = fm_environment == "sandbox"`) por compatibilidad de UI.
+
+## Por qué es a prueba de restore
+
+`bench restore` restaura **la base de datos**, no `site_config.json`. Una copia restaurada desde
+producción conserva su propio `site_config.json`; por tanto **no hereda** el `fm_environment` de
+producción. Si la copia no declara el ambiente, queda **bloqueada** para emitir.
+
+## Configuración requerida por sitio
+
+Todo sitio que timbre debe declarar `fm_environment`:
+
+- **Producción:** `"production"`.
+- **Staging / desarrollo:** `"sandbox"`.
+
+> **Importante (orden de despliegue):** fija `fm_environment` en el `site_config.json` de cada sitio
+> **antes** de desplegar esta guarda. Si producción no lo declara al activarse la guarda, su timbrado
+> legítimo quedaría bloqueado.

--- a/docs/tecnico/ambiente-fiscal.md
+++ b/docs/tecnico/ambiente-fiscal.md
@@ -9,12 +9,18 @@ Esto evita que una copia restaurada de producción (staging/dev) timbre CFDIs re
 - **Ubicación:** `site_config.json` del sitio (no en la BD, no en `common_site_config.json`).
 - **Valores permitidos:** `"production"` o `"sandbox"`.
 
+Ejemplo del archivo `sites/<sitio>/site_config.json`:
+
 ```json
-// sites/<sitio>/site_config.json
 {
   "fm_environment": "production"
 }
 ```
+
+> **Estrictamente por-sitio.** El código lee `fm_environment` **directamente del `site_config.json`
+> del sitio** (vía `frappe.get_site_path`), **no** de la configuración mergeada (`frappe.conf` /
+> `frappe.get_site_config()`, que combinan common + site). Por tanto, un `fm_environment` puesto en
+> `common_site_config.json` **se ignora**: no habilita ni cambia el ambiente de ningún sitio.
 
 ## Comportamiento
 

--- a/facturacion_mexico/__init__.py
+++ b/facturacion_mexico/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.3.2"
+__version__ = "1.4.0"
 
 # Trigger CI rebuild - GitHub Actions refresh

--- a/facturacion_mexico/facturacion_fiscal/api_client.py
+++ b/facturacion_mexico/facturacion_fiscal/api_client.py
@@ -4,6 +4,8 @@ import frappe
 import requests
 from frappe import _
 
+from facturacion_mexico.facturacion_fiscal import pac_environment
+
 
 class FacturAPIClient:
 	"""Cliente para FacturAPI.io usando requests (ya incluido en Frappe)."""
@@ -14,7 +16,11 @@ class FacturAPIClient:
 	def __init__(self, company=None):
 		"""Inicializar cliente con configuración."""
 		self.company = company
-		self.sandbox_mode = self._resolve_sandbox_mode()
+		# Fuente de verdad del ambiente: site_config.json (issue #215), no la BD.
+		self.environment = pac_environment.get_fm_environment()
+		# `sandbox_mode` se conserva como valor DERIVADO por compatibilidad (UI, defaults
+		# cosméticos de E-Receipt). Ya NO decide la credencial.
+		self.sandbox_mode = self.environment == "sandbox"
 		self.base_url = self._get_base_url()
 		self.api_key = self._get_api_key()
 		self.timeout = self._DEFAULT_TIMEOUT
@@ -49,24 +55,35 @@ class FacturAPIClient:
 			)
 		return doc
 
-	def _resolve_sandbox_mode(self) -> bool:
-		"""Resolver sandbox_mode desde Company Settings."""
-		return bool(self._get_company_settings().sandbox_mode)
-
 	def _get_base_url(self) -> str:
 		"""URL base FacturAPI."""
 		return "https://www.facturapi.io/v2"
 
 	def _get_api_key(self) -> str:
-		"""Obtener API key desde Company Settings según modo sandbox/producción."""
+		"""Obtener API key desde Company Settings según el ambiente del sitio (issue #215).
+
+		El campo se elige por `fm_environment` (production → api_key, sandbox → test_api_key),
+		NO por `sandbox_mode`. Sin fallback entre campos. Si el ambiente es inválido no se
+		selecciona credencial (cadena vacía); las operaciones mutantes quedan bloqueadas por
+		la guarda central antes de contactar al PAC.
+		"""
 		from frappe.utils.password import get_decrypted_password
 
+		field = pac_environment.credential_field_for(self.environment)
+		if not field:
+			return ""
+
 		settings = self._get_company_settings()
-		field = "test_api_key" if settings.sandbox_mode else "api_key"
 		return get_decrypted_password("Facturacion Mexico Company Settings", settings.name, field) or ""
+
+	def _assert_operation_allowed(self, method: str) -> None:
+		"""Guarda central (issue #215): bloquea mutaciones al PAC en ambientes inseguros."""
+		pac_environment.assert_pac_operation_allowed(method, self.environment, self.api_key)
 
 	def _make_request(self, method: str, endpoint: str, data: dict | None = None) -> dict[str, Any]:
 		"""Realizar petición HTTP a FacturAPI."""
+		# Guarda central de ambiente (issue #215): bloquea mutaciones inseguras antes de la red.
+		self._assert_operation_allowed(method)
 		url = f"{self.base_url}{endpoint}"
 
 		try:
@@ -160,7 +177,14 @@ class FacturAPIClient:
 		return None
 
 	def _make_request_silent(self, method: str, endpoint: str, data: dict | None = None) -> dict[str, Any]:
-		"""Realizar petición HTTP a FacturAPI SIN frappe.throw() para validaciones."""
+		"""Realizar petición HTTP a FacturAPI SIN frappe.throw() para validaciones.
+
+		Nota: la guarda de ambiente (issue #215) SÍ puede lanzar `frappe.throw` para una
+		operación mutante insegura — la seguridad prevalece sobre el modo silencioso. Los GET
+		(uso habitual de este método) no se bloquean.
+		"""
+		# Guarda central de ambiente (issue #215): bloquea mutaciones inseguras antes de la red.
+		self._assert_operation_allowed(method)
 		url = f"{self.base_url}{endpoint}"
 
 		try:

--- a/facturacion_mexico/facturacion_fiscal/pac_environment.py
+++ b/facturacion_mexico/facturacion_fiscal/pac_environment.py
@@ -1,0 +1,80 @@
+"""Ambiente fiscal del sitio — fuente de verdad para el PAC (issue #215).
+
+La variable explícita `fm_environment` en `site_config.json` decide el ambiente fiscal
+del sitio y, por tanto, la credencial de FacturAPI que se usa:
+
+  - "production" → credencial `api_key`
+  - "sandbox"   → credencial `test_api_key`
+
+`sandbox_mode` (BD) deja de decidir la credencial. Vive en `site_config.json` (filesystem),
+que `bench restore` NO copia desde la BD de producción: una copia restaurada conserva su
+propia configuración de ambiente.
+
+Comportamiento fail-closed: si `fm_environment` falta o es inválida, se bloquea cualquier
+operación MUTANTE al PAC (POST/PUT/PATCH/DELETE) antes de contactarlo. Los GET siguen
+permitidos.
+"""
+
+import frappe
+from frappe import _
+
+VALID_ENVIRONMENTS = ("production", "sandbox")
+MUTATING_METHODS = ("POST", "PUT", "PATCH", "DELETE")
+
+
+def get_fm_environment() -> str:
+	"""Ambiente fiscal declarado en site_config.json, normalizado (minúsculas)."""
+	return (frappe.conf.get("fm_environment") or "").strip().lower()
+
+
+def credential_field_for(environment: str) -> str | None:
+	"""Campo de credencial de Company Settings según ambiente; None si es inválido."""
+	if environment == "production":
+		return "api_key"
+	if environment == "sandbox":
+		return "test_api_key"
+	return None
+
+
+def assert_pac_operation_allowed(method: str, environment: str, effective_key: str) -> None:
+	"""Guarda central fail-closed para operaciones mutantes al PAC (issue #215).
+
+	No bloquea GET. Cuando bloquea, lanza `frappe.throw` (que Frappe registra en Error Log
+	en contextos de background) SIN contactar a FacturAPI.
+	"""
+	if (method or "").upper() not in MUTATING_METHODS:
+		return  # GET y demás de solo lectura: permitidos
+
+	# Regla 3: ambiente ausente o inválido → fail-closed.
+	if environment not in VALID_ENVIRONMENTS:
+		frappe.throw(
+			_(
+				"Operación fiscal bloqueada: falta o es inválida la variable 'fm_environment' en site_config.json (valores válidos: 'production' o 'sandbox'). No se contactó a FacturAPI."
+			),
+			title=_("Ambiente fiscal no configurado"),
+		)
+
+	# Regla 4: credencial productiva (sk_live_) en un ambiente NO productivo.
+	if effective_key.startswith("sk_live_") and environment != "production":
+		frappe.throw(
+			_(
+				"Operación fiscal bloqueada: la credencial efectiva es de producción (sk_live_) pero el ambiente del sitio no es 'production'. No se contactó a FacturAPI."
+			),
+			title=_("Credencial de producción en ambiente no productivo"),
+		)
+
+	# Reglas 1 y 2: la credencial del ambiente debe existir (sin fallback al otro campo).
+	if not effective_key:
+		if environment == "production":
+			frappe.throw(
+				_(
+					"Operación fiscal bloqueada: el ambiente es 'production' pero falta 'api_key' en Facturacion Mexico Company Settings. No se contactó a FacturAPI."
+				),
+				title=_("Falta api_key de producción"),
+			)
+		frappe.throw(
+			_(
+				"Operación fiscal bloqueada: el ambiente es 'sandbox' pero falta 'test_api_key' en Facturacion Mexico Company Settings. No se contactó a FacturAPI."
+			),
+			title=_("Falta test_api_key de sandbox"),
+		)

--- a/facturacion_mexico/facturacion_fiscal/pac_environment.py
+++ b/facturacion_mexico/facturacion_fiscal/pac_environment.py
@@ -15,6 +15,8 @@ operación MUTANTE al PAC (POST/PUT/PATCH/DELETE) antes de contactarlo. Los GET 
 permitidos.
 """
 
+import json
+
 import frappe
 from frappe import _
 
@@ -22,9 +24,27 @@ VALID_ENVIRONMENTS = ("production", "sandbox")
 MUTATING_METHODS = ("POST", "PUT", "PATCH", "DELETE")
 
 
+def _read_site_only_config() -> dict:
+	"""Leer SOLO el `site_config.json` del sitio actual (sin merge con common_site_config.json).
+
+	`frappe.conf` / `frappe.get_site_config()` combinan `common_site_config.json` + `site_config.json`,
+	por lo que un `fm_environment` puesto en common se heredaría a sitios que lo omiten. Para que el
+	ambiente sea estrictamente **por-sitio** (issue #215), se lee el archivo del sitio directamente y
+	NO se consulta la configuración mergeada.
+	"""
+	try:
+		with open(frappe.get_site_path("site_config.json")) as fh:
+			return json.load(fh)
+	except (OSError, ValueError):
+		return {}
+
+
 def get_fm_environment() -> str:
-	"""Ambiente fiscal declarado en site_config.json, normalizado (minúsculas)."""
-	return (frappe.conf.get("fm_environment") or "").strip().lower()
+	"""Ambiente fiscal declarado en el `site_config.json` DEL SITIO (no heredado de common), normalizado.
+
+	Estrictamente por-sitio: un valor presente únicamente en `common_site_config.json` se ignora.
+	"""
+	return (_read_site_only_config().get("fm_environment") or "").strip().lower()
 
 
 def credential_field_for(environment: str) -> str | None:

--- a/facturacion_mexico/facturacion_fiscal/tests/test_facturacion_mexico_company_settings.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_facturacion_mexico_company_settings.py
@@ -1,12 +1,12 @@
-"""
-Tests para Facturacion Mexico Company Settings — sandbox_mode, api_key, test_api_key.
+"""Tests de selección de credencial de FacturAPIClient — modelo `fm_environment` (issue #215).
 
-Cubre:
+La credencial se elige por el ambiente del sitio (`fm_environment` en site_config.json),
+NO por `sandbox_mode` de BD:
   1. Sin Company Settings → throw
   2. Sin company → throw
-  3. sandbox_mode desde Company Settings
-  4. api_key (producción) desde Company Settings
-  5. test_api_key (sandbox) desde Company Settings
+  3. `sandbox_mode` derivado de `fm_environment`
+  4. production → api_key
+  5. sandbox → test_api_key (nunca api_key)
 """
 
 from unittest.mock import patch
@@ -15,16 +15,16 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
-def _mock_company_settings(sandbox_mode=1, api_key="cs-prod-key", test_api_key="cs-test-key"):
-	"""Dict que simula Facturacion Mexico Company Settings."""
+def _mock_company_settings(api_key="cs-prod-key", test_api_key="cs-test-key"):
+	"""Dict que simula Facturacion Mexico Company Settings (sandbox_mode ya no decide)."""
 	return frappe._dict(
-		{"name": "FMCS-Test", "sandbox_mode": sandbox_mode, "api_key": api_key, "test_api_key": test_api_key}
+		{"name": "FMCS-Test", "sandbox_mode": 1, "api_key": api_key, "test_api_key": test_api_key}
 	)
 
 
 class TestCompanySettingsClient(FrappeTestCase):
-	def _make_client(self, company="Test Company", company_settings=None):
-		"""Construye FacturAPIClient mockeando acceso a BD y desencriptación de passwords."""
+	def _make_client(self, company="Test Company", company_settings=None, environment="sandbox"):
+		"""Construye FacturAPIClient mockeando BD, desencriptación y ambiente del sitio."""
 		from facturacion_mexico.facturacion_fiscal.api_client import FacturAPIClient
 
 		def mock_get_decrypted_password(doctype, name, fieldname, raise_exception=True):
@@ -43,67 +43,68 @@ class TestCompanySettingsClient(FrappeTestCase):
 				"frappe.utils.password.get_decrypted_password",
 				side_effect=mock_get_decrypted_password,
 			),
+			patch(
+				"facturacion_mexico.facturacion_fiscal.pac_environment.get_fm_environment",
+				return_value=environment,
+			),
 		):
 			return FacturAPIClient(company=company)
 
-	# ── Sin Company Settings → throw ─────────────────────────────────────────
+	# ── Sin Company Settings / sin company → throw ───────────────────────────
 
 	def test_throws_when_no_company_settings(self):
-		"""Sin Company Settings → frappe.throw."""
+		"""Ambiente válido pero sin Company Settings → frappe.throw."""
 		with self.assertRaises(frappe.ValidationError):
-			self._make_client(company="Sin Configurar", company_settings=None)
+			self._make_client(company="Sin Configurar", company_settings=None, environment="production")
 
 	def test_throws_when_no_company(self):
-		"""Sin company → frappe.throw."""
-		from facturacion_mexico.facturacion_fiscal.api_client import FacturAPIClient
-
+		"""Ambiente válido pero sin company → frappe.throw."""
 		with self.assertRaises(frappe.ValidationError):
-			FacturAPIClient(company=None)
+			self._make_client(company=None, company_settings=None, environment="production")
 
-	# ── sandbox_mode ──────────────────────────────────────────────────────────
+	# ── sandbox_mode derivado de fm_environment ──────────────────────────────
 
-	def test_sandbox_mode_true(self):
-		client = self._make_client(company_settings=_mock_company_settings(sandbox_mode=1))
+	def test_sandbox_mode_derived_true(self):
+		client = self._make_client(company_settings=_mock_company_settings(), environment="sandbox")
 		self.assertTrue(client.sandbox_mode)
 
-	def test_sandbox_mode_false(self):
-		client = self._make_client(company_settings=_mock_company_settings(sandbox_mode=0))
+	def test_sandbox_mode_derived_false(self):
+		client = self._make_client(company_settings=_mock_company_settings(), environment="production")
 		self.assertFalse(client.sandbox_mode)
 
-	# ── api_key (producción) ──────────────────────────────────────────────────
+	# ── production → api_key ─────────────────────────────────────────────────
 
-	def test_prod_uses_api_key(self):
-		"""sandbox=0 → api_key de Company Settings."""
+	def test_production_uses_api_key(self):
 		client = self._make_client(
-			company_settings=_mock_company_settings(sandbox_mode=0, api_key="mi-prod-key")
+			company_settings=_mock_company_settings(api_key="mi-prod-key"), environment="production"
 		)
 		self.assertEqual(client.api_key, "mi-prod-key")
 
-	def test_prod_empty_api_key_returns_empty(self):
-		"""sandbox=0 sin api_key → cadena vacía."""
-		client = self._make_client(company_settings=_mock_company_settings(sandbox_mode=0, api_key=""))
+	def test_production_empty_api_key_returns_empty(self):
+		client = self._make_client(
+			company_settings=_mock_company_settings(api_key=""), environment="production"
+		)
 		self.assertEqual(client.api_key, "")
 
-	# ── test_api_key (sandbox) ────────────────────────────────────────────────
+	# ── sandbox → test_api_key ───────────────────────────────────────────────
 
 	def test_sandbox_uses_test_api_key(self):
-		"""sandbox=1 → test_api_key de Company Settings."""
 		client = self._make_client(
-			company_settings=_mock_company_settings(sandbox_mode=1, test_api_key="mi-test-key")
+			company_settings=_mock_company_settings(test_api_key="mi-test-key"), environment="sandbox"
 		)
 		self.assertEqual(client.api_key, "mi-test-key")
 
 	def test_sandbox_empty_test_api_key_returns_empty(self):
-		"""sandbox=1 sin test_api_key → cadena vacía."""
-		client = self._make_client(company_settings=_mock_company_settings(sandbox_mode=1, test_api_key=""))
+		client = self._make_client(
+			company_settings=_mock_company_settings(test_api_key=""), environment="sandbox"
+		)
 		self.assertEqual(client.api_key, "")
 
 	def test_sandbox_does_not_use_prod_key(self):
-		"""sandbox=1 → NO usa api_key aunque esté configurada."""
+		"""sandbox → usa test_api_key aunque api_key esté configurada."""
 		client = self._make_client(
-			company_settings=_mock_company_settings(
-				sandbox_mode=1, api_key="prod-key", test_api_key="test-key"
-			)
+			company_settings=_mock_company_settings(api_key="prod-key", test_api_key="test-key"),
+			environment="sandbox",
 		)
 		self.assertEqual(client.api_key, "test-key")
 		self.assertNotEqual(client.api_key, "prod-key")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_pac_environment_guard.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_pac_environment_guard.py
@@ -5,7 +5,7 @@ cuando el ambiente del sitio es inseguro, y que producción/sandbox legítimos y
 sigan funcionando. Nunca se contacta a FacturAPI real: `requests.request` está mockeado.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -122,3 +122,17 @@ class TestPacEnvironmentGuard(FrappeTestCase):
 		self.assertEqual(kwargs["method"], "POST")
 		self.assertTrue(kwargs["url"].endswith("/invoices"))
 		self.assertEqual(kwargs["json"], data)
+
+	# 10. F-01: un fm_environment presente SOLO en common_site_config NO debe aplicar (estrictamente por-sitio).
+	def test_common_only_environment_is_rejected(self):
+		from facturacion_mexico.facturacion_fiscal import pac_environment
+
+		# Simula que la config MERGEADA (common + site) reportaría "production"...
+		with patch.dict(frappe.conf, {"fm_environment": "production"}, clear=False):
+			# ...pero el site_config.json DEL SITIO no tiene la clave → se ignora la herencia de common.
+			with patch("builtins.open", mock_open(read_data='{"db_name": "x"}')):
+				self.assertEqual(pac_environment.get_fm_environment(), "")
+
+		# En cambio, si el site_config.json DEL SITIO sí la declara, se respeta.
+		with patch("builtins.open", mock_open(read_data='{"fm_environment": "sandbox"}')):
+			self.assertEqual(pac_environment.get_fm_environment(), "sandbox")

--- a/facturacion_mexico/facturacion_fiscal/tests/test_pac_environment_guard.py
+++ b/facturacion_mexico/facturacion_fiscal/tests/test_pac_environment_guard.py
@@ -1,0 +1,124 @@
+"""Tests de la guarda central de ambiente fiscal — issue #215.
+
+Verifican que las operaciones MUTANTES al PAC se bloqueen (sin contactar a FacturAPI)
+cuando el ambiente del sitio es inseguro, y que producción/sandbox legítimos y los GET
+sigan funcionando. Nunca se contacta a FacturAPI real: `requests.request` está mockeado.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+_REQUESTS_TARGET = "facturacion_mexico.facturacion_fiscal.api_client.requests.request"
+
+
+def _fake_ok_response():
+	resp = MagicMock()
+	resp.ok = True
+	resp.status_code = 201
+	resp.headers = {"Content-Type": "application/json"}
+	resp.json.return_value = {"id": "inv_test", "livemode": False}
+	return resp
+
+
+class TestPacEnvironmentGuard(FrappeTestCase):
+	def _client(self, environment, api_key="", test_api_key=""):
+		"""Construye un FacturAPIClient con ambiente y credenciales controlados."""
+		from facturacion_mexico.facturacion_fiscal.api_client import FacturAPIClient
+
+		settings = frappe._dict(
+			{"name": "FMCS-Test", "sandbox_mode": 1, "api_key": api_key, "test_api_key": test_api_key}
+		)
+
+		def mock_pwd(doctype, name, fieldname, raise_exception=True):
+			return settings.get(fieldname) or ""
+
+		with (
+			patch(
+				"frappe.db.get_value",
+				side_effect=lambda doctype, filters, fields, **kw: (
+					settings if doctype == "Facturacion Mexico Company Settings" else None
+				),
+			),
+			patch("frappe.utils.password.get_decrypted_password", side_effect=mock_pwd),
+			patch(
+				"facturacion_mexico.facturacion_fiscal.pac_environment.get_fm_environment",
+				return_value=environment,
+			),
+		):
+			return FacturAPIClient(company="Test Company")
+
+	# 1. production + api_key válida + POST → permitido
+	def test_production_post_allowed(self):
+		client = self._client("production", api_key="prod-key")
+		with patch(_REQUESTS_TARGET, return_value=_fake_ok_response()) as req:
+			result = client.create_invoice({"type": "I"})
+		req.assert_called_once()
+		self.assertTrue(result["success"])
+
+	# 2. sandbox + test_api_key válida + POST → permitido
+	def test_sandbox_post_allowed(self):
+		client = self._client("sandbox", test_api_key="sk_test_ok")
+		with patch(_REQUESTS_TARGET, return_value=_fake_ok_response()) as req:
+			result = client.create_invoice({"type": "I"})
+		req.assert_called_once()
+		self.assertTrue(result["success"])
+
+	# 3. falta fm_environment + POST → bloqueado y requests.request NO llamado
+	def test_missing_environment_post_blocked(self):
+		client = self._client("", api_key="prod-key")
+		with patch(_REQUESTS_TARGET) as req:
+			with self.assertRaises(frappe.ValidationError):
+				client.create_invoice({"type": "I"})
+		req.assert_not_called()
+
+	# 4. valor inválido + POST → bloqueado
+	def test_invalid_environment_post_blocked(self):
+		client = self._client("staging", api_key="prod-key")
+		with patch(_REQUESTS_TARGET) as req:
+			with self.assertRaises(frappe.ValidationError):
+				client.create_invoice({"type": "I"})
+		req.assert_not_called()
+
+	# 5. production sin api_key → bloqueado
+	def test_production_without_api_key_blocked(self):
+		client = self._client("production", api_key="")
+		with patch(_REQUESTS_TARGET) as req:
+			with self.assertRaises(frappe.ValidationError):
+				client.create_invoice({"type": "I"})
+		req.assert_not_called()
+
+	# 6. sandbox sin test_api_key → bloqueado
+	def test_sandbox_without_test_api_key_blocked(self):
+		client = self._client("sandbox", test_api_key="")
+		with patch(_REQUESTS_TARGET) as req:
+			with self.assertRaises(frappe.ValidationError):
+				client.create_invoice({"type": "I"})
+		req.assert_not_called()
+
+	# 7. sandbox + test_api_key que contiene sk_live_ → bloqueado
+	def test_sandbox_with_live_key_blocked(self):
+		client = self._client("sandbox", test_api_key="sk_live_leaked")
+		with patch(_REQUESTS_TARGET) as req:
+			with self.assertRaises(frappe.ValidationError):
+				client.create_invoice({"type": "I"})
+		req.assert_not_called()
+
+	# 8. GET continúa permitido (incluso con ambiente ausente)
+	def test_get_allowed_even_without_environment(self):
+		client = self._client("", api_key="")
+		with patch(_REQUESTS_TARGET, return_value=_fake_ok_response()) as req:
+			client.get_invoice("inv_1")
+		req.assert_called_once()
+
+	# 9. payload/endpoint de una operación permitida NO cambia
+	def test_allowed_payload_and_endpoint_unchanged(self):
+		client = self._client("production", api_key="prod-key")
+		data = {"type": "E", "related_documents": [{"relationship": "03", "documents": ["UUID-1"]}]}
+		with patch(_REQUESTS_TARGET, return_value=_fake_ok_response()) as req:
+			client.create_invoice(data)
+		_, kwargs = req.call_args
+		self.assertEqual(kwargs["method"], "POST")
+		self.assertTrue(kwargs["url"].endswith("/invoices"))
+		self.assertEqual(kwargs["json"], data)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
     - Email CFDI: tecnico/email-system.md
     - Regeneración STCT: tecnico/proceso-regeneracion-stct-e4.md
     - Reconciliación y fallback: tecnico/reconciliacion-fallback.md
+    - Ambiente fiscal (fm_environment): tecnico/ambiente-fiscal.md
     - ADRs:
       - adr/index.md
       - adr/0000-estado-real-pre-migracion.md
@@ -115,6 +116,7 @@ nav:
       - adr/0035-motor-reconciliacion-ffm.md
       - adr/0036-integridad-proyeccion-cancelacion.md
       - adr/0037-resiliencia-cancelacion-sustitucion-motivo-01.md
+      - adr/0038-guarda-ambiente-fiscal-fm-environment.md
   - Referencia:
     - referencia/index.md
     - DocTypes: referencia/doctypes.md


### PR DESCRIPTION
## Objetivo

Evitar que un entorno no productivo (p. ej. un sitio restaurado desde producción) pueda
emitir CFDIs reales contra FacturAPI. La selección de credencial y la autorización para
emitir dejan de depender de la BD (`sandbox_mode`) y pasan a una variable explícita por
sitio en `site_config.json` (`fm_environment`), a prueba de `bench restore`. Issue #215.

## Versión

Versión objetivo: `v1.4.0`
Release: MINOR
(base upstream/main: `v1.3.2` → objetivo `v1.4.0` por nueva capacidad: mecanismo de
ambiente + guarda del PAC)

## Cambios principales

- **Nuevo módulo `pac_environment.py`**: guarda central fail-closed en el único chokepoint
  (`FacturAPIClient._make_request` / `_make_request_silent`), antes de cualquier `requests.request`.
- **Selección de credencial por `fm_environment`** (`production` → `api_key`, `sandbox` →
  `test_api_key`), **sin fallback** entre campos. `sandbox_mode` pasa a valor **derivado** (compat).
- **Bloqueo de operaciones mutantes** (POST/PUT/PATCH/DELETE) cuando: falta o es inválido
  `fm_environment`; falta la credencial del ambiente; o la key efectiva es `sk_live_` en ambiente
  no productivo. **GET permitido** (reconciliación/validación intactas).
- **Cero cambios** en lógica fiscal, cálculo ni payload.

## Documentación actualizada

- `docs/tecnico/ambiente-fiscal.md` (nueva) — variable, valores, fail-closed, orden de despliegue.
- `docs/adr/0038-guarda-ambiente-fiscal-fm-environment.md` (nuevo ADR) + `docs/adr/index.md`.
- `mkdocs.yml` — nav de la página técnica y del ADR.

## Validaciones realizadas

- Tests focalizados (bench run-tests, `test-facturacion.localhost`):
  `test_pac_environment_guard` 9/9 · `test_facturacion_mexico_company_settings` 9/9.
- Validación funcional local:
  - Bloqueo real: `fm_environment` ausente → `ValidationError` y `requests.request` **no llamado**;
    `sk_live_` en sandbox → bloqueo.
  - Happy-path sandbox real (POST `create_invoice` vía cliente en un sitio `sandbox` con `sk_test_`):
    `success=True`, **`livemode=false`**, `status=valid`. Sin datos de cliente alterados.
- `ruff check` + `ruff format` OK · `mkdocs build --strict` OK.
- Suite completa: 2 fallos + 11 errores **pre-existentes y ajenos** a este cambio (validaciones de
  datos: UOM/`ObjetoImp`, naming de campos nativos UAE, conteo de reconciliación); ninguna traza
  referencia el código nuevo.
- **No requiere** `bench migrate` ni `export-fixtures` (sin cambios de esquema/fixtures).

## Fuera de alcance

- Indicador visual de ambiente (issue #171), allowlist por IP, saneo automático post-restore.

## Riesgos / pendientes

- **Orden de despliegue (crítico):** fijar `fm_environment` en `site_config.json` de cada sitio que
  timbra (`production` en prod; `sandbox` en dev/staging) **antes** de activar la guarda, o el
  timbrado legítimo de producción quedaría bloqueado.
- El ambiente es **por sitio**, no por Company (un sitio es todo `production` o todo `sandbox`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit production and sandbox environment selection for fiscal operations.
  * Unsafe invoice changes are blocked when the environment or required credentials are missing or invalid.
  * Read-only requests remain available without environment configuration.

* **Documentation**
  * Added technical guidance and an architectural decision record covering configuration, deployment, and safeguards.

* **Chores**
  * Updated the package version to 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->